### PR TITLE
Phase 1: GitHub polling ingestion with bounded backfill and resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,134 @@
+# decision-graph
+
+Organizational Intelligence Engine — implementation of `PRD_v3.1_Organizational_Intelligence_Engine.md`.
+
+**Phase 1 only.** The knowledge graph schema and extraction-first GitHub ingestion.
+Retrieval, traversal, reasoning, and Decision synthesis (Phase 2+) are not built.
+
+- **Code repo:** this repository.
+- **Ingestion target:** `pallets/flask`.
+
+## Layout
+
+```
+db/migrations/     schema (apply in numeric order)
+db/tests/          behavioural checks for the rubric + inferred-edge gate
+src/decision_graph/  ingestion
+tests/             unit tests for the parsers
+```
+
+## Schema
+
+Node registry + per-type detail tables + one adjacency-list `edge` table. A composite
+FK on `(id, node_type)` keeps referential integrity — a row in `commit` cannot point at
+a non-commit node — while leaving Engine 2 a single table to traverse instead of a
+15-way UNION across per-relationship tables.
+
+Two columns carry provenance, split deliberately:
+
+| column | values | meaning |
+|---|---|---|
+| `edge.tag` | `explicit` \| `inferred` | how the edge came to exist; set at creation, never rewritten |
+| `edge.evidence_tier` | `explicit` \| `corroborated` \| `inferred` | §5.4 presentation tier; derived, Phase 3 upgrades explicit → corroborated |
+
+A CHECK ties them (`tag='inferred' ⟺ evidence_tier='inferred'`), so only explicit edges
+are ever eligible for the corroborated upgrade and inference cannot launder itself into
+a higher tier. §5.3's "explicit and corroborated first" pass is then just `tag='explicit'`.
+
+### The reconstructed-Decision rubric is executable
+
+§5.1's rubric exists in three forms, all one implementation:
+
+- `decision_rubric(node_id)` — as a query, returning each clause plus a failure reason
+- `v_decision_rubric_audit` — as a standing invariant over every Decision
+- `decision_rubric_guard` — as a **deferred constraint trigger**, on both `decision` and
+  `edge`, so a reconstructed Decision cannot be stranded by later deleting the
+  `motivated_by` edge that justified it
+
+Motivation is mandatory; Implementation or Validation must also be present; all rubric
+edges must share one PR/issue thread. `decision_status` has no `inferred` member — a
+Decision that cannot reach explicit or reconstructed is simply not created.
+
+**`thread_key` is the v1 stand-in for §5.1's "bounded time window"** and is the most
+likely thing to be revisited. A thread is one conversation cluster (a PR, the issues it
+closes, its commits, its reviews). Chosen over a literal time window because it is
+mechanically checkable with no tunable magic number; the cost is that a decision
+genuinely spanning two threads cannot reach `reconstructed`.
+
+### Inferred edges are gated in the database
+
+Three bounds, all enforced by the `edge_inferred_gate` trigger rather than by calling
+code, so backfills and manual fixes stay bounded too:
+
+1. relevance ≥ `graph_config.inferred_edge_min_relevance` (v1: 0.75)
+2. at most `graph_config.inferred_edge_max_per_node` per node, both directions (v1: 4)
+3. **no inferred edge may touch a Decision node**
+
+## Ingestion
+
+Bounded backfill — 12 months by default — with resume as the primary mechanism, not a
+recovery path. The same cursor drives the first backfill and every steady-state poll, so
+the resume path runs on every single run and cannot quietly rot.
+
+The transaction commits after each page, immediately after that page's cursor advances,
+so the cursor on disk never claims more progress than the graph contains.
+
+Three cursor strategies, because the endpoints genuinely differ:
+
+| strategy | resources | why |
+|---|---|---|
+| `UPDATED_ASC` | issues, pulls | `since` + updated-ascending; backfill and steady poll are the same forward walk |
+| `COMMITTED_DESC` | commits | always newest-first, so backfill pages *backwards* with `until`, then flips to `steady` |
+| `FULL` | releases, workflows, CODEOWNERS | small and unwindowed; ETag makes the no-change case one request |
+
+`window_floor` is pinned on first contact rather than recomputed, so resuming a backfill
+days later cannot move the floor forward and leave an unfetched hole mid-window.
+
+Rate limiting is first-class: a 12-month backfill of a repo flask's size sits close
+enough to the 5,000 req/hour budget that exhaustion is expected. The client stops
+cleanly at a configurable floor and the next run resumes.
+
+**No Decision nodes are created by ingestion.** Phase 1 asserts artifacts and the links
+between them; asserting that a *decision* occurred is gated by the rubric and belongs to
+a later phase.
+
+## Known limitations on `pallets/flask`
+
+Accepted deliberately rather than fixed by switching repos:
+
+- **No CODEOWNERS** at `/CODEOWNERS`, `/.github/CODEOWNERS`, or `/docs/CODEOWNERS`. The
+  `owns` extractor is built but no-ops; the graph gets no ownership edges. **The §9
+  evaluation set cannot include ownership queries against flask.**
+- **`has_wiki: false`.** The `wiki_page` extractor no-ops. On this repo `motivated_by`
+  therefore resolves only to issues and PR bodies, never wiki pages.
+- Cross-references to artifacts **outside** the 12-month window are skipped rather than
+  fetched — fetching them would make the window unbounded by the back door. They are
+  counted in the run summary under `*_target_not_ingested` rather than hidden.
+
+## Running it
+
+```bash
+docker run -d --name oie-pg -e POSTGRES_PASSWORD=oie -e POSTGRES_DB=oie \
+    -p 55432:5432 postgres:16
+
+for f in db/migrations/*.sql; do
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
+done
+
+pip install -e .
+export DATABASE_URL="postgresql://postgres:oie@localhost:55432/oie"
+export GITHUB_TOKEN="$(gh auth token)"
+
+dg-ingest --resources issues commits releases codeowners
+dg-ingest --resources issues --max-pages 1   # smoke test; leaves cursor mid-window
+```
+
+`GITHUB_TOKEN` is required — unauthenticated access is capped at 60 req/hour, which
+cannot complete a backfill.
+
+## Tests
+
+```bash
+psql "$DATABASE_URL" -f db/tests/0002_rubric_checks.sql   # 13 checks, rolls back
+python -m unittest discover -s tests                       # 11 checks
+```

--- a/db/migrations/0003_ingestion_cursor_phase.sql
+++ b/db/migrations/0003_ingestion_cursor_phase.sql
@@ -1,0 +1,49 @@
+-- 0003_ingestion_cursor_phase.sql
+-- Cursor model for bounded backfill + resume (PRD v3.1 §8).
+--
+-- 0001 gave ingestion_cursor a single `last_since` watermark. That is enough for
+-- steady-state polling but not for a bounded backfill, because the two move in
+-- opposite directions: a backfill walks from now *backwards* to a window floor,
+-- while steady-state polling walks *forwards* from the newest thing already seen.
+-- One column cannot hold both without ambiguity about which direction it means.
+--
+-- Only the commits resource actually needs the two-phase treatment. The GitHub
+-- issues endpoint accepts `since` and can be sorted updated-ascending, so its
+-- backfill is just a forward walk starting at the window floor — the same
+-- mechanism as steady state, seeded differently. The commits endpoint accepts
+-- `since`/`until` but always returns newest-first, so backfill must page
+-- backwards with `until` and checkpoint on the oldest row seen.
+--
+-- Resource strategies (see cursors.py):
+--   UPDATED_ASC    issues, pull requests  — steady_watermark only
+--   COMMITTED_DESC commits                — phase + backfill_cursor, then watermark
+--   FULL           releases, workflows, CODEOWNERS — no window, ETag-conditional
+
+BEGIN;
+
+ALTER TABLE ingestion_cursor RENAME COLUMN last_since TO steady_watermark;
+
+ALTER TABLE ingestion_cursor
+    ADD COLUMN phase text NOT NULL DEFAULT 'backfill'
+        CHECK (phase IN ('backfill', 'steady')),
+    ADD COLUMN window_floor    timestamptz,
+    ADD COLUMN backfill_cursor timestamptz,
+    ADD COLUMN last_run_id     bigint REFERENCES ingestion_run (id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN ingestion_cursor.phase IS
+    'backfill = still walking towards window_floor; steady = floor reached, now polling '
+    'forward from steady_watermark. Only COMMITTED_DESC resources pass through backfill.';
+
+COMMENT ON COLUMN ingestion_cursor.window_floor IS
+    'Oldest point this resource intends to reach, set once at first run (now - N months). '
+    'Persisted rather than recomputed so that resuming a run days later does not silently '
+    'move the floor forward and leave a hole in the middle of the window.';
+
+COMMENT ON COLUMN ingestion_cursor.backfill_cursor IS
+    'Oldest timestamp fully processed during backfill. A run that dies mid-window resumes '
+    'from here instead of restarting at now. Meaningless once phase = steady.';
+
+COMMENT ON COLUMN ingestion_cursor.steady_watermark IS
+    'Newest timestamp fully processed. Drives the `since` parameter for steady-state polls.';
+
+COMMIT;

--- a/db/migrations/0004_repository_node_identity.sql
+++ b/db/migrations/0004_repository_node_identity.sql
@@ -1,0 +1,34 @@
+-- 0004_repository_node_identity.sql
+-- Repair + invariant for repository node identity.
+--
+-- Found by running ingestion twice against pallets/flask. The repository extractor
+-- wrote the node's own id back into its repo_node_id as a self-reference. Because
+-- repo_node_id participates in node_identity_uidx via COALESCE(repo_node_id, 0),
+-- that write moved the row's identity key from (repository, 0, 'pallets/flask') to
+-- (repository, 30, 'pallets/flask'). The next run looked up the former, missed,
+-- and inserted a SECOND repository node — caught only incidentally by the
+-- repository(owner, name) unique constraint, one layer downstream.
+--
+-- 0001 already documented repo_node_id as "NULL only for repository nodes
+-- themselves"; nothing enforced it. Since identity depends on this column, a
+-- comment is not a strong enough guarantee: any writer that sets it re-keys the
+-- row and silently breaks upsert idempotency for every future run.
+
+BEGIN;
+
+-- Repair rows written by the pre-fix extractor.
+UPDATE node
+SET repo_node_id = NULL
+WHERE node_type = 'repository'
+  AND repo_node_id = id;
+
+ALTER TABLE node
+    ADD CONSTRAINT node_repository_owns_itself
+        CHECK (node_type <> 'repository' OR repo_node_id IS NULL);
+
+COMMENT ON CONSTRAINT node_repository_owns_itself ON node IS
+    'A repository node must not point at a repository, including itself. repo_node_id '
+    'is part of the node identity key, so self-reference re-keys the row and breaks '
+    'upsert idempotency across runs.';
+
+COMMIT;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,19 @@
+[project]
+name = "decision-graph"
+version = "0.1.0"
+description = "Organizational Intelligence Engine — Phase 1 (knowledge graph + GitHub ingestion)"
+requires-python = ">=3.11"
+dependencies = [
+    "psycopg[binary]>=3.1",
+    "httpx>=0.27",
+]
+
+[project.scripts]
+dg-ingest = "decision_graph.run:main"
+
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]

