### PR TITLE
Resolve forward references via a pending queue

### DIFF
--- a/db/migrations/0005_pending_reference.sql
+++ b/db/migrations/0005_pending_reference.sql
@@ -1,0 +1,81 @@
+-- 0005_pending_reference.sql
+-- Deferred resolution of forward references (issue #3).
+--
+-- extractors._lookup_by_number resolved "#N" against whatever was in the graph at that
+-- instant. Issues and PRs are walked updated-ascending, so a PR whose updated_at
+-- precedes the issue it closes was written first, found nothing, and dropped the edge.
+-- Nothing revisited it: the cursor had already moved past both. Measured on the first
+-- pallets/flask window, 9 of 30 closing keywords were lost this way.
+--
+-- The queue records the *intent* to link, so resolution can be retried once the rest of
+-- the window has landed. It deliberately stores a reference NUMBER rather than a target
+-- node id — the target does not exist yet, which is the entire problem.
+--
+-- This preserves the bounded window. Resolution only retries the LOOKUP; it never
+-- fetches the missing target. A reference to an artifact genuinely outside the 12-month
+-- window stays unresolved forever, which is correct, and is visible as a row with a
+-- climbing attempts count rather than as silence.
+
+BEGIN;
+
+CREATE TABLE pending_reference (
+    id               bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    repo_node_id     bigint NOT NULL REFERENCES node (id) ON DELETE CASCADE,
+
+    -- The artifact that made the reference. Known; it is the target that is missing.
+    src_node_id      bigint NOT NULL REFERENCES node (id) ON DELETE CASCADE,
+    ref_number       integer NOT NULL,
+    edge_type        edge_type NOT NULL,
+
+    -- Carried so the edge created on resolution is indistinguishable from one written
+    -- inline at extraction time — same extractor, same source_ref, same observed_at.
+    extractor        text NOT NULL,
+    source_ref       text,
+    observed_at      timestamptz,
+
+    first_seen_at    timestamptz NOT NULL DEFAULT now(),
+    last_attempt_at  timestamptz,
+    attempts         integer NOT NULL DEFAULT 0,
+
+    resolved_at      timestamptz,
+    resolved_edge_id bigint REFERENCES edge (id) ON DELETE SET NULL,
+
+    CONSTRAINT pending_reference_resolution_consistent
+        CHECK ((resolved_at IS NULL) = (resolved_edge_id IS NULL))
+);
+
+-- One open row per (source, number, edge type). Re-parsing the same body on a later
+-- poll must not enqueue a duplicate.
+CREATE UNIQUE INDEX pending_reference_open_uidx
+    ON pending_reference (src_node_id, ref_number, edge_type)
+    WHERE resolved_at IS NULL;
+
+CREATE INDEX pending_reference_open_idx
+    ON pending_reference (repo_node_id, ref_number)
+    WHERE resolved_at IS NULL;
+
+COMMENT ON TABLE pending_reference IS
+    'Queue of parsed cross-references whose target was not yet in the graph. Drained at '
+    'the end of every ingestion run (issue #3). An unresolved row is not necessarily a '
+    'bug: a reference to an artifact outside the backfill window can never resolve, and '
+    'stays here as a visible record rather than being silently dropped.';
+
+-- Unresolved references, split by whether the target has since arrived. A row in
+-- `resolvable_now` means the drain has not run yet; a row in `outside_window` is the
+-- expected, correct outcome of bounding the backfill.
+CREATE VIEW v_pending_reference_status AS
+SELECT p.repo_node_id,
+       p.edge_type,
+       count(*)                                            AS open_refs,
+       count(*) FILTER (WHERE t.id IS NOT NULL)            AS resolvable_now,
+       count(*) FILTER (WHERE t.id IS NULL)                AS target_outside_window,
+       max(p.attempts)                                     AS max_attempts
+FROM pending_reference p
+LEFT JOIN node t
+       ON t.repo_node_id = p.repo_node_id
+      AND t.external_id = p.ref_number::text
+      AND t.node_type IN ('issue', 'pull_request')
+WHERE p.resolved_at IS NULL
+GROUP BY p.repo_node_id, p.edge_type;
+
+COMMIT;

--- a/db/tests/0005_pending_reference_checks.sql
+++ b/db/tests/0005_pending_reference_checks.sql
@@ -1,0 +1,122 @@
+-- 0005_pending_reference_checks.sql
+-- Constraint behaviour for the deferred-reference queue (issue #3).
+-- Transactional; rolls back. Companion to 0002_rubric_checks.sql.
+
+BEGIN;
+
+CREATE TEMP TABLE test_result (
+    seq    int GENERATED ALWAYS AS IDENTITY,
+    name   text,
+    expect text,
+    passed boolean,
+    detail text
+);
+
+CREATE FUNCTION pg_temp.mk(p_type node_type, p_ext text, p_repo bigint DEFAULT NULL)
+RETURNS bigint LANGUAGE sql AS $fn$
+    INSERT INTO node (node_type, external_id, repo_node_id)
+    VALUES (p_type, p_ext, p_repo) RETURNING id;
+$fn$;
+
+CREATE FUNCTION pg_temp.enqueue(p_repo bigint, p_src bigint, p_ref int, p_type edge_type)
+RETURNS bigint LANGUAGE sql AS $fn$
+    INSERT INTO pending_reference (repo_node_id, src_node_id, ref_number, edge_type, extractor)
+    VALUES (p_repo, p_src, p_ref, p_type, 'test_fixture')
+    RETURNING id;
+$fn$;
+
+
+-- T1  One open row per (src, ref, edge_type): re-parsing on a later poll must not
+--     enqueue a duplicate.
+DO $t$
+DECLARE repo bigint; pr bigint; ok boolean; err text;
+BEGIN
+    repo := pg_temp.mk('repository', 't1-repo');
+    pr   := pg_temp.mk('pull_request', 't1-pr', repo);
+    PERFORM pg_temp.enqueue(repo, pr, 999, 'closes');
+    BEGIN
+        PERFORM pg_temp.enqueue(repo, pr, 999, 'closes');
+        ok := true;
+    EXCEPTION WHEN unique_violation THEN ok := false; err := SQLERRM;
+    END;
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T1 duplicate open reference refused', 'rejected', NOT ok, err);
+END;
+$t$;
+
+
+-- T2  The uniqueness is PARTIAL. Once resolved, the same triple may be queued again --
+--     an edge can legitimately be invalidated and re-derived on a later poll.
+DO $t$
+DECLARE repo bigint; pr bigint; iss bigint; e bigint; p bigint; ok boolean; err text;
+BEGIN
+    repo := pg_temp.mk('repository', 't2-repo');
+    pr   := pg_temp.mk('pull_request', 't2-pr', repo);
+    iss  := pg_temp.mk('issue', 't2-issue', repo);
+    p    := pg_temp.enqueue(repo, pr, 42, 'closes');
+
+    INSERT INTO edge (src_node_id, dst_node_id, edge_type, tag, evidence_tier, extractor)
+    VALUES (pr, iss, 'closes', 'explicit', 'explicit', 'test_fixture') RETURNING id INTO e;
+
+    UPDATE pending_reference SET resolved_at = now(), resolved_edge_id = e WHERE id = p;
+
+    BEGIN
+        PERFORM pg_temp.enqueue(repo, pr, 42, 'closes');
+        ok := true;
+    EXCEPTION WHEN others THEN ok := false; err := SQLERRM;
+    END;
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T2 re-queue allowed after resolution', 'accepted', ok, err);
+END;
+$t$;
+
+
+-- T3  A row cannot claim resolution without naming the edge that resolved it.
+DO $t$
+DECLARE repo bigint; pr bigint; p bigint; ok boolean; err text;
+BEGIN
+    repo := pg_temp.mk('repository', 't3-repo');
+    pr   := pg_temp.mk('pull_request', 't3-pr', repo);
+    p    := pg_temp.enqueue(repo, pr, 7, 'references');
+    BEGIN
+        UPDATE pending_reference SET resolved_at = now() WHERE id = p;
+        ok := true;
+    EXCEPTION WHEN check_violation THEN ok := false; err := SQLERRM;
+    END;
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T3 resolution without edge id refused', 'rejected', NOT ok, err);
+END;
+$t$;
+
+
+-- T4  The status view separates "drain has not run" from "target outside window" --
+--     the distinction that made issue #3 diagnosable in the first place.
+DO $t$
+DECLARE repo bigint; pr bigint; iss bigint; v_now int; v_out int;
+BEGIN
+    repo := pg_temp.mk('repository', 't4-repo');
+    pr   := pg_temp.mk('pull_request', 't4-pr', repo);
+    iss  := pg_temp.mk('issue', '4242', repo);      -- in-window target
+    PERFORM pg_temp.enqueue(repo, pr, 4242, 'closes');   -- resolvable
+    PERFORM pg_temp.enqueue(repo, pr, 1111, 'closes');   -- outside window
+
+    SELECT resolvable_now, target_outside_window INTO v_now, v_out
+    FROM v_pending_reference_status WHERE repo_node_id = repo AND edge_type = 'closes';
+
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T4 view separates resolvable from out-of-window', '1 and 1',
+            v_now = 1 AND v_out = 1,
+            format('resolvable_now=%s target_outside_window=%s', v_now, v_out));
+END;
+$t$;
+
+
+SELECT seq, CASE WHEN passed THEN 'PASS' ELSE 'FAIL' END AS result, name, expect,
+       left(regexp_replace(COALESCE(detail, ''), '\s+', ' ', 'g'), 60) AS detail
+FROM test_result ORDER BY seq;
+
+SELECT count(*) FILTER (WHERE passed) AS passed,
+       count(*) FILTER (WHERE NOT passed) AS failed, count(*) AS total
+FROM test_result;
+
+ROLLBACK;

--- a/src/decision_graph/db.py
+++ b/src/decision_graph/db.py
@@ -122,8 +122,11 @@ def upsert_explicit_edge(
     extractor: str,
     source_ref: str | None = None,
     observed_at: datetime | None = None,
-) -> bool:
-    """Create (or refresh) an explicit edge. Returns True if a new edge was created.
+) -> tuple[int | None, bool]:
+    """Create (or refresh) an explicit edge. Returns (edge_id, newly_created).
+
+    The id is returned as well as the flag so deferred resolution (issue #3) can record
+    which edge finally satisfied a queued reference.
 
     Self-loops are dropped here rather than left to hit the CHECK constraint: a PR
     body containing its own number is common and is not an error worth aborting on.
@@ -132,7 +135,7 @@ def upsert_explicit_edge(
     currently-valid edges collide. Superseded edges keep their history via valid_to.
     """
     if src == dst:
-        return False
+        return None, False
 
     row = conn.execute(
         """
@@ -145,7 +148,7 @@ def upsert_explicit_edge(
         DO UPDATE SET
             source_ref  = COALESCE(EXCLUDED.source_ref, edge.source_ref),
             observed_at = COALESCE(EXCLUDED.observed_at, edge.observed_at)
-        RETURNING (xmax = 0) AS inserted
+        RETURNING id, (xmax = 0) AS inserted
         """,
         {
             "src": src,
@@ -158,7 +161,9 @@ def upsert_explicit_edge(
             "observed_at": observed_at,
         },
     ).fetchone()
-    return bool(row and row["inserted"])
+    if row is None:
+        return None, False
+    return row["id"], bool(row["inserted"])
 
 
 # ---------------------------------------------------------------------------

--- a/src/decision_graph/extractors.py
+++ b/src/decision_graph/extractors.py
@@ -49,9 +49,11 @@ class Context:
         self.stats.nodes += 1
         return node_id
 
-    def edge(self, **kwargs: Any) -> None:
-        if db.upsert_explicit_edge(self.conn, **kwargs):
+    def edge(self, **kwargs: Any) -> int | None:
+        edge_id, created = db.upsert_explicit_edge(self.conn, **kwargs)
+        if created:
             self.stats.edges += 1
+        return edge_id
 
 
 # ---------------------------------------------------------------------------
@@ -201,45 +203,206 @@ def _link_body_refs(
     A bare mention yields `references` and deliberately does NOT union: mentioning a
     neighbouring issue is not the same conversation, and merging on it would let
     clause 3 pass on unrelated work.
-    """
-    for number in refs.closing_refs(text):
-        target = _lookup_by_number(ctx, number)
-        if target is None:
-            ctx.stats.note_skip("closes_ref_target_not_ingested")
-            continue
-        ctx.edge(
-            src=src_node_id,
-            dst=target,
-            edge_type="closes",
-            extractor="body_closing_keyword",
-            source_ref=source_ref,
-            observed_at=observed_at,
-        )
-        threads.union(ctx.conn, src_node_id, target)
 
-    for number in refs.mentioned_refs(text):
+    A reference whose target is not in the graph yet is QUEUED, not dropped (issue #3).
+    """
+    for number, edge_type, extractor in [
+        *((n, "closes", "body_closing_keyword") for n in refs.closing_refs(text)),
+        *((n, "references", "body_issue_mention") for n in refs.mentioned_refs(text)),
+    ]:
         target = _lookup_by_number(ctx, number)
         if target is None:
-            ctx.stats.note_skip("mention_ref_target_not_ingested")
+            _enqueue_reference(
+                ctx,
+                src_node_id=src_node_id,
+                number=number,
+                edge_type=edge_type,
+                extractor=extractor,
+                source_ref=source_ref,
+                observed_at=observed_at,
+            )
             continue
-        ctx.edge(
-            src=src_node_id,
-            dst=target,
-            edge_type="references",
-            extractor="body_issue_mention",
-            source_ref=source_ref,
-            observed_at=observed_at,
+        _link(ctx, src_node_id, target, edge_type, extractor, source_ref, observed_at)
+
+
+def _link(
+    ctx: Context,
+    src: int,
+    dst: int,
+    edge_type: str,
+    extractor: str,
+    source_ref: str | None,
+    observed_at: datetime | None,
+) -> int | None:
+    """Create one reference edge, unioning threads for `closes` only."""
+    edge_id = ctx.edge(
+        src=src,
+        dst=dst,
+        edge_type=edge_type,
+        extractor=extractor,
+        source_ref=source_ref,
+        observed_at=observed_at,
+    )
+    if edge_type == "closes":
+        threads.union(ctx.conn, src, dst)
+    return edge_id
+
+
+def _enqueue_reference(
+    ctx: Context,
+    *,
+    src_node_id: int,
+    number: int,
+    edge_type: str,
+    extractor: str,
+    source_ref: str | None,
+    observed_at: datetime | None,
+) -> None:
+    """Record the intent to link, for the end-of-run drain (issue #3).
+
+    Stores the reference NUMBER rather than a target id, because the target does not
+    exist yet — that is the whole reason this row is being written.
+    """
+    ctx.conn.execute(
+        """
+        INSERT INTO pending_reference (repo_node_id, src_node_id, ref_number, edge_type,
+                                       extractor, source_ref, observed_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s)
+        ON CONFLICT (src_node_id, ref_number, edge_type) WHERE resolved_at IS NULL
+        DO NOTHING
+        """,
+        (
+            ctx.repo_node_id,
+            src_node_id,
+            number,
+            edge_type,
+            extractor,
+            source_ref,
+            observed_at,
+        ),
+    )
+    ctx.stats.note_skip(f"{edge_type}_ref_queued_for_resolution")
+
+
+def drain_pending_references(ctx: Context) -> tuple[int, int]:
+    """Retry queued references now the rest of the window has landed (issue #3).
+
+    Returns (resolved, still_pending). Only the LOOKUP is retried — the missing target
+    is never fetched — so the bounded backfill window stays bounded. A reference to an
+    artifact genuinely outside the window simply never resolves, which is correct, and
+    stays visible as a row with a climbing attempts count.
+    """
+    rows = ctx.conn.execute(
+        """
+        SELECT id, src_node_id, ref_number, edge_type, extractor, source_ref, observed_at
+        FROM pending_reference
+        WHERE repo_node_id = %s AND resolved_at IS NULL
+        ORDER BY id
+        """,
+        (ctx.repo_node_id,),
+    ).fetchall()
+
+    resolved = 0
+    for row in rows:
+        target = _lookup_by_number(ctx, row["ref_number"])
+        if target is None:
+            ctx.conn.execute(
+                "UPDATE pending_reference SET attempts = attempts + 1, "
+                "last_attempt_at = now() WHERE id = %s",
+                (row["id"],),
+            )
+            continue
+
+        edge_id = _link(
+            ctx,
+            row["src_node_id"],
+            target,
+            row["edge_type"],
+            row["extractor"],
+            row["source_ref"],
+            row["observed_at"],
         )
+        if edge_id is None:
+            # Self-reference; it will never resolve to a real edge. Count the attempt
+            # rather than looping on it every run.
+            ctx.conn.execute(
+                "UPDATE pending_reference SET attempts = attempts + 1, "
+                "last_attempt_at = now() WHERE id = %s",
+                (row["id"],),
+            )
+            continue
+
+        ctx.conn.execute(
+            "UPDATE pending_reference SET resolved_at = now(), resolved_edge_id = %s, "
+            "attempts = attempts + 1, last_attempt_at = now() WHERE id = %s",
+            (edge_id, row["id"]),
+        )
+        resolved += 1
+
+    still_pending = len(rows) - resolved
+    if rows:
+        log.info(
+            "pending references: %s resolved, %s still open", resolved, still_pending
+        )
+    return resolved, still_pending
+
+
+def reconcile_stored_bodies(ctx: Context) -> int:
+    """Re-parse already-ingested bodies and queue any reference that has no edge.
+
+    Recovery path for references dropped before the queue existed. Costs no API calls:
+    the bodies are already in the graph, so this re-derives the links purely from stored
+    text. Also a safety net if a parser rule is ever widened — reconcile picks up what
+    the new rule now matches, without re-polling GitHub.
+    """
+    sources = (
+        ("pull_request", "SELECT node_id AS id, body AS text FROM pull_request"),
+        ("issue", "SELECT node_id AS id, body AS text FROM issue"),
+        ("commit", "SELECT node_id AS id, message AS text FROM commit"),
+    )
+
+    queued = 0
+    for label, query in sources:
+        for row in ctx.conn.execute(query).fetchall():
+            text = row["text"]
+            if not text:
+                continue
+            for number, edge_type, extractor in [
+                *((n, "closes", "body_closing_keyword") for n in refs.closing_refs(text)),
+                *((n, "references", "body_issue_mention") for n in refs.mentioned_refs(text)),
+            ]:
+                target = _lookup_by_number(ctx, number)
+                if target is not None:
+                    # Idempotent: an edge that already exists is refreshed, not doubled.
+                    before = ctx.stats.edges
+                    _link(ctx, row["id"], target, edge_type, extractor, None, None)
+                    queued += ctx.stats.edges - before
+                    continue
+                _enqueue_reference(
+                    ctx,
+                    src_node_id=row["id"],
+                    number=number,
+                    edge_type=edge_type,
+                    extractor=extractor,
+                    source_ref=None,
+                    observed_at=None,
+                )
+        log.info("reconciled %s bodies", label)
+
+    return queued
 
 
 def _lookup_by_number(ctx: Context, number: int) -> int | None:
     """Resolve #N to an already-ingested issue or PR.
 
-    Returns None when the target is outside the backfill window. That is a real and
-    expected consequence of bounding the window: an in-window PR can close a
-    three-year-old issue. We do not fetch it — that would make the window unbounded
-    by the back door — so the edge is skipped and counted in Stats.skipped, where it
-    shows up honestly rather than silently.
+    Returns None for two different situations, which the caller must not conflate:
+    the target is outside the backfill window (permanent, correct), or it is inside the
+    window but has not been written yet (transient — issues are walked
+    updated-ascending, so a PR can be processed before the issue it closes).
+
+    Callers therefore queue rather than drop; drain_pending_references sorts out which
+    was which by retrying once the window has landed. We never fetch the missing target,
+    as that would make the window unbounded by the back door.
     """
     row = ctx.conn.execute(
         """

--- a/src/decision_graph/run.py
+++ b/src/decision_graph/run.py
@@ -27,7 +27,13 @@ from .github import GitHubClient, RateLimitExhausted, parse_ts
 log = logging.getLogger("decision_graph")
 
 
-def ingest(settings: Settings, *, resources: list[str], max_pages: int | None) -> int:
+def ingest(
+    settings: Settings,
+    *,
+    resources: list[str],
+    max_pages: int | None,
+    reconcile: bool = False,
+) -> int:
     conn = db.connect(settings.database_url)
     client = GitHubClient(
         token=settings.github_token,
@@ -45,9 +51,22 @@ def ingest(settings: Settings, *, resources: list[str], max_pages: int | None) -
     status, error = "succeeded", None
 
     try:
+        if reconcile:
+            log.info("--- reconcile stored bodies ---")
+            extractors.reconcile_stored_bodies(ctx)
+            conn.commit()
+
         for resource in resources:
             log.info("--- %s ---", resource)
             _ingest_resource(ctx, resource, run_id, max_pages)
+
+        # Drain queued forward references before inference (issue #3). Order matters:
+        # these are explicit edges, and §5.3 only lets inference bridge gaps that
+        # explicit extraction could not fill. Draining afterwards would let inference
+        # propose an edge for a pair the queue was about to link explicitly.
+        log.info("--- pending references ---")
+        extractors.drain_pending_references(ctx)
+        conn.commit()
 
         # Gated inference runs last: it may only bridge gaps that explicit extraction
         # left behind, so it must not run before extraction has had its say (§5.1).
@@ -207,6 +226,13 @@ def main(argv: list[str] | None = None) -> int:
         help="stop each resource after N pages. For smoke tests — leaves the cursor "
         "mid-window on purpose so the next run demonstrates resume.",
     )
+    parser.add_argument(
+        "--reconcile",
+        action="store_true",
+        help="re-parse already-stored bodies and queue/link any reference lacking an "
+        "edge, before polling. Costs no API calls. Recovers references dropped before "
+        "the pending queue existed (issue #3).",
+    )
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args(argv)
 
@@ -227,7 +253,12 @@ def main(argv: list[str] | None = None) -> int:
     log.info("target repo    : %s", settings.target_repo)
     log.info("backfill window: %s months", settings.backfill_months)
 
-    return ingest(settings, resources=args.resources, max_pages=args.max_pages)
+    return ingest(
+        settings,
+        resources=args.resources,
+        max_pages=args.max_pages,
+        reconcile=args.reconcile,
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes #3.

## The fix

References whose target isn't in the graph yet are now **queued** in `pending_reference` instead of counted and discarded, then drained at the end of every run. The queue stores a reference *number*, not a target id — the target doesn't exist yet, which is the entire problem.

The bounded window survives: resolution retries only the **lookup**, never fetching the missing target. A reference to an artifact genuinely outside the 12-month window never resolves and stays visible as a row with a climbing `attempts` count. `v_pending_reference_status` separates that (correct, permanent) from "the drain hasn't run yet" (transient) — the same distinction that made #3 diagnosable.

`--reconcile` re-parses already-stored bodies to recover references dropped before the queue existed. Costs **1 API call**, since the bodies are already in the graph. It doubles as the safety net if a parser rule is ever widened later.

Ordering detail: the drain runs **before** inference, not after. These are explicit edges, and §5.3 only permits inference to bridge gaps explicit extraction could not fill — draining afterwards would let inference propose an edge for a pair the queue was about to link explicitly.

## Result on the flask window

| metric | before | after |
|---|---|---|
| `closes` edges | 21 | **34** |
| `references` edges | 9 | **17** |
| PRs with closing keyword but no edge | 11 | **2** |
| …of those, target actually in graph (the bug) | 9 | **0** |
| threads passing the rubric | 17 | **20** |

Both remaining unresolved PRs reference issues genuinely outside the window. All 19 open queue rows classify as `target_outside_window`, `resolvable_now = 0` — the drain is complete and correct.

## I predicted ~26 and got 20. Here's why

My estimate assumed each recovered `closes` edge would yield one new qualifying thread. It doesn't, because **`closes` unions threads** — and several issues are closed by multiple sources:

| issue | closed by |
|---|---|
| 5912 | 5 sources (PRs 5913, 5914, 5944 + 2 commits) |
| 5825 | 4 sources |
| 5816 | 3 sources |
| 5718 | 3 sources |

Issue 5912's five closing sources collapse **five** previously separate threads into **one** qualifying thread, not five. Total threads fell 170 → 161 (−9, matching the 9 recovered edges) while qualifying threads rose 17 → 20.

That's the union working as designed — it's correctly recognising that a PR, its follow-up PR, and the commits all belong to one decision cluster. A higher thread count would have meant worse clustering, not better. So the smaller-than-predicted number is a better result than the number I predicted, and my estimate was wrong about the mechanism rather than the fix being weak.

Incidentally this also confirms commit-message extraction works: several closing sources are raw commit SHAs, not PRs.

## Tests

- 4 new queue checks (`db/tests/0005_pending_reference_checks.sql`) — partial-unique behaviour, resolution consistency CHECK, view classification
- 13 rubric checks still pass, no regression
- 11 unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pCAUDALD1g8DBsf8j8PuK