### PR TITLE
Explicit-status Decisions from release notes

### DIFF
--- a/src/decision_graph/run.py
+++ b/src/decision_graph/run.py
@@ -73,11 +73,16 @@ def ingest(
             log.info("--- decision synthesis ---")
             outcome = synthesis.synthesize(conn, repo_node_id)
             conn.commit()
+            # Runs after promotion so a Decision created this run can be upgraded in the
+            # same pass rather than waiting for the next one.
+            upgraded = synthesis.upgrade_explicit(conn, repo_node_id)
+            conn.commit()
             log.info(
-                "decisions: %s created, %s refreshed, %s refused",
+                "decisions: %s created, %s refreshed, %s refused, %s upgraded to explicit",
                 outcome.created,
                 outcome.refreshed,
                 outcome.refused,
+                upgraded,
             )
             for refusal in outcome.refusals:
                 log.warning("  refused %s", refusal)

--- a/src/decision_graph/synthesis.py
+++ b/src/decision_graph/synthesis.py
@@ -107,6 +107,77 @@ def synthesize(conn: psycopg.Connection, repo_node_id: int) -> SynthesisResult:
     return result
 
 
+# A release note that itemises the issue a Decision was motivated by IS the formal
+# artifact §5.1 requires for `explicit` status -- "release note" is named there
+# alongside ADR and RFC.
+#
+# This UPGRADES an existing reconstructed Decision rather than creating a second one.
+# The decision is the same decision; what changed is that a formal record of it has been
+# found. Creating a parallel explicit Decision would assert that two decisions occurred
+# where the evidence shows one.
+#
+# Note this only reaches Decisions whose motivating artifact was itemised in a release
+# body. flask's release notes are mostly boilerplate pointing at CHANGES.rst, so
+# coverage is thin -- see the §9 note in the README.
+EXPLICIT_UPGRADE_QUERY = """
+SELECT DISTINCT ON (d.node_id)
+       d.node_id   AS decision_node_id,
+       rel.id      AS release_node_id,
+       rel.title   AS release_title,
+       art.external_id AS via_artifact
+FROM edge e
+JOIN node art ON art.id = e.src_node_id
+JOIN node rel ON rel.id = e.dst_node_id
+JOIN node dn  ON dn.thread_key = art.thread_key AND dn.node_type = 'decision'
+JOIN decision d ON d.node_id = dn.id
+WHERE e.edge_type = 'deployed_by'
+  AND e.tag       = 'explicit'
+  AND e.valid_to IS NULL
+  AND rel.node_type = 'release'
+  AND art.thread_key IS NOT NULL
+  AND d.status = 'reconstructed'
+ORDER BY d.node_id, rel.id
+"""
+
+
+def upgrade_explicit(conn: psycopg.Connection, repo_node_id: int) -> int:
+    """Promote reconstructed Decisions to `explicit` where a release note records them.
+
+    Returns the number upgraded. Idempotent: the query only selects Decisions still in
+    `reconstructed` status, so a second run finds nothing to do.
+    """
+    rows = conn.execute(EXPLICIT_UPGRADE_QUERY).fetchall()
+
+    for row in rows:
+        # status and source_artifact_node_id must move in ONE statement --
+        # decision_explicit_needs_artifact (migration 0001) rejects an explicit
+        # Decision without an artifact, so setting them separately would fail.
+        conn.execute(
+            """
+            UPDATE decision
+            SET status = 'explicit', source_artifact_node_id = %s
+            WHERE node_id = %s
+            """,
+            (row["release_node_id"], row["decision_node_id"]),
+        )
+        # Keep the artifact reachable by traversal, not only by the FK column.
+        db.upsert_explicit_edge(
+            conn,
+            src=row["decision_node_id"],
+            dst=row["release_node_id"],
+            edge_type="deployed_by",
+            extractor="synthesis_release_note",
+            source_ref=f"release:{row['release_title']} via #{row['via_artifact']}",
+        )
+        log.info(
+            "decision %s upgraded to explicit via release %s",
+            row["decision_node_id"],
+            row["release_title"],
+        )
+
+    return len(rows)
+
+
 def _promote(conn: psycopg.Connection, repo_node_id: int, row: dict) -> bool:
     """Create or refresh one Decision plus its two rubric edges. Returns True if new."""
     thread_key = row["thread_key"]


### PR DESCRIPTION
Answers the question raised on #6: flask's GitHub Releases **do** reference specific issues, so the explicit-status path gets real coverage for free — no `CHANGES.rst` ingestion, no new extractor.

## Finding

38 releases ingested. Most bodies are boilerplate linking to `CHANGES.rst`, but some itemise fixes. Release **3.1.2** names issues 5776, 5786 and 5774, all already in the graph.

All three map to issues that already carry reconstructed Decisions — so this is an **upgrade** path, not a duplicate-creation path. The decision is the same decision; what changed is that a formal record of it was found. Creating a parallel explicit Decision would assert that two decisions occurred where the evidence shows one.

## Result

| status | count |
|---|---|
| explicit | **3** |
| reconstructed | 17 |

`v_decision_rubric_audit` still reports zero reconstructed Decisions failing the rubric. Re-running upgrades 0 — the query selects only `status='reconstructed'`, which makes it idempotent.

## Precision check

The same release bodies contain URL fragments like `changes/#version-3-0-3` and `milestone/35?closed=1`. A naive `#[0-9]+` match treats those as issue references and produces false `deployed_by` edges. The parser's `(?<![\w/])` lookbehind rejects them, so all 3 references are genuine — I verified each against its target issue title rather than trusting the count.

This matters more than recall here: a false `deployed_by` edge could upgrade the wrong Decision to explicit status, which is exactly the "assert without evidence" failure the PRD's top risk row guards against.

## Schema detail

`status` and `source_artifact_node_id` move in a single `UPDATE`, because `decision_explicit_needs_artifact` (migration 0001) rejects an explicit Decision with no artifact — setting them in separate statements cannot succeed. Another case of the schema constraint dictating correct call shape rather than merely documenting it.

## §9 consequence

The evaluation set can now exercise the explicit path against flask. That closes the fourth gap noted on #6, leaving CODEOWNERS (#1), wiki (#1) and workflows (#4) outstanding — all still properties of the target repo or deferred scope, not the system.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pCAUDALD1g8DBsf8j8PuK