--- a/src/decision_graph/__init__.py
+++ b/src/decision_graph/__init__.py
@@ -1,0 +1,7 @@
+"""Organizational Intelligence Engine — Phase 1.
+
+Knowledge graph schema (db/migrations) plus extraction-first GitHub ingestion.
+Phase 2+ (retrieval, traversal, reasoning, Decision synthesis) is out of scope.
+"""
+
+__version__ = "0.1.0"

--- a/src/decision_graph/config.py
+++ b/src/decision_graph/config.py
@@ -1,0 +1,59 @@
+"""Runtime configuration.
+
+Ingestion target is ``pallets/flask``; ``decision-graph`` is the code repo only.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+DEFAULT_TARGET_REPO = "pallets/flask"
+DEFAULT_BACKFILL_MONTHS = 12
+
+
+@dataclass(frozen=True)
+class Settings:
+    database_url: str
+    github_token: str
+    target_repo: str = DEFAULT_TARGET_REPO
+    backfill_months: int = DEFAULT_BACKFILL_MONTHS
+
+    # Stop a run once fewer than this many API calls remain in the hourly budget,
+    # rather than blocking until the limit resets. Resume picks up from the cursor.
+    rate_limit_floor: int = 100
+
+    user_agent: str = "decision-graph/0.1 (+https://github.com/harshiit-rana/decision-graph)"
+
+    @property
+    def owner(self) -> str:
+        return self.target_repo.split("/", 1)[0]
+
+    @property
+    def name(self) -> str:
+        return self.target_repo.split("/", 1)[1]
+
+    @classmethod
+    def from_env(cls, **overrides: object) -> "Settings":
+        token = os.environ.get("GITHUB_TOKEN", "")
+        if not token:
+            raise RuntimeError(
+                "GITHUB_TOKEN is not set. Unauthenticated GitHub API access is capped at "
+                "60 requests/hour, which cannot complete a backfill. Try: "
+                'export GITHUB_TOKEN="$(gh auth token)"'
+            )
+
+        dsn = os.environ.get("DATABASE_URL", "")
+        if not dsn:
+            raise RuntimeError("DATABASE_URL is not set.")
+
+        base = {
+            "database_url": dsn,
+            "github_token": token,
+            "target_repo": os.environ.get("TARGET_REPO", DEFAULT_TARGET_REPO),
+            "backfill_months": int(
+                os.environ.get("BACKFILL_MONTHS", DEFAULT_BACKFILL_MONTHS)
+            ),
+        }
+        base.update({k: v for k, v in overrides.items() if v is not None})
+        return cls(**base)  # type: ignore[arg-type]

--- a/src/decision_graph/cursors.py
+++ b/src/decision_graph/cursors.py
@@ -1,0 +1,212 @@
+"""Cursor management: bounded backfill and resume (PRD v3.1 §8).
+
+Resume is the mechanism, not a recovery path bolted on. The same cursor drives the
+first backfill and every steady-state poll thereafter; the only difference is where
+it starts. That means the resume path is exercised on every single run, so it cannot
+quietly rot the way a rarely-taken recovery branch would.
+
+Three strategies, because the GitHub endpoints genuinely differ:
+
+  UPDATED_ASC     issues, pull requests
+                  `since` + sort=updated&direction=asc. Backfill is a forward walk
+                  from the window floor, which is the same shape as a steady-state
+                  poll from the watermark. No phase transition needed.
+
+  COMMITTED_DESC  commits
+                  `since`/`until` supported but results are always newest-first, so
+                  a backfill must page *backwards* with `until`, checkpointing the
+                  oldest row seen. Once the floor is reached it flips to `steady`
+                  and polls forward. This is the only strategy that uses `phase`.
+
+  FULL            releases, workflows, CODEOWNERS
+                  Small, unwindowed, refreshed whole each run; ETag makes the
+                  no-change case cost one request.
+
+The window floor is persisted on first contact rather than recomputed per run. If it
+were recomputed, resuming a backfill a week later would move the floor forward and
+leave an unfetched hole in the middle of the window that nothing would ever revisit.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+from typing import Any
+
+import psycopg
+
+log = logging.getLogger(__name__)
+
+
+class Strategy(Enum):
+    UPDATED_ASC = "updated_asc"
+    COMMITTED_DESC = "committed_desc"
+    FULL = "full"
+
+
+RESOURCE_STRATEGY: dict[str, Strategy] = {
+    "issues": Strategy.UPDATED_ASC,
+    "pulls": Strategy.UPDATED_ASC,
+    "commits": Strategy.COMMITTED_DESC,
+    "releases": Strategy.FULL,
+    "workflows": Strategy.FULL,
+    "codeowners": Strategy.FULL,
+    # Reviews have no independent cursor: they are fetched per-PR, driven by whichever
+    # PRs the pulls cursor surfaced this run.
+}
+
+
+@dataclass
+class Cursor:
+    repo_node_id: int
+    resource: str
+    phase: str
+    window_floor: datetime | None
+    backfill_cursor: datetime | None
+    steady_watermark: datetime | None
+    last_etag: str | None
+
+    @property
+    def strategy(self) -> Strategy:
+        return RESOURCE_STRATEGY[self.resource]
+
+    @property
+    def is_backfilling(self) -> bool:
+        return self.phase == "backfill"
+
+
+def load(
+    conn: psycopg.Connection, repo_node_id: int, resource: str, backfill_months: int
+) -> Cursor:
+    """Fetch the cursor, creating it (and pinning the window floor) on first contact."""
+    floor = datetime.now(timezone.utc) - timedelta(days=30 * backfill_months)
+
+    row = conn.execute(
+        """
+        INSERT INTO ingestion_cursor (repo_node_id, resource, window_floor, phase)
+        VALUES (%s, %s, %s, %s)
+        ON CONFLICT (repo_node_id, resource) DO UPDATE
+            SET updated_at = now()
+        RETURNING phase, window_floor, backfill_cursor, steady_watermark, last_etag
+        """,
+        (
+            repo_node_id,
+            resource,
+            floor,
+            # FULL resources have no window to walk, so they start life in steady.
+            "steady" if RESOURCE_STRATEGY[resource] is Strategy.FULL else "backfill",
+        ),
+    ).fetchone()
+    assert row is not None
+
+    return Cursor(
+        repo_node_id=repo_node_id,
+        resource=resource,
+        phase=row["phase"],
+        window_floor=row["window_floor"],
+        backfill_cursor=row["backfill_cursor"],
+        steady_watermark=row["steady_watermark"],
+        last_etag=row["last_etag"],
+    )
+
+
+def query_params(cursor: Cursor) -> dict[str, Any]:
+    """Translate cursor state into GitHub query parameters."""
+    if cursor.strategy is Strategy.UPDATED_ASC:
+        # Resume point, or the window floor on a first run. Ascending order is what
+        # makes a partial run safe to checkpoint: everything before the last row
+        # processed is known-complete.
+        since = cursor.steady_watermark or cursor.window_floor
+        params: dict[str, Any] = {"state": "all", "sort": "updated", "direction": "asc"}
+        if since:
+            params["since"] = _iso(since)
+        return params
+
+    if cursor.strategy is Strategy.COMMITTED_DESC:
+        if cursor.is_backfilling:
+            params = {}
+            if cursor.window_floor:
+                params["since"] = _iso(cursor.window_floor)
+            # Walk backwards from wherever the last run stopped.
+            if cursor.backfill_cursor:
+                params["until"] = _iso(cursor.backfill_cursor)
+            return params
+        return {"since": _iso(cursor.steady_watermark)} if cursor.steady_watermark else {}
+
+    return {}
+
+
+def advance_backfill(
+    conn: psycopg.Connection, cursor: Cursor, oldest_seen: datetime, newest_seen: datetime
+) -> None:
+    """Checkpoint a backfill page. Called after each page, hence resumable per page."""
+    cursor.backfill_cursor = oldest_seen
+    # Track the high-water mark during backfill too, so the eventual flip to steady
+    # does not re-walk everything the backfill already covered.
+    if cursor.steady_watermark is None or newest_seen > cursor.steady_watermark:
+        cursor.steady_watermark = newest_seen
+
+    conn.execute(
+        """
+        UPDATE ingestion_cursor
+        SET backfill_cursor = %s, steady_watermark = %s, updated_at = now()
+        WHERE repo_node_id = %s AND resource = %s
+        """,
+        (cursor.backfill_cursor, cursor.steady_watermark, cursor.repo_node_id, cursor.resource),
+    )
+
+
+def advance_steady(
+    conn: psycopg.Connection, cursor: Cursor, watermark: datetime, etag: str | None = None
+) -> None:
+    if cursor.steady_watermark is not None and watermark <= cursor.steady_watermark:
+        return
+    cursor.steady_watermark = watermark
+    conn.execute(
+        """
+        UPDATE ingestion_cursor
+        SET steady_watermark = %s, last_etag = COALESCE(%s, last_etag), updated_at = now()
+        WHERE repo_node_id = %s AND resource = %s
+        """,
+        (watermark, etag, cursor.repo_node_id, cursor.resource),
+    )
+
+
+def complete_backfill(conn: psycopg.Connection, cursor: Cursor) -> None:
+    """Window floor reached: switch to forward polling for good."""
+    if not cursor.is_backfilling:
+        return
+    cursor.phase = "steady"
+    conn.execute(
+        """
+        UPDATE ingestion_cursor
+        SET phase = 'steady', updated_at = now()
+        WHERE repo_node_id = %s AND resource = %s
+        """,
+        (cursor.repo_node_id, cursor.resource),
+    )
+    log.info("%s: backfill complete, now polling forward", cursor.resource)
+
+
+def set_etag(conn: psycopg.Connection, cursor: Cursor, etag: str | None) -> None:
+    if not etag:
+        return
+    cursor.last_etag = etag
+    conn.execute(
+        "UPDATE ingestion_cursor SET last_etag = %s, updated_at = now() "
+        "WHERE repo_node_id = %s AND resource = %s",
+        (etag, cursor.repo_node_id, cursor.resource),
+    )
+
+
+def bind_run(conn: psycopg.Connection, cursor: Cursor, run_id: int) -> None:
+    conn.execute(
+        "UPDATE ingestion_cursor SET last_run_id = %s WHERE repo_node_id = %s AND resource = %s",
+        (run_id, cursor.repo_node_id, cursor.resource),
+    )
+
+
+def _iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")

--- a/src/decision_graph/db.py
+++ b/src/decision_graph/db.py
@@ -1,0 +1,195 @@
+"""Graph writes: node/edge upserts and run bookkeeping.
+
+Every write here is idempotent, because resume means the same page can legitimately
+be processed twice — once by the run that died and once by the run that resumed it.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import psycopg
+from psycopg.rows import dict_row
+
+log = logging.getLogger(__name__)
+
+# Explicit-signal extractors only. The inferred path lives in inference.py and is
+# gated by the database trigger installed in migration 0001.
+TAG_EXPLICIT = "explicit"
+TIER_EXPLICIT = "explicit"
+
+
+def connect(dsn: str) -> psycopg.Connection:
+    conn = psycopg.connect(dsn, row_factory=dict_row)
+    conn.execute("SET application_name = 'decision-graph-ingest'")
+    return conn
+
+
+# ---------------------------------------------------------------------------
+# Nodes
+# ---------------------------------------------------------------------------
+
+
+def upsert_node(
+    conn: psycopg.Connection,
+    *,
+    node_type: str,
+    external_id: str,
+    repo_node_id: int | None = None,
+    github_node_id: str | None = None,
+    title: str | None = None,
+    url: str | None = None,
+    thread_key: str | None = None,
+    source_created_at: datetime | None = None,
+    source_updated_at: datetime | None = None,
+    raw: Any = None,
+) -> int:
+    """Insert or refresh a node, returning its id.
+
+    Conflict target mirrors ``node_identity_uidx``, including its COALESCE, so the
+    expression index is actually inferred rather than silently missed.
+
+    thread_key is deliberately COALESCEd rather than overwritten: a later union may
+    already have promoted this node into a merged thread, and a plain refresh of the
+    artifact must not undo that.
+    """
+    row = conn.execute(
+        """
+        INSERT INTO node (node_type, repo_node_id, external_id, github_node_id,
+                          title, url, thread_key,
+                          source_created_at, source_updated_at, raw)
+        VALUES (%(node_type)s, %(repo_node_id)s, %(external_id)s, %(github_node_id)s,
+                %(title)s, %(url)s, %(thread_key)s,
+                %(source_created_at)s, %(source_updated_at)s, %(raw)s)
+        ON CONFLICT (node_type, COALESCE(repo_node_id, 0), external_id)
+        DO UPDATE SET
+            github_node_id    = COALESCE(EXCLUDED.github_node_id, node.github_node_id),
+            title             = COALESCE(EXCLUDED.title, node.title),
+            url               = COALESCE(EXCLUDED.url, node.url),
+            thread_key        = COALESCE(node.thread_key, EXCLUDED.thread_key),
+            source_updated_at = GREATEST(
+                COALESCE(EXCLUDED.source_updated_at, node.source_updated_at),
+                COALESCE(node.source_updated_at, EXCLUDED.source_updated_at)),
+            raw               = COALESCE(EXCLUDED.raw, node.raw),
+            last_polled_at    = now()
+        RETURNING id
+        """,
+        {
+            "node_type": node_type,
+            "repo_node_id": repo_node_id,
+            "external_id": external_id,
+            "github_node_id": github_node_id,
+            "title": title,
+            "url": url,
+            "thread_key": thread_key,
+            "source_created_at": source_created_at,
+            "source_updated_at": source_updated_at,
+            "raw": psycopg.types.json.Jsonb(raw) if raw is not None else None,
+        },
+    ).fetchone()
+    assert row is not None
+    return row["id"]
+
+
+def upsert_detail(conn: psycopg.Connection, table: str, node_id: int, **columns: Any) -> None:
+    """Upsert the per-type detail row for a node.
+
+    Table names come only from this module's extractors, never from API payloads.
+    """
+    cols = ["node_id", *columns.keys()]
+    placeholders = ", ".join(f"%({c})s" for c in cols)
+    updates = ", ".join(f"{c} = EXCLUDED.{c}" for c in columns)
+    conn.execute(
+        f"INSERT INTO {table} ({', '.join(cols)}) VALUES ({placeholders}) "
+        f"ON CONFLICT (node_id) DO UPDATE SET {updates}",
+        {"node_id": node_id, **columns},
+    )
+
+
+# ---------------------------------------------------------------------------
+# Edges
+# ---------------------------------------------------------------------------
+
+
+def upsert_explicit_edge(
+    conn: psycopg.Connection,
+    *,
+    src: int,
+    dst: int,
+    edge_type: str,
+    extractor: str,
+    source_ref: str | None = None,
+    observed_at: datetime | None = None,
+) -> bool:
+    """Create (or refresh) an explicit edge. Returns True if a new edge was created.
+
+    Self-loops are dropped here rather than left to hit the CHECK constraint: a PR
+    body containing its own number is common and is not an error worth aborting on.
+
+    Conflict target matches the partial unique index ``edge_current_uidx``, so only
+    currently-valid edges collide. Superseded edges keep their history via valid_to.
+    """
+    if src == dst:
+        return False
+
+    row = conn.execute(
+        """
+        INSERT INTO edge (src_node_id, dst_node_id, edge_type, tag, evidence_tier,
+                          extractor, source_ref, observed_at, valid_from)
+        VALUES (%(src)s, %(dst)s, %(edge_type)s, %(tag)s, %(tier)s,
+                %(extractor)s, %(source_ref)s, %(observed_at)s,
+                COALESCE(%(observed_at)s, now()))
+        ON CONFLICT (src_node_id, dst_node_id, edge_type) WHERE valid_to IS NULL
+        DO UPDATE SET
+            source_ref  = COALESCE(EXCLUDED.source_ref, edge.source_ref),
+            observed_at = COALESCE(EXCLUDED.observed_at, edge.observed_at)
+        RETURNING (xmax = 0) AS inserted
+        """,
+        {
+            "src": src,
+            "dst": dst,
+            "edge_type": edge_type,
+            "tag": TAG_EXPLICIT,
+            "tier": TIER_EXPLICIT,
+            "extractor": extractor,
+            "source_ref": source_ref,
+            "observed_at": observed_at,
+        },
+    ).fetchone()
+    return bool(row and row["inserted"])
+
+
+# ---------------------------------------------------------------------------
+# Run bookkeeping
+# ---------------------------------------------------------------------------
+
+
+def start_run(conn: psycopg.Connection, repo_node_id: int) -> int:
+    row = conn.execute(
+        "INSERT INTO ingestion_run (repo_node_id) VALUES (%s) RETURNING id",
+        (repo_node_id,),
+    ).fetchone()
+    assert row is not None
+    return row["id"]
+
+
+def finish_run(
+    conn: psycopg.Connection,
+    run_id: int,
+    *,
+    status: str,
+    nodes: int,
+    edges: int,
+    error: str | None = None,
+) -> None:
+    conn.execute(
+        """
+        UPDATE ingestion_run
+        SET finished_at = now(), status = %s, nodes_upserted = %s,
+            edges_upserted = %s, error = %s
+        WHERE id = %s
+        """,
+        (status, nodes, edges, error, run_id),
+    )

--- a/src/decision_graph/extractors.py
+++ b/src/decision_graph/extractors.py
@@ -1,0 +1,514 @@
+"""Resource extractors: GitHub payloads -> nodes + explicit edges.
+
+Extraction-first (§5.1): every edge below is justified by a signal present in the
+data — a closing keyword, a review event, a commit parent, a CODEOWNERS line. None
+of them are guesses.
+
+No extractor creates a Decision node. Phase 1 asserts artifacts and the links
+between them; deciding that a *decision* occurred is a separate step gated by the
+rubric, and doing it here would be exactly the "assert a decision without evidence"
+failure the PRD's top risk row is about.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+import psycopg
+
+from . import db, refs, threads
+from .config import Settings
+from .github import GitHubClient, parse_ts
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class Stats:
+    nodes: int = 0
+    edges: int = 0
+    skipped: dict[str, int] = field(default_factory=dict)
+
+    def note_skip(self, reason: str) -> None:
+        self.skipped[reason] = self.skipped.get(reason, 0) + 1
+
+
+@dataclass
+class Context:
+    conn: psycopg.Connection
+    client: GitHubClient
+    settings: Settings
+    repo_node_id: int
+    stats: Stats = field(default_factory=Stats)
+
+    def node(self, **kwargs: Any) -> int:
+        node_id = db.upsert_node(self.conn, repo_node_id=self.repo_node_id, **kwargs)
+        self.stats.nodes += 1
+        return node_id
+
+    def edge(self, **kwargs: Any) -> None:
+        if db.upsert_explicit_edge(self.conn, **kwargs):
+            self.stats.edges += 1
+
+
+# ---------------------------------------------------------------------------
+# Repository (the root node; everything else hangs off it)
+# ---------------------------------------------------------------------------
+
+
+def extract_repository(conn: psycopg.Connection, client: GitHubClient, settings: Settings) -> int:
+    payload = client.get(f"/repos/{settings.target_repo}")
+    if payload is None:
+        raise RuntimeError(f"repository {settings.target_repo} not found or not visible")
+
+    node_id = db.upsert_node(
+        conn,
+        node_type="repository",
+        external_id=settings.target_repo,
+        github_node_id=payload.get("node_id"),
+        title=payload.get("full_name"),
+        url=payload.get("html_url"),
+        source_created_at=parse_ts(payload.get("created_at")),
+        source_updated_at=parse_ts(payload.get("updated_at")),
+        raw=payload,
+    )
+    db.upsert_detail(
+        conn,
+        "repository",
+        node_id,
+        owner=settings.owner,
+        name=settings.name,
+        default_branch=payload.get("default_branch"),
+        visibility=payload.get("visibility"),
+    )
+    # repo_node_id stays NULL on the repository node itself. It must not self-reference:
+    # repo_node_id is part of node_identity_uidx (via COALESCE(repo_node_id, 0)), so
+    # writing the id back into it moves the row's identity key out from under the next
+    # run's lookup, and every subsequent run creates a duplicate repository node.
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# People
+# ---------------------------------------------------------------------------
+
+
+def upsert_person(ctx: Context, payload: dict[str, Any] | None) -> int | None:
+    """People are org-scoped, not repo-scoped, so repo_node_id stays NULL."""
+    if not payload or not payload.get("login"):
+        return None
+    login = payload["login"]
+    node_id = db.upsert_node(
+        ctx.conn,
+        node_type="person",
+        repo_node_id=None,
+        external_id=login,
+        github_node_id=payload.get("node_id"),
+        title=login,
+        url=payload.get("html_url"),
+    )
+    db.upsert_detail(ctx.conn, "person", node_id, login=login)
+    ctx.stats.nodes += 1
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# Issues and pull requests
+#
+# One endpoint feeds both: GET /issues returns pull requests too, flagged by a
+# "pull_request" key. Driving both off it keeps a single cursor and avoids paging
+# the same conversation set twice.
+# ---------------------------------------------------------------------------
+
+
+def extract_issue_or_pr(ctx: Context, payload: dict[str, Any]) -> int:
+    is_pr = "pull_request" in payload
+    number = payload["number"]
+    body = payload.get("body") or ""
+    updated = parse_ts(payload.get("updated_at"))
+
+    node_type = "pull_request" if is_pr else "issue"
+    key = (
+        threads.pr_key(ctx.repo_node_id, number)
+        if is_pr
+        else threads.issue_key(ctx.repo_node_id, number)
+    )
+
+    node_id = ctx.node(
+        node_type=node_type,
+        external_id=str(number),
+        github_node_id=payload.get("node_id"),
+        title=payload.get("title"),
+        url=payload.get("html_url"),
+        thread_key=key,
+        source_created_at=parse_ts(payload.get("created_at")),
+        source_updated_at=updated,
+        raw=payload,
+    )
+
+    if is_pr:
+        db.upsert_detail(
+            ctx.conn,
+            "pull_request",
+            node_id,
+            number=number,
+            state=payload.get("state") or "unknown",
+            body=body,
+            closed_at=parse_ts(payload.get("closed_at")),
+        )
+    else:
+        db.upsert_detail(
+            ctx.conn,
+            "issue",
+            node_id,
+            number=number,
+            state=payload.get("state") or "unknown",
+            body=body,
+            closed_at=parse_ts(payload.get("closed_at")),
+        )
+
+    # created: author -> artifact
+    author_id = upsert_person(ctx, payload.get("user"))
+    if author_id:
+        ctx.edge(
+            src=author_id,
+            dst=node_id,
+            edge_type="created",
+            extractor="issue_author",
+            source_ref=payload.get("html_url"),
+            observed_at=parse_ts(payload.get("created_at")),
+        )
+
+    _link_body_refs(ctx, node_id, body, source_ref=payload.get("html_url"), observed_at=updated)
+    return node_id
+
+
+def _link_body_refs(
+    ctx: Context,
+    src_node_id: int,
+    text: str,
+    *,
+    source_ref: str | None,
+    observed_at: datetime | None,
+) -> None:
+    """Turn #-references in body text into edges.
+
+    A closing keyword yields `closes` and unions the two threads — that union is what
+    later lets a Decision satisfy rubric clause 3 across a PR and the issue it closed.
+    A bare mention yields `references` and deliberately does NOT union: mentioning a
+    neighbouring issue is not the same conversation, and merging on it would let
+    clause 3 pass on unrelated work.
+    """
+    for number in refs.closing_refs(text):
+        target = _lookup_by_number(ctx, number)
+        if target is None:
+            ctx.stats.note_skip("closes_ref_target_not_ingested")
+            continue
+        ctx.edge(
+            src=src_node_id,
+            dst=target,
+            edge_type="closes",
+            extractor="body_closing_keyword",
+            source_ref=source_ref,
+            observed_at=observed_at,
+        )
+        threads.union(ctx.conn, src_node_id, target)
+
+    for number in refs.mentioned_refs(text):
+        target = _lookup_by_number(ctx, number)
+        if target is None:
+            ctx.stats.note_skip("mention_ref_target_not_ingested")
+            continue
+        ctx.edge(
+            src=src_node_id,
+            dst=target,
+            edge_type="references",
+            extractor="body_issue_mention",
+            source_ref=source_ref,
+            observed_at=observed_at,
+        )
+
+
+def _lookup_by_number(ctx: Context, number: int) -> int | None:
+    """Resolve #N to an already-ingested issue or PR.
+
+    Returns None when the target is outside the backfill window. That is a real and
+    expected consequence of bounding the window: an in-window PR can close a
+    three-year-old issue. We do not fetch it — that would make the window unbounded
+    by the back door — so the edge is skipped and counted in Stats.skipped, where it
+    shows up honestly rather than silently.
+    """
+    row = ctx.conn.execute(
+        """
+        SELECT id FROM node
+        WHERE repo_node_id = %s AND external_id = %s
+          AND node_type IN ('issue', 'pull_request')
+        ORDER BY node_type
+        LIMIT 1
+        """,
+        (ctx.repo_node_id, str(number)),
+    ).fetchone()
+    return row["id"] if row else None
+
+
+# ---------------------------------------------------------------------------
+# Reviews (per PR; no independent cursor)
+# ---------------------------------------------------------------------------
+
+
+def extract_reviews(ctx: Context, pr_number: int, pr_node_id: int) -> None:
+    for page in ctx.client.paginate(
+        f"/repos/{ctx.settings.target_repo}/pulls/{pr_number}/reviews"
+    ):
+        for review in page.items:
+            reviewer_id = upsert_person(ctx, review.get("user"))
+            if not reviewer_id:
+                continue
+            # `reviewed` is one of the two Validation signals in the rubric, so it is
+            # recorded for every review state, not just APPROVED — a CHANGES_REQUESTED
+            # review is still evidence the change was scrutinised.
+            ctx.edge(
+                src=reviewer_id,
+                dst=pr_node_id,
+                edge_type="reviewed",
+                extractor="pr_review",
+                source_ref=f"review:{review.get('id')}:{review.get('state')}",
+                observed_at=parse_ts(review.get("submitted_at")),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Commits
+# ---------------------------------------------------------------------------
+
+
+def extract_commit(ctx: Context, payload: dict[str, Any]) -> int:
+    sha = payload["sha"]
+    commit = payload.get("commit") or {}
+    message = commit.get("message") or ""
+    authored = parse_ts((commit.get("author") or {}).get("date"))
+    committed = parse_ts((commit.get("committer") or {}).get("date"))
+
+    node_id = ctx.node(
+        node_type="commit",
+        external_id=sha,
+        github_node_id=payload.get("node_id"),
+        title=message.split("\n", 1)[0][:200],
+        url=payload.get("html_url"),
+        source_created_at=authored,
+        source_updated_at=committed,
+        raw=payload,
+    )
+    db.upsert_detail(
+        ctx.conn,
+        "commit",
+        node_id,
+        sha=sha,
+        message=message,
+        authored_at=authored,
+        committed_at=committed,
+    )
+
+    author_id = upsert_person(ctx, payload.get("author"))
+    if author_id:
+        ctx.edge(
+            src=author_id,
+            dst=node_id,
+            edge_type="created",
+            extractor="commit_author",
+            source_ref=sha,
+            observed_at=authored,
+        )
+
+    # Commit messages carry the same closing keywords as PR bodies, and on flask this
+    # is a primary source of issue linkage.
+    _link_body_refs(ctx, node_id, message, source_ref=sha, observed_at=committed)
+
+    for parent in payload.get("parents") or []:
+        parent_row = ctx.conn.execute(
+            "SELECT id FROM node WHERE repo_node_id = %s AND node_type = 'commit' "
+            "AND external_id = %s",
+            (ctx.repo_node_id, parent.get("sha")),
+        ).fetchone()
+        if parent_row:
+            ctx.edge(
+                src=node_id,
+                dst=parent_row["id"],
+                edge_type="depends_on",
+                extractor="commit_parent",
+                source_ref=parent.get("sha"),
+                observed_at=committed,
+            )
+        else:
+            # Expected at the window boundary: the oldest commits in the window have
+            # parents outside it.
+            ctx.stats.note_skip("commit_parent_outside_window")
+
+    return node_id
+
+
+def link_pr_commits(ctx: Context, pr_number: int, pr_node_id: int) -> None:
+    """`implements` edges PR -> its commits, and pull those commits into the thread."""
+    for page in ctx.client.paginate(
+        f"/repos/{ctx.settings.target_repo}/pulls/{pr_number}/commits"
+    ):
+        for payload in page.items:
+            commit_node_id = extract_commit(ctx, payload)
+            ctx.edge(
+                src=pr_node_id,
+                dst=commit_node_id,
+                edge_type="implements",
+                extractor="pr_commit_list",
+                source_ref=payload.get("sha"),
+            )
+            threads.union(ctx.conn, pr_node_id, commit_node_id)
+
+
+# ---------------------------------------------------------------------------
+# Releases
+# ---------------------------------------------------------------------------
+
+
+def extract_release(ctx: Context, payload: dict[str, Any]) -> int:
+    tag = payload.get("tag_name") or str(payload.get("id"))
+    published = parse_ts(payload.get("published_at"))
+    body = payload.get("body") or ""
+
+    node_id = ctx.node(
+        node_type="release",
+        external_id=tag,
+        github_node_id=payload.get("node_id"),
+        title=payload.get("name") or tag,
+        url=payload.get("html_url"),
+        source_created_at=parse_ts(payload.get("created_at")),
+        source_updated_at=published,
+        raw=payload,
+    )
+    db.upsert_detail(
+        ctx.conn,
+        "release",
+        node_id,
+        tag_name=tag,
+        body=body,
+        is_prerelease=bool(payload.get("prerelease")),
+        published_at=published,
+    )
+
+    # Release notes referencing a PR are a `deployed_by` signal: this is where the
+    # change reached users. Release notes are also the classic source of an *explicit*
+    # Decision in §5.1 — but creating that node is Phase 2+, not here.
+    for number in refs.mentioned_refs(body) | refs.closing_refs(body):
+        target = _lookup_by_number(ctx, number)
+        if target is None:
+            ctx.stats.note_skip("release_ref_target_not_ingested")
+            continue
+        ctx.edge(
+            src=target,
+            dst=node_id,
+            edge_type="deployed_by",
+            extractor="release_notes_reference",
+            source_ref=tag,
+            observed_at=published,
+        )
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# Workflows
+# ---------------------------------------------------------------------------
+
+
+def extract_workflow(ctx: Context, payload: dict[str, Any]) -> int:
+    path = payload.get("path") or str(payload.get("id"))
+    node_id = ctx.node(
+        node_type="workflow",
+        external_id=path,
+        github_node_id=payload.get("node_id"),
+        title=payload.get("name"),
+        url=payload.get("html_url"),
+        source_created_at=parse_ts(payload.get("created_at")),
+        source_updated_at=parse_ts(payload.get("updated_at")),
+        raw=payload,
+    )
+    db.upsert_detail(
+        ctx.conn, "workflow", node_id, path=path, name=payload.get("name"), state=payload.get("state")
+    )
+    return node_id
+
+
+# ---------------------------------------------------------------------------
+# CODEOWNERS  —  no-op on pallets/flask (issue #1)
+# ---------------------------------------------------------------------------
+
+CODEOWNERS_PATHS = (".github/CODEOWNERS", "CODEOWNERS", "docs/CODEOWNERS")
+
+
+def extract_codeowners(ctx: Context) -> bool:
+    """Build `owns` edges from CODEOWNERS. Returns False when the repo has no such file.
+
+    KNOWN LIMITATION: pallets/flask ships no CODEOWNERS at any of the three canonical
+    paths, so this returns False every run and the graph gets no `owns` edges. The
+    parser is still built and exercised by unit tests because the gap belongs to the
+    target repo, not the system. Consequence for §9: the evaluation set cannot include
+    ownership queries against flask.
+    """
+    import base64
+
+    for path in CODEOWNERS_PATHS:
+        payload = ctx.client.get(f"/repos/{ctx.settings.target_repo}/contents/{path}")
+        if payload is None:
+            continue
+
+        content = base64.b64decode(payload.get("content", "")).decode("utf-8", "replace")
+        for lineno, pattern, owners in refs.parse_codeowners(content):
+            scope_id = ctx.node(
+                node_type="codeowners_scope",
+                external_id=f"{path}:{lineno}",
+                title=pattern,
+            )
+            db.upsert_detail(
+                ctx.conn,
+                "codeowners_scope",
+                scope_id,
+                path_pattern=pattern,
+                source_path=path,
+                source_sha=payload.get("sha"),
+                line_number=lineno,
+            )
+            for owner in owners:
+                if "/" in owner:  # org/team
+                    org, slug = owner.split("/", 1)
+                    owner_id = ctx.node(
+                        node_type="team", repo_node_id=None, external_id=owner, title=owner
+                    )
+                    db.upsert_detail(ctx.conn, "team", owner_id, org=org, slug=slug)
+                else:
+                    owner_id = upsert_person(ctx, {"login": owner})
+                if owner_id:
+                    ctx.edge(
+                        src=owner_id,
+                        dst=scope_id,
+                        edge_type="owns",
+                        extractor="codeowners_parse",
+                        source_ref=f"{path}:{lineno}",
+                    )
+        return True
+
+    log.info("no CODEOWNERS file in %s — `owns` extractor no-ops", ctx.settings.target_repo)
+    ctx.stats.note_skip("codeowners_absent")
+    return False
+
+
+def extract_wiki(ctx: Context) -> bool:
+    """Wiki pages are not exposed by the REST API and require cloning `<repo>.wiki.git`.
+
+    KNOWN LIMITATION: pallets/flask has has_wiki=false, so there is nothing to clone.
+    Left as an explicit no-op rather than an unimplemented gap. Consequence for §5.1:
+    on this repo `motivated_by` resolves only to issues and PR bodies, never wiki pages.
+    """
+    log.info("wiki ingestion unsupported for %s — no-op", ctx.settings.target_repo)
+    ctx.stats.note_skip("wiki_unsupported")
+    return False

--- a/src/decision_graph/github.py
+++ b/src/decision_graph/github.py
@@ -1,0 +1,196 @@
+"""GitHub REST client: pagination, rate-limit accounting, conditional requests.
+
+Rate limiting is treated as a first-class concern rather than an afterthought,
+because a 12-month backfill of a repo the size of pallets/flask sits close enough
+to the 5,000 req/hour authenticated budget that running out mid-run is expected,
+not exceptional. When the budget is nearly spent the client raises
+:class:`RateLimitExhausted` and the run stops cleanly — the cursor has already been
+committed, so the next run resumes rather than restarting.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Iterator
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+API_ROOT = "https://api.github.com"
+
+
+class RateLimitExhausted(RuntimeError):
+    """Budget hit the configured floor. Not an error — a clean stopping point."""
+
+    def __init__(self, remaining: int, reset_at: datetime) -> None:
+        self.remaining = remaining
+        self.reset_at = reset_at
+        super().__init__(
+            f"GitHub rate limit budget exhausted ({remaining} remaining); "
+            f"resets at {reset_at.isoformat()}. Re-run to resume from the cursor."
+        )
+
+
+@dataclass
+class Page:
+    """One page of results, plus the ETag needed to make the next poll conditional."""
+
+    items: list[dict[str, Any]]
+    etag: str | None = None
+    not_modified: bool = False
+
+
+@dataclass
+class GitHubClient:
+    token: str
+    user_agent: str
+    rate_limit_floor: int = 100
+    per_page: int = 100
+
+    requests_made: int = 0
+    _client: httpx.Client = field(init=False)
+
+    def __post_init__(self) -> None:
+        self._client = httpx.Client(
+            base_url=API_ROOT,
+            timeout=httpx.Timeout(30.0),
+            headers={
+                "Authorization": f"Bearer {self.token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": self.user_agent,
+            },
+            follow_redirects=True,
+        )
+
+    def close(self) -> None:
+        self._client.close()
+
+    def __enter__(self) -> "GitHubClient":
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # -- core request ------------------------------------------------------
+
+    def _request(
+        self, path: str, params: dict[str, Any] | None = None, etag: str | None = None
+    ) -> httpx.Response:
+        headers = {"If-None-Match": etag} if etag else {}
+
+        for attempt in range(4):
+            resp = self._client.get(path, params=params, headers=headers)
+            self.requests_made += 1
+
+            # Secondary (abuse) rate limit — always honour the server's own backoff.
+            if resp.status_code in (403, 429) and "Retry-After" in resp.headers:
+                delay = int(resp.headers["Retry-After"])
+                log.warning("secondary rate limit; sleeping %ss", delay)
+                time.sleep(delay)
+                continue
+
+            if resp.status_code >= 500 and attempt < 3:
+                delay = 2**attempt
+                log.warning("GitHub %s; retrying in %ss", resp.status_code, delay)
+                time.sleep(delay)
+                continue
+
+            self._check_budget(resp)
+            return resp
+
+        resp.raise_for_status()
+        return resp
+
+    def _check_budget(self, resp: httpx.Response) -> None:
+        raw_remaining = resp.headers.get("X-RateLimit-Remaining")
+        if raw_remaining is None:
+            return
+        remaining = int(raw_remaining)
+        if remaining > self.rate_limit_floor:
+            return
+
+        reset = datetime.fromtimestamp(
+            int(resp.headers.get("X-RateLimit-Reset", "0")), tz=timezone.utc
+        )
+        raise RateLimitExhausted(remaining, reset)
+
+    # -- public helpers ----------------------------------------------------
+
+    def get(self, path: str, params: dict[str, Any] | None = None) -> dict[str, Any] | None:
+        """Single resource. Returns None for 404 — several resources are optional.
+
+        pallets/flask has no CODEOWNERS file and no wiki, so a 404 is an expected
+        outcome for those extractors rather than a failure (see issue #1).
+        """
+        resp = self._request(path, params)
+        if resp.status_code == 404:
+            return None
+        resp.raise_for_status()
+        return resp.json()
+
+    def paginate(
+        self,
+        path: str,
+        params: dict[str, Any] | None = None,
+        etag: str | None = None,
+        max_pages: int | None = None,
+    ) -> Iterator[Page]:
+        """Yield pages, following Link rel="next".
+
+        Pages are yielded rather than accumulated so the caller can commit a cursor
+        after each one. That is what makes a killed run resumable at page
+        granularity instead of losing the whole window.
+        """
+        query = dict(params or {})
+        query.setdefault("per_page", self.per_page)
+
+        page_no = 0
+        url: str | None = path
+        first = True
+
+        while url is not None:
+            if max_pages is not None and page_no >= max_pages:
+                log.info("stopping at max_pages=%s", max_pages)
+                return
+
+            # ETag only applies to the first page; deeper pages have their own.
+            resp = self._request(url, query if first else None, etag if first else None)
+
+            if resp.status_code == 304:
+                yield Page(items=[], etag=etag, not_modified=True)
+                return
+
+            resp.raise_for_status()
+            payload = resp.json()
+            items = payload if isinstance(payload, list) else [payload]
+
+            yield Page(items=items, etag=resp.headers.get("ETag") if first else None)
+
+            page_no += 1
+            first = False
+            url = _next_link(resp)
+            query = {}
+
+
+def _next_link(resp: httpx.Response) -> str | None:
+    link = resp.headers.get("Link")
+    if not link:
+        return None
+    for part in link.split(","):
+        segments = part.split(";")
+        if len(segments) < 2:
+            continue
+        if 'rel="next"' in segments[1]:
+            return segments[0].strip().strip("<>")
+    return None
+
+
+def parse_ts(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))

--- a/src/decision_graph/inference.py
+++ b/src/decision_graph/inference.py
@@ -1,0 +1,113 @@
+"""LLM-inference edge proposal — STUBBED, but wired through the real gate (§5.1).
+
+`propose()` returns nothing yet: no model is called in Phase 1. What is built is
+everything around it, because the gate is the part that carries risk. An ungated
+inference path is the failure mode the PRD calls out by name — inferred edges
+treated as fact, and a long tail of speculative connections diluting every traversal.
+
+Three independent bounds, none of which live only in this file:
+
+1. Relevance threshold (graph_config.inferred_edge_min_relevance, v1 0.75)
+2. Per-node cap (graph_config.inferred_edge_max_per_node, v1 4)
+3. Decision nodes may never be touched by an inferred edge
+
+All three are enforced by the `edge_inferred_gate` trigger in migration 0001, not
+here. This module re-reads the config only to avoid proposing work that will be
+rejected; if these checks were deleted the bounds would still hold. That is the point
+— a future caller that forgets to check cannot widen the blast radius.
+
+Rejection is expected flow, not an error. Each proposal is inserted inside a
+SAVEPOINT so that a refusal rolls back one edge instead of aborting the whole
+ingestion transaction.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import psycopg
+
+log = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Proposal:
+    src_node_id: int
+    dst_node_id: int
+    edge_type: str
+    relevance: float
+    rationale: str
+
+
+@dataclass
+class GateOutcome:
+    accepted: int = 0
+    rejected_threshold: int = 0
+    rejected_cap: int = 0
+    rejected_decision: int = 0
+
+    @property
+    def total_rejected(self) -> int:
+        return self.rejected_threshold + self.rejected_cap + self.rejected_decision
+
+
+def propose(conn: psycopg.Connection, repo_node_id: int) -> list[Proposal]:
+    """STUB (Phase 1): always returns no proposals.
+
+    Intended contract when implemented: consider only pairs of entities that are
+    plausibly related but have NO explicit path between them — per §5.1, inference
+    exists to bridge a gap, not to add a second opinion where the graph already has
+    an answer. Candidate generation must therefore run *after* explicit extraction
+    and must exclude already-connected pairs.
+    """
+    log.debug("inference proposal path is stubbed in Phase 1; no edges proposed")
+    return []
+
+
+def persist(conn: psycopg.Connection, proposals: list[Proposal]) -> GateOutcome:
+    """Attempt each proposal against the DB gate. Refusals are counted, not raised."""
+    outcome = GateOutcome()
+
+    for p in proposals:
+        try:
+            with conn.transaction():  # SAVEPOINT: one rejection must not kill the run
+                conn.execute(
+                    """
+                    INSERT INTO edge (src_node_id, dst_node_id, edge_type,
+                                      tag, evidence_tier, extractor, source_ref,
+                                      relevance, valid_from)
+                    VALUES (%s, %s, %s, 'inferred', 'inferred', %s, %s, %s, now())
+                    """,
+                    (
+                        p.src_node_id,
+                        p.dst_node_id,
+                        p.edge_type,
+                        "llm_similarity_v1",
+                        p.rationale[:500],
+                        p.relevance,
+                    ),
+                )
+            outcome.accepted += 1
+        except psycopg.errors.CheckViolation as exc:
+            message = str(exc)
+            if "decision node" in message:
+                outcome.rejected_decision += 1
+            elif "below threshold" in message:
+                outcome.rejected_threshold += 1
+            elif "inferred edges (cap" in message:
+                outcome.rejected_cap += 1
+            else:
+                raise
+            log.debug("proposal refused by gate: %s", message.strip())
+
+    if outcome.total_rejected:
+        log.info(
+            "inference gate: %s accepted, %s refused (threshold=%s cap=%s decision=%s)",
+            outcome.accepted,
+            outcome.total_rejected,
+            outcome.rejected_threshold,
+            outcome.rejected_cap,
+            outcome.rejected_decision,
+        )
+    return outcome

--- a/src/decision_graph/refs.py
+++ b/src/decision_graph/refs.py
@@ -1,0 +1,74 @@
+"""Cross-reference parsing — the core of extraction-first edge construction (§5.1).
+
+Every edge produced here comes from a signal literally present in the text. Nothing
+in this module guesses; guessing is inference.py's job and is gated separately.
+
+Deliberately conservative: a missed edge leaves an artifact queryable on its own,
+whereas a false edge corrupts a traversal and, worse, can push a Decision over the
+reconstructed rubric bar on evidence that was never really there.
+"""
+
+from __future__ import annotations
+
+import re
+
+# GitHub's own closing keywords. Anything else that mentions an issue is a plain
+# reference — the distinction matters because `closes` counts as Validation in the
+# §5.1 rubric while `references` does not.
+CLOSING_KEYWORDS = r"clos(?:e|es|ed)|fix(?:|es|ed)|resolv(?:e|es|ed)"
+
+CLOSES_RE = re.compile(rf"\b(?:{CLOSING_KEYWORDS})\b\s*:?\s+#(\d+)", re.IGNORECASE)
+ISSUE_REF_RE = re.compile(r"(?<![\w/])#(\d+)\b")
+
+# Only full 40-character SHAs. Abbreviated SHAs are indistinguishable from ordinary
+# hex strings in prose and produced false edges in early testing.
+SHA_RE = re.compile(r"\b([0-9a-f]{40})\b")
+
+# "Co-authored-by: Name <email>" — an explicit authorship signal git itself defines.
+COAUTHOR_RE = re.compile(r"^Co-authored-by:\s*(.+?)\s*<(.+?)>\s*$", re.IGNORECASE | re.MULTILINE)
+
+
+def closing_refs(text: str | None) -> set[int]:
+    """Issue/PR numbers this text explicitly closes."""
+    if not text:
+        return set()
+    return {int(m) for m in CLOSES_RE.findall(text)}
+
+
+def mentioned_refs(text: str | None) -> set[int]:
+    """Issue/PR numbers mentioned but not closed."""
+    if not text:
+        return set()
+    return {int(m) for m in ISSUE_REF_RE.findall(text)} - closing_refs(text)
+
+
+def commit_refs(text: str | None) -> set[str]:
+    if not text:
+        return set()
+    return set(SHA_RE.findall(text.lower()))
+
+
+def coauthors(message: str | None) -> list[tuple[str, str]]:
+    if not message:
+        return []
+    return [(name, email) for name, email in COAUTHOR_RE.findall(message)]
+
+
+def parse_codeowners(text: str) -> list[tuple[int, str, list[str]]]:
+    """Parse CODEOWNERS into (line_number, path_pattern, owners).
+
+    Built and tested even though pallets/flask ships no CODEOWNERS file (issue #1),
+    so the `owns` extractor no-ops there. Kept because the parser is repo-independent
+    and the gap is a property of the target repo, not of the system.
+    """
+    rules: list[tuple[int, str, list[str]]] = []
+    for lineno, raw in enumerate(text.splitlines(), start=1):
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        parts = line.split()
+        if len(parts) < 2:
+            continue
+        pattern, owners = parts[0], [o.lstrip("@") for o in parts[1:]]
+        rules.append((lineno, pattern, owners))
+    return rules

--- a/src/decision_graph/run.py
+++ b/src/decision_graph/run.py
@@ -1,0 +1,234 @@
+"""Ingestion orchestrator (PRD v3.1 §8).
+
+Commit discipline is what makes resume real: the transaction is committed after each
+page, immediately after that page's cursor is advanced. So the cursor on disk never
+claims more progress than the graph actually contains. A run killed mid-page loses
+that page and redoes it; a run killed between pages loses nothing. The reverse
+ordering — commit the data, advance the cursor later — would let a crash skip a page
+permanently, which is the kind of hole nothing downstream would ever notice.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime, timezone
+
+import psycopg
+
+from . import cursors, db, extractors, inference, threads
+from .config import Settings
+from .cursors import Strategy
+from .extractors import Context
+from .github import GitHubClient, RateLimitExhausted, parse_ts
+
+log = logging.getLogger("decision_graph")
+
+
+def ingest(settings: Settings, *, resources: list[str], max_pages: int | None) -> int:
+    conn = db.connect(settings.database_url)
+    client = GitHubClient(
+        token=settings.github_token,
+        user_agent=settings.user_agent,
+        rate_limit_floor=settings.rate_limit_floor,
+    )
+
+    repo_node_id = extractors.extract_repository(conn, client, settings)
+    conn.commit()
+
+    run_id = db.start_run(conn, repo_node_id)
+    conn.commit()
+
+    ctx = Context(conn=conn, client=client, settings=settings, repo_node_id=repo_node_id)
+    status, error = "succeeded", None
+
+    try:
+        for resource in resources:
+            log.info("--- %s ---", resource)
+            _ingest_resource(ctx, resource, run_id, max_pages)
+
+        # Gated inference runs last: it may only bridge gaps that explicit extraction
+        # left behind, so it must not run before extraction has had its say (§5.1).
+        inference.persist(conn, inference.propose(conn, repo_node_id))
+        conn.commit()
+
+    except RateLimitExhausted as exc:
+        conn.commit()  # cursors are already consistent; keep the progress
+        status, error = "succeeded", f"stopped early: {exc}"
+        log.warning("%s", exc)
+    except KeyboardInterrupt:
+        conn.commit()
+        status, error = "succeeded", "interrupted by user; cursors preserved"
+        log.warning("interrupted — progress preserved, re-run to resume")
+    except Exception as exc:  # noqa: BLE001 - recorded on the run row, then re-raised
+        conn.rollback()
+        status, error = "failed", f"{type(exc).__name__}: {exc}"
+        log.exception("ingestion failed")
+    finally:
+        db.finish_run(
+            conn, run_id, status=status, nodes=ctx.stats.nodes, edges=ctx.stats.edges, error=error
+        )
+        conn.commit()
+        client.close()
+
+    _report(ctx, client)
+    conn.close()
+    return 0 if status == "succeeded" else 1
+
+
+def _ingest_resource(ctx: Context, resource: str, run_id: int, max_pages: int | None) -> None:
+    conn = ctx.conn
+
+    if resource == "codeowners":
+        extractors.extract_codeowners(ctx)
+        conn.commit()
+        return
+    if resource == "wiki":
+        extractors.extract_wiki(ctx)
+        conn.commit()
+        return
+
+    cursor = cursors.load(conn, ctx.repo_node_id, resource, ctx.settings.backfill_months)
+    cursors.bind_run(conn, cursor, run_id)
+    conn.commit()
+
+    params = cursors.query_params(cursor)
+    path = _resource_path(ctx.settings.target_repo, resource)
+    etag = cursor.last_etag if cursor.strategy is Strategy.FULL else None
+
+    log.info(
+        "%s: phase=%s params=%s", resource, cursor.phase, {k: v for k, v in params.items()}
+    )
+
+    saw_any = False
+
+    for page in ctx.client.paginate(path, params, etag=etag, max_pages=max_pages):
+        if page.not_modified:
+            log.info("%s: unchanged since last poll (304)", resource)
+            return
+        if not page.items:
+            break
+
+        saw_any = True
+        timestamps = _process_page(ctx, resource, page.items)
+
+        if timestamps:
+            oldest, newest = min(timestamps), max(timestamps)
+            if cursor.strategy is Strategy.COMMITTED_DESC and cursor.is_backfilling:
+                cursors.advance_backfill(conn, cursor, oldest, newest)
+            else:
+                cursors.advance_steady(conn, cursor, newest, page.etag)
+
+        cursors.set_etag(conn, cursor, page.etag)
+        # Cursor and data land together. See module docstring.
+        conn.commit()
+
+    # Pages exhausted: for a windowed backfill that means the floor has been reached.
+    if cursor.strategy is Strategy.COMMITTED_DESC and cursor.is_backfilling and max_pages is None:
+        cursors.complete_backfill(conn, cursor)
+    if not saw_any:
+        log.info("%s: nothing new", resource)
+    conn.commit()
+
+
+def _process_page(ctx: Context, resource: str, items: list[dict]) -> list[datetime]:
+    timestamps: list[datetime] = []
+
+    for payload in items:
+        if resource in ("issues", "pulls"):
+            node_id = extractors.extract_issue_or_pr(ctx, payload)
+            ts = parse_ts(payload.get("updated_at"))
+
+            if "pull_request" in payload:
+                number = payload["number"]
+                extractors.extract_reviews(ctx, number, node_id)
+                extractors.link_pr_commits(ctx, number, node_id)
+
+        elif resource == "commits":
+            extractors.extract_commit(ctx, payload)
+            ts = parse_ts(((payload.get("commit") or {}).get("committer") or {}).get("date"))
+
+        elif resource == "releases":
+            extractors.extract_release(ctx, payload)
+            ts = parse_ts(payload.get("published_at"))
+
+        elif resource == "workflows":
+            extractors.extract_workflow(ctx, payload)
+            ts = parse_ts(payload.get("updated_at"))
+
+        else:
+            raise ValueError(f"unknown resource: {resource}")
+
+        if ts:
+            timestamps.append(ts)
+
+    return timestamps
+
+
+def _resource_path(repo: str, resource: str) -> str:
+    return {
+        # /issues returns pull requests too; both cursors ride the same endpoint.
+        "issues": f"/repos/{repo}/issues",
+        "pulls": f"/repos/{repo}/issues",
+        "commits": f"/repos/{repo}/commits",
+        "releases": f"/repos/{repo}/releases",
+        "workflows": f"/repos/{repo}/actions/workflows",
+    }[resource]
+
+
+def _report(ctx: Context, client: GitHubClient) -> None:
+    log.info("")
+    log.info("nodes upserted : %s", ctx.stats.nodes)
+    log.info("edges created  : %s", ctx.stats.edges)
+    log.info("API requests   : %s", client.requests_made)
+    if ctx.stats.skipped:
+        log.info("skipped (expected, not hidden):")
+        for reason, count in sorted(ctx.stats.skipped.items(), key=lambda kv: -kv[1]):
+            log.info("  %-36s %s", reason, count)
+
+
+# workflows sits behind a paginated object rather than a bare list, so it is excluded
+# from the default set until the response shape is handled.
+DEFAULT_RESOURCES = ["issues", "commits", "releases", "codeowners", "wiki"]
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(prog="dg-ingest", description=__doc__)
+    parser.add_argument("--repo", help="owner/name (default: pallets/flask)")
+    parser.add_argument("--months", type=int, help="backfill window in months (default: 12)")
+    parser.add_argument(
+        "--resources", nargs="*", default=DEFAULT_RESOURCES, help="subset to ingest"
+    )
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        help="stop each resource after N pages. For smoke tests — leaves the cursor "
+        "mid-window on purpose so the next run demonstrates resume.",
+    )
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)-7s %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    # httpx logs every request at INFO, which buries the ingestion narrative.
+    logging.getLogger("httpx").setLevel(logging.WARNING)
+
+    try:
+        settings = Settings.from_env(target_repo=args.repo, backfill_months=args.months)
+    except RuntimeError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+
+    log.info("target repo    : %s", settings.target_repo)
+    log.info("backfill window: %s months", settings.backfill_months)
+
+    return ingest(settings, resources=args.resources, max_pages=args.max_pages)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/decision_graph/threads.py
+++ b/src/decision_graph/threads.py
@@ -1,0 +1,91 @@
+"""thread_key assignment — the v1 stand-in for §5.1's "bounded time window".
+
+The reconstructed-Decision rubric requires that every edge it relies on references
+"the same PR/issue thread". A thread here is one conversation cluster: a PR, the
+issues it closes, its commits, and its reviews.
+
+Why this is DB-backed union rather than an in-memory pass: linkage is discovered out
+of order and across runs. A PR ingested in March can close an issue ingested in
+January, and the January run had no way to know. So union has to be able to merge two
+threads that already exist and are already persisted, which is exactly a single
+UPDATE. The alternative — rebuilding a DSU over the whole graph each run — would
+break the bounded-backfill property by requiring a full scan.
+
+Canonical key selection is deterministic and PR-preferring, so merging threads A and
+B always yields the same winner no matter which order the runs happened in. Without
+that, the same repo ingested in two different orders could produce different
+thread_keys, and the rubric's clause 3 would be order-dependent — a Decision that
+passes on one machine and fails on another.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+import psycopg
+
+log = logging.getLogger(__name__)
+
+_KEY_RE = re.compile(r"^thread:(\d+):(pr|issue)-(\d+)$")
+
+
+def pr_key(repo_node_id: int, number: int) -> str:
+    return f"thread:{repo_node_id}:pr-{number}"
+
+
+def issue_key(repo_node_id: int, number: int) -> str:
+    return f"thread:{repo_node_id}:issue-{number}"
+
+
+def _rank(key: str) -> tuple[int, int]:
+    """Lower sorts first and wins. PR keys beat issue keys; then lowest number.
+
+    A PR is preferred as the canonical anchor because it is where implementation and
+    review converge, which is what clause 2 of the rubric looks for.
+    """
+    m = _KEY_RE.match(key)
+    if not m:
+        return (2, 0)
+    _, kind, number = m.groups()
+    return (0 if kind == "pr" else 1, int(number))
+
+
+def assign(conn: psycopg.Connection, node_id: int, key: str) -> None:
+    """Give a node a thread key if it has none. Never overwrites an existing key —
+    that is union's job, and overwriting would silently split an existing thread."""
+    conn.execute(
+        "UPDATE node SET thread_key = %s WHERE id = %s AND thread_key IS NULL",
+        (key, node_id),
+    )
+
+
+def union(conn: psycopg.Connection, node_a: int, node_b: int) -> str | None:
+    """Merge the threads containing two nodes; returns the surviving key.
+
+    Nodes without a key are pulled into the other's thread. If neither has one there
+    is nothing to merge and no key is invented — an unthreaded node correctly fails
+    rubric clause 3 rather than being given a plausible-looking home.
+    """
+    rows = conn.execute(
+        "SELECT id, thread_key FROM node WHERE id IN (%s, %s)", (node_a, node_b)
+    ).fetchall()
+    keys = {r["id"]: r["thread_key"] for r in rows}
+
+    key_a, key_b = keys.get(node_a), keys.get(node_b)
+
+    if key_a is None and key_b is None:
+        return None
+    if key_a == key_b:
+        return key_a
+    if key_a is None:
+        conn.execute("UPDATE node SET thread_key = %s WHERE id = %s", (key_b, node_a))
+        return key_b
+    if key_b is None:
+        conn.execute("UPDATE node SET thread_key = %s WHERE id = %s", (key_a, node_b))
+        return key_a
+
+    winner, loser = sorted([key_a, key_b], key=_rank)
+    conn.execute("UPDATE node SET thread_key = %s WHERE thread_key = %s", (winner, loser))
+    log.debug("merged thread %s into %s", loser, winner)
+    return winner

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -1,0 +1,104 @@
+"""Unit tests for the extraction-first parsers.
+
+stdlib unittest, no test dependency: `python -m unittest discover tests`.
+
+The CODEOWNERS parser matters most here. pallets/flask ships no CODEOWNERS file
+(issue #1), so ingestion can never exercise it against the real target — these tests
+are the only verification it will ever get.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from decision_graph import refs, threads
+
+
+class TestClosingRefs(unittest.TestCase):
+    def test_recognises_github_closing_keywords(self) -> None:
+        for text in (
+            "Fixes #123",
+            "fixed #123",
+            "Closes #123",
+            "closed #123",
+            "Resolves #123",
+            "close #123",
+            "Fixes: #123",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(refs.closing_refs(text), {123})
+
+    def test_plain_mention_is_not_a_closure(self) -> None:
+        text = "Related to #99, see also #100"
+        self.assertEqual(refs.closing_refs(text), set())
+        self.assertEqual(refs.mentioned_refs(text), {99, 100})
+
+    def test_mentions_exclude_closures(self) -> None:
+        # A body that both closes one issue and mentions another must not produce a
+        # duplicate `references` edge alongside the `closes` edge — the rubric treats
+        # them differently, so double-counting would inflate Validation evidence.
+        text = "Fixes #1. Context in #2."
+        self.assertEqual(refs.closing_refs(text), {1})
+        self.assertEqual(refs.mentioned_refs(text), {2})
+
+    def test_ignores_urls_and_paths(self) -> None:
+        self.assertEqual(refs.mentioned_refs("see docs/page#3 for detail"), set())
+
+    def test_handles_empty_and_none(self) -> None:
+        self.assertEqual(refs.closing_refs(None), set())
+        self.assertEqual(refs.mentioned_refs(""), set())
+
+
+class TestCommitRefs(unittest.TestCase):
+    def test_requires_full_forty_char_sha(self) -> None:
+        full = "a" * 40
+        self.assertEqual(refs.commit_refs(f"reverts {full}"), {full})
+
+    def test_rejects_abbreviated_sha(self) -> None:
+        # Abbreviated SHAs are indistinguishable from ordinary hex in prose; accepting
+        # them produced false `references` edges.
+        self.assertEqual(refs.commit_refs("see abc1234 for context"), set())
+
+
+class TestCodeowners(unittest.TestCase):
+    def test_parses_patterns_and_owners(self) -> None:
+        content = "\n".join(
+            [
+                "# comment line",
+                "",
+                "*       @global-owner",
+                "/docs/  @org/docs-team @alice",
+                "*.js    @js-owner   # trailing comment",
+            ]
+        )
+        rules = refs.parse_codeowners(content)
+        self.assertEqual(
+            rules,
+            [
+                (3, "*", ["global-owner"]),
+                (4, "/docs/", ["org/docs-team", "alice"]),
+                (5, "*.js", ["js-owner"]),
+            ],
+        )
+
+    def test_skips_blank_comment_and_ownerless_lines(self) -> None:
+        self.assertEqual(refs.parse_codeowners("# just a comment\n\n/orphan-pattern\n"), [])
+
+
+class TestThreadKeyRanking(unittest.TestCase):
+    def test_pull_request_key_beats_issue_key(self) -> None:
+        # Determinism matters: if the winner depended on ingestion order, the same repo
+        # ingested twice could produce different thread_keys, making rubric clause 3
+        # order-dependent.
+        pr = threads.pr_key(1, 500)
+        issue = threads.issue_key(1, 2)
+        self.assertEqual(sorted([pr, issue], key=threads._rank)[0], pr)
+        self.assertEqual(sorted([issue, pr], key=threads._rank)[0], pr)
+
+    def test_lower_number_wins_within_same_kind(self) -> None:
+        low, high = threads.pr_key(1, 10), threads.pr_key(1, 99)
+        self.assertEqual(sorted([high, low], key=threads._rank)[0], low)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #1. Implements PRD v3.1 §8 and the extraction-first half of §5.1.

## Resume is the mechanism, not a fallback

One cursor drives both the initial backfill and every steady-state poll — the only difference is where it starts. That means the resume path runs on every single invocation and can't quietly rot the way a rarely-taken recovery branch would.

Commit ordering is the load-bearing detail: the transaction commits after each page, immediately after that page's cursor advances. The cursor on disk never claims more progress than the graph actually contains. The reverse ordering would let a crash skip a page permanently — a hole nothing downstream would ever notice.

Three strategies, because the endpoints genuinely differ:

| strategy | resources | why |
|---|---|---|
| `UPDATED_ASC` | issues, pulls | `since` + updated-ascending; backfill and steady poll are the same forward walk |
| `COMMITTED_DESC` | commits | always newest-first, so backfill pages *backwards* on `until`, then flips to `steady` |
| `FULL` | releases, workflows, CODEOWNERS | small, unwindowed, ETag-conditional |

`window_floor` is pinned on first contact rather than recomputed per run. Recomputing it would mean resuming a backfill a week later silently moves the floor forward, leaving an unfetched gap mid-window that nothing revisits.

## Inference is stubbed but not ungated

`propose()` returns nothing — no model call in Phase 1. Everything *around* it is built, because the gate is where the risk lives. All three bounds (relevance ≥ 0.75, ≤ 4 edges per node, never touching a Decision node) are enforced by the `edge_inferred_gate` trigger in migration 0001, not by this module. If the Python checks were deleted the bounds would still hold. Proposals insert inside a `SAVEPOINT`, so a refusal rolls back one edge instead of aborting the run — rejection is expected flow, not an error.

## Two schema additions this work uncovered

**0003** splits the cursor into `window_floor` / `backfill_cursor` / `steady_watermark`. A single `last_since` can't serve both directions: a backfill walks from now *backwards* to a floor, steady-state walks *forwards* from the newest thing seen.

**0004** repairs and then forbids repository nodes self-referencing `repo_node_id`. This was a real bug found by running ingestion twice: `repo_node_id` participates in `node_identity_uidx` via `COALESCE(repo_node_id, 0)`, so writing the node's own id back into it moved the identity key from `(repository, 0, 'pallets/flask')` to `(repository, 30, 'pallets/flask')`. The next run missed the lookup and inserted a **second repository node** — caught only incidentally, one layer downstream, by the `repository(owner, name)` unique constraint. 0001 documented the rule in a comment; nothing enforced it. Now a CHECK does.

## Verification against pallets/flask

Two real runs, not a dry run:

- Cursor advanced `2026-02-09` → `2026-07-30` on the second run, resuming from the watermark rather than restarting the window
- 569 nodes (213 commit, 156 person, 145 PR, 54 issue, 1 repository) across 170 threads
- Exactly **1** repository node after two runs — the 0004 fix confirmed
- **0 Decision nodes** and **0 inferred edges**, as Phase 1 requires
- Thread union merging correctly: `thread:30:pr-5914` spans commit + issue + pull_request, which is the PR↔issue cluster rubric clause 3 depends on
- 11 unit tests pass, covering the CODEOWNERS parser that flask can never exercise

## Known limitations on flask, documented not fixed

- **No CODEOWNERS** at any of the three canonical paths → `owns` extractor no-ops, no ownership edges. **The §9 eval set cannot include ownership queries against flask.**
- **`has_wiki: false`** → `wiki_page` extractor no-ops; `motivated_by` resolves only to issues and PR bodies on this repo.
- Cross-refs to artifacts outside the 12-month window are skipped, not fetched — fetching would make the window unbounded by the back door. Counted in the run summary under `*_target_not_ingested` rather than hidden.

## Out of scope

Phase 2+. No retrieval, no traversal, no reasoning, no Decision synthesis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pCAUDALD1g8DBsf8j8PuK