### PR TITLE
Phase 2b: Candidate Retrieval and the traversal engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,48 @@ cleanly at a configurable floor and the next run resumes.
 between them; asserting that a *decision* occurred is gated by the rubric and belongs to
 a later phase.
 
+## Reasoning (Phase 2)
+
+**Engine 1.5 — Candidate Retrieval.** Exact → identifier → prefix → trigram, in that
+order, so an exact title always outranks a fuzzy match regardless of score. Deliberately
+not ranked or embedding-based. It exists as a named seam because traversal stops working
+past a toy graph without one, and adding a narrowing step after the traversal engine
+assumes it can start anywhere touches every caller.
+
+**Engine 2 — Graph Reasoning.** One `_walk` implementation, two modes. Only the start
+node and edge set differ — sharing is a requirement, not an optimisation, since two
+traversals would drift and §5.3's fallback rule would have to be correct twice.
+
+The fallback order is written as an algorithm, not left as a principle for callers to
+honour:
+
+1. Walk `explicit` edges only. Thanks to the tag/tier invariant, `tag='explicit'` is
+   exactly the "explicit and corroborated" set §5.3 names.
+2. Only if that leaves the start disconnected from a plausible answer does the walk
+   re-run with `inferred` edges admitted.
+3. If an explicit path exists, inferred edges are excluded **entirely** — never fetched,
+   not filtered out afterwards.
+
+Clause 3 fails invisibly if implemented as a single pass that merely admits inferred
+edges: the answers look fine and quietly blend tiers. The two-pass structure makes the
+blend impossible, because the second pass runs only when the first returned nothing.
+
+**A path's tier is its weakest link.** One inferred hop makes the whole answer inferred,
+however many explicit edges surround it.
+
+Two consequences worth knowing:
+
+- Because no inferred edge may touch a Decision (§5.1), the Why fallback can never fire
+  on its *first* hop from a Decision node. Any inferred bridge has to be further out.
+- Point-in-time queries work via `--as-of`, using the `valid_from` / `valid_to` window
+  that migration 0001 insisted on from v1.
+
+```bash
+dg-query "change default redirect code to 303" --mode why
+dg-query "#5898" --mode impact --depth 2
+dg-query "send_file type annotations" --mode why --as-of 2026-03-01T00:00:00Z
+```
+
 ## Known limitations on `pallets/flask`
 
 Accepted deliberately rather than fixed by switching repos:
@@ -129,6 +171,11 @@ cannot complete a backfill.
 ## Tests
 
 ```bash
-psql "$DATABASE_URL" -f db/tests/0002_rubric_checks.sql   # 13 checks, rolls back
-python -m unittest discover -s tests                       # 11 checks
+psql "$DATABASE_URL" -f db/tests/0002_rubric_checks.sql             # 13 checks
+psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 18 checks
 ```
+
+All SQL suites run in a transaction and roll back. The Python suite runs 11 unit tests
+standalone; setting `DATABASE_URL` adds the 7 traversal-fallback integration tests,
+which seed their own fixture because the real graph holds no inferred edges.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ dependencies = [
 
 [project.scripts]
 dg-ingest = "decision_graph.run:main"
+dg-query = "decision_graph.query:main"
 
 [build-system]
 requires = ["setuptools>=68"]

--- a/src/decision_graph/query.py
+++ b/src/decision_graph/query.py
@@ -1,0 +1,111 @@
+"""CLI for the Why Engine and Impact Analysis (§6 feature surface).
+
+A thin view over Retrieval + Reasoning. It holds no logic of its own — per §6, no
+feature may introduce engine-level behaviour, and formatting a path is presentation.
+The trace it prints is the path data Engine 2 already computed, which is what
+Explainability Mode (Phase 4) will render properly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from datetime import datetime
+
+from . import db, reasoning, retrieval
+from .reasoning import Answer, Mode, Path
+
+TIER_MARK = {"explicit": "==", "corroborated": "++", "inferred": "~~"}
+
+
+def _label(path: Path, node_id: int) -> str:
+    node_type = path.types.get(node_id) or "?"
+    title = (path.titles.get(node_id) or "").strip()
+    if len(title) > 58:
+        title = title[:55] + "..."
+    return f"{node_type}:{node_id}" + (f' "{title}"' if title else "")
+
+
+def render(answer: Answer, out=sys.stdout) -> None:
+    header = f"{answer.mode.value.upper()}  start=node:{answer.start_node_id}"
+    print(header, file=out)
+    print("-" * len(header), file=out)
+
+    if not answer.found:
+        print(f"  no answer — {answer.explanation}", file=out)
+        return
+
+    if answer.used_inferred_fallback:
+        # Never let this pass silently: an inferred answer is a different kind of claim.
+        print("  !! INFERRED FALLBACK — no explicit path existed", file=out)
+    print(f"  {answer.explanation}\n", file=out)
+
+    for i, path in enumerate(sorted(answer.paths, key=lambda p: (p.depth, p.target_id)), 1):
+        print(f"  [{i}] tier={path.tier}  depth={path.depth}", file=out)
+        print(f"      {_label(path, path.node_ids[0])}", file=out)
+        for step, node_id in zip(path.steps, path.node_ids[1:]):
+            mark = TIER_MARK.get(step.evidence_tier, "??")
+            arrow = "->" if step.to_node_id == node_id else "<-"
+            print(
+                f"        {mark}{arrow} {step.edge_type} [{step.evidence_tier}]"
+                f" ({step.extractor})",
+                file=out,
+            )
+            print(f"      {_label(path, node_id)}", file=out)
+        print(file=out)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="dg-query", description="Why Engine / Impact Analysis over the graph"
+    )
+    parser.add_argument("query", help="entity title, #number, or sha to start from")
+    parser.add_argument(
+        "--mode", choices=[m.value for m in Mode], default=Mode.WHY.value
+    )
+    parser.add_argument("--depth", type=int, default=reasoning.DEFAULT_MAX_DEPTH)
+    parser.add_argument(
+        "--as-of",
+        help="ISO timestamp for a point-in-time query; uses edge valid_from/valid_to",
+    )
+    parser.add_argument("--limit", type=int, default=3, help="candidate start nodes to try")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(levelname)-7s %(message)s",
+    )
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        print("error: DATABASE_URL is not set", file=sys.stderr)
+        return 2
+
+    as_of = datetime.fromisoformat(args.as_of) if args.as_of else None
+    conn = db.connect(dsn)
+
+    candidates = retrieval.find_candidates(conn, args.query, limit=args.limit)
+    if not candidates:
+        print(f"no candidate start node matched {args.query!r}", file=sys.stderr)
+        return 1
+
+    print(f"candidates for {args.query!r}:")
+    for c in candidates:
+        print(f"  node:{c.node_id:<5} {c.node_type:<13} {c.match:<11} {(c.title or '')[:56]}")
+    print()
+
+    for c in candidates:
+        answer = reasoning.reason(
+            conn, c.node_id, Mode(args.mode), max_depth=args.depth, as_of=as_of
+        )
+        render(answer)
+
+    conn.close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/decision_graph/reasoning.py
+++ b/src/decision_graph/reasoning.py
@@ -1,0 +1,327 @@
+"""Engine 2 — Graph Reasoning (PRD v3.1 §5.3).
+
+ONE traversal implementation, exposed through two directional modes. Only the starting
+node and the edge set differ; `_walk` is shared. That sharing is a requirement rather
+than an optimisation — two separate traversals would drift, and §5.3's fallback rule
+would then have to be correct twice.
+
+The fallback order is the delicate part, so it is written as an explicit algorithm here
+rather than left as a principle for callers to honour:
+
+  1. Walk using `explicit` edges only. Because of the tag/tier invariant in migration
+     0001, `tag = 'explicit'` is exactly the "explicit and corroborated" set §5.3 names
+     — `corroborated` is an upgraded explicit edge, never an upgraded inferred one.
+  2. Only if that leaves the start node disconnected from any plausible answer does the
+     walk re-run with `inferred` edges admitted.
+  3. If an explicit path exists, inferred edges are excluded from the answer ENTIRELY.
+
+Clause 3 is the one that is easy to get wrong invisibly. A single-pass traversal that
+merely admits inferred edges produces answers that look fine and quietly blend tiers.
+The two-pass structure below makes the blend impossible: the second pass runs only when
+the first returned nothing, so no answer can ever contain both.
+
+A path's tier is the WEAKEST tier along it. A chain is only as strong as its weakest
+link, so a route that traverses one inferred edge is an inferred answer no matter how
+many explicit edges surround it.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Sequence
+
+import psycopg
+
+log = logging.getLogger(__name__)
+
+DEFAULT_MAX_DEPTH = 3  # §5.1: v1 traversals are shallow (2-3 hops)
+
+TIER_ORDER = {"explicit": 0, "corroborated": 1, "inferred": 2}
+
+
+class Mode(Enum):
+    """Which question is being asked. Determines the edge set, not the algorithm."""
+
+    WHY = "why"
+    IMPACT = "impact"
+
+
+# §5.3 backward: motivation -> discussion -> decision -> implementation -> follow-ups.
+# implemented_by is included because the PRD's own description of the causal chain ends
+# at implementation, even though the prose list omits it.
+WHY_EDGES: tuple[str, ...] = (
+    "motivated_by",
+    "implemented_by",
+    "discussed_in",
+    "references",
+    "supersedes",
+    "superseded_by",
+)
+
+# §5.3 forward: what is affected. Traversed in both orientations so one edge set answers
+# "what does this depend on" and "what would reverting this affect".
+IMPACT_EDGES: tuple[str, ...] = (
+    "depends_on",
+    "implements",
+    "closes",
+    "deployed_by",
+    "implemented_by",
+)
+
+MODE_EDGES = {Mode.WHY: WHY_EDGES, Mode.IMPACT: IMPACT_EDGES}
+
+
+@dataclass(frozen=True)
+class Step:
+    edge_id: int
+    edge_type: str
+    tag: str
+    evidence_tier: str
+    from_node_id: int
+    to_node_id: int
+    extractor: str
+    source_ref: str | None
+
+
+@dataclass
+class Path:
+    """One route from the start node to a reached node, with its evidence trail."""
+
+    node_ids: list[int]
+    steps: list[Step]
+    titles: dict[int, str] = field(default_factory=dict)
+    types: dict[int, str] = field(default_factory=dict)
+
+    @property
+    def target_id(self) -> int:
+        return self.node_ids[-1]
+
+    @property
+    def depth(self) -> int:
+        return len(self.steps)
+
+    @property
+    def tier(self) -> str:
+        """Weakest tier along the path. A chain is as strong as its weakest link."""
+        if not self.steps:
+            return "explicit"
+        return max((s.evidence_tier for s in self.steps), key=lambda t: TIER_ORDER[t])
+
+
+@dataclass
+class Answer:
+    mode: Mode
+    start_node_id: int
+    paths: list[Path]
+    used_inferred_fallback: bool
+    explanation: str
+
+    @property
+    def found(self) -> bool:
+        return bool(self.paths)
+
+
+# Recursive walk. Both orientations are followed in one CTE so a single implementation
+# serves "what led to this" and "what does this affect"; the mode's edge set is what
+# gives the walk its direction of meaning.
+_WALK_SQL = """
+WITH RECURSIVE walk AS (
+    SELECT %(start)s::bigint AS node_id,
+           0                 AS depth,
+           ARRAY[%(start)s::bigint] AS path_nodes,
+           ARRAY[]::bigint[] AS path_edges
+
+    UNION ALL
+
+    SELECT nxt.next_id,
+           w.depth + 1,
+           w.path_nodes || nxt.next_id,
+           w.path_edges || nxt.edge_id
+    FROM walk w
+    CROSS JOIN LATERAL (
+        SELECT e.id AS edge_id, e.dst_node_id AS next_id
+        FROM edge e
+        WHERE e.src_node_id = w.node_id
+          AND e.edge_type = ANY(%(types)s::edge_type[])
+          AND e.valid_from <= %(as_of)s
+          AND (e.valid_to IS NULL OR e.valid_to > %(as_of)s)
+          {tag_clause}
+        UNION ALL
+        SELECT e.id, e.src_node_id
+        FROM edge e
+        WHERE e.dst_node_id = w.node_id
+          AND e.edge_type = ANY(%(types)s::edge_type[])
+          AND e.valid_from <= %(as_of)s
+          AND (e.valid_to IS NULL OR e.valid_to > %(as_of)s)
+          {tag_clause}
+    ) nxt
+    WHERE w.depth < %(max_depth)s
+      AND NOT nxt.next_id = ANY(w.path_nodes)   -- cycle guard
+)
+SELECT depth, path_nodes, path_edges
+FROM walk
+WHERE depth > 0
+ORDER BY depth, path_nodes
+"""
+
+
+def _walk(
+    conn: psycopg.Connection,
+    start: int,
+    edge_types: Sequence[str],
+    *,
+    allow_inferred: bool,
+    max_depth: int,
+    as_of: datetime | None,
+) -> list[Path]:
+    """One pass of the traversal. `allow_inferred` is the ONLY difference between passes."""
+    # Explicit-only is expressed as tag = 'explicit'. Per the 0001 invariant that is
+    # exactly {explicit, corroborated} by tier, which is what §5.3 step 1 asks for.
+    tag_clause = "" if allow_inferred else "AND e.tag = 'explicit'"
+    sql = _WALK_SQL.format(tag_clause=tag_clause)
+
+    rows = conn.execute(
+        sql,
+        {
+            "start": start,
+            "types": list(edge_types),
+            "max_depth": max_depth,
+            "as_of": as_of or datetime.now().astimezone(),
+        },
+    ).fetchall()
+
+    if not rows:
+        return []
+
+    edge_ids = {eid for r in rows for eid in r["path_edges"]}
+    node_ids = {nid for r in rows for nid in r["path_nodes"]}
+
+    edges = {
+        e["id"]: Step(
+            edge_id=e["id"],
+            edge_type=e["edge_type"],
+            tag=e["tag"],
+            evidence_tier=e["evidence_tier"],
+            from_node_id=e["src_node_id"],
+            to_node_id=e["dst_node_id"],
+            extractor=e["extractor"],
+            source_ref=e["source_ref"],
+        )
+        for e in conn.execute(
+            "SELECT id, edge_type, tag, evidence_tier, src_node_id, dst_node_id, "
+            "extractor, source_ref FROM edge WHERE id = ANY(%s)",
+            (list(edge_ids),),
+        ).fetchall()
+    }
+    nodes = {
+        n["id"]: (n["node_type"], n["title"])
+        for n in conn.execute(
+            "SELECT id, node_type, title FROM node WHERE id = ANY(%s)", (list(node_ids),)
+        ).fetchall()
+    }
+
+    return [
+        Path(
+            node_ids=list(r["path_nodes"]),
+            steps=[edges[eid] for eid in r["path_edges"]],
+            titles={nid: (nodes.get(nid) or (None, None))[1] for nid in r["path_nodes"]},
+            types={nid: (nodes.get(nid) or (None, None))[0] for nid in r["path_nodes"]},
+        )
+        for r in rows
+    ]
+
+
+def _is_answer(mode: Mode, start_type: str | None, path: Path) -> bool:
+    """Does this path reach a plausible answer, as §5.3 step 2 means it?
+
+    Defined per mode rather than "reached anything", because the fallback decision hangs
+    on it: too loose a definition means the inferred fallback never fires, and too tight
+    means it fires when an explicit answer was available.
+    """
+    target_type = path.types.get(path.target_id)
+
+    if mode is Mode.WHY:
+        if start_type == "decision":
+            # Asking why a decision was taken: motivation is the answer.
+            return target_type in ("issue", "pull_request", "wiki_page")
+        # Asking why an artifact exists: the decision that produced it is the answer.
+        return target_type == "decision"
+
+    # Impact: anything reachable is affected.
+    return True
+
+
+def reason(
+    conn: psycopg.Connection,
+    start_node_id: int,
+    mode: Mode,
+    *,
+    max_depth: int = DEFAULT_MAX_DEPTH,
+    as_of: datetime | None = None,
+) -> Answer:
+    """Answer a Why or Impact query, honouring the §5.3 explicit-first fallback order."""
+    row = conn.execute(
+        "SELECT node_type FROM node WHERE id = %s", (start_node_id,)
+    ).fetchone()
+    start_type = row["node_type"] if row else None
+
+    edge_types = MODE_EDGES[mode]
+
+    # Pass 1 — explicit (and corroborated) only.
+    explicit_paths = _walk(
+        conn,
+        start_node_id,
+        edge_types,
+        allow_inferred=False,
+        max_depth=max_depth,
+        as_of=as_of,
+    )
+    answers = [p for p in explicit_paths if _is_answer(mode, start_type, p)]
+
+    if answers:
+        # §5.3 step 3: an explicit route exists, so inferred edges are excluded from
+        # this answer entirely. Not filtered out afterwards -- never fetched.
+        return Answer(
+            mode=mode,
+            start_node_id=start_node_id,
+            paths=answers,
+            used_inferred_fallback=False,
+            explanation=(
+                f"{len(answers)} explicit path(s) found; inferred edges not consulted"
+            ),
+        )
+
+    # Pass 2 — the gap-bridging fallback. Reached only because pass 1 found nothing.
+    log.debug("no explicit path from %s; expanding to inferred edges", start_node_id)
+    fallback_paths = _walk(
+        conn,
+        start_node_id,
+        edge_types,
+        allow_inferred=True,
+        max_depth=max_depth,
+        as_of=as_of,
+    )
+    fallback_answers = [p for p in fallback_paths if _is_answer(mode, start_type, p)]
+
+    if not fallback_answers:
+        return Answer(
+            mode=mode,
+            start_node_id=start_node_id,
+            paths=[],
+            used_inferred_fallback=True,
+            explanation="no path found, explicit or inferred",
+        )
+
+    return Answer(
+        mode=mode,
+        start_node_id=start_node_id,
+        paths=fallback_answers,
+        used_inferred_fallback=True,
+        explanation=(
+            f"no explicit path existed; {len(fallback_answers)} path(s) found only by "
+            "admitting inferred edges"
+        ),
+    )

--- a/src/decision_graph/retrieval.py
+++ b/src/decision_graph/retrieval.py
@@ -1,0 +1,110 @@
+"""Engine 1.5 — Candidate Retrieval (PRD v3.1 §5.2).
+
+A narrowing step between the graph and the reasoning engine: given a query string,
+select a plausible set of start nodes before traversal begins, rather than traversing
+the whole graph.
+
+v1 is intentionally trivial — exact match, then prefix, then trigram similarity. It is
+not ranked retrieval and not embedding-based. It exists as a named seam because
+traversal stops working at any scale past a toy graph without one, and retrofitting a
+narrowing step after the traversal engine assumes it can start anywhere is the kind of
+change that touches every caller.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+import psycopg
+
+log = logging.getLogger(__name__)
+
+DEFAULT_LIMIT = 10
+
+# Trigram similarity floor for the fuzzy tier. Below this the matches stop resembling
+# the query at all; an empty candidate set is a better answer than a wrong start node,
+# for the same reason §5.1 prefers no inferred edge to a weak one.
+FUZZY_FLOOR = 0.25
+
+
+@dataclass(frozen=True)
+class Candidate:
+    node_id: int
+    node_type: str
+    external_id: str
+    title: str | None
+    match: str  # which tier matched: exact | identifier | prefix | fuzzy
+    score: float
+
+
+def find_candidates(
+    conn: psycopg.Connection,
+    query: str,
+    *,
+    node_types: tuple[str, ...] | None = None,
+    limit: int = DEFAULT_LIMIT,
+) -> list[Candidate]:
+    """Resolve a query string to plausible start nodes, best match first.
+
+    Tiers are tried in order and the results concatenated, so an exact title match
+    always outranks a fuzzy one regardless of trigram score. `#1234` and a bare number
+    resolve as identifiers, which is how an impact query normally arrives.
+    """
+    cleaned = query.strip()
+    if not cleaned:
+        return []
+
+    identifier = cleaned.lstrip("#")
+    type_filter = "AND node_type = ANY(%(types)s)" if node_types else ""
+    params = {
+        "q": cleaned,
+        "identifier": identifier,
+        "prefix": f"{cleaned}%",
+        "floor": FUZZY_FLOOR,
+        "limit": limit,
+        "types": list(node_types) if node_types else None,
+    }
+
+    sql = f"""
+        WITH matches AS (
+            SELECT id, node_type, external_id, title, 'exact' AS match, 1.0 AS score
+            FROM node
+            WHERE lower(title) = lower(%(q)s) {type_filter}
+
+            UNION ALL
+            SELECT id, node_type, external_id, title, 'identifier', 0.95
+            FROM node
+            WHERE external_id = %(identifier)s {type_filter}
+
+            UNION ALL
+            SELECT id, node_type, external_id, title, 'prefix', 0.75
+            FROM node
+            WHERE title ILIKE %(prefix)s {type_filter}
+
+            UNION ALL
+            SELECT id, node_type, external_id, title, 'fuzzy',
+                   similarity(title, %(q)s)
+            FROM node
+            WHERE title IS NOT NULL
+              AND similarity(title, %(q)s) >= %(floor)s {type_filter}
+        )
+        SELECT DISTINCT ON (id) id, node_type, external_id, title, match, score
+        FROM matches
+        ORDER BY id, score DESC
+    """
+
+    rows = conn.execute(sql, params).fetchall()
+    rows.sort(key=lambda r: (-r["score"], r["id"]))
+
+    return [
+        Candidate(
+            node_id=r["id"],
+            node_type=r["node_type"],
+            external_id=r["external_id"],
+            title=r["title"],
+            match=r["match"],
+            score=float(r["score"]),
+        )
+        for r in rows[:limit]
+    ]

--- a/tests/test_traversal_fallback.py
+++ b/tests/test_traversal_fallback.py
@@ -1,0 +1,185 @@
+"""Integration tests for the §5.3 explicit-first / inferred-fallback traversal order.
+
+The real graph holds zero inferred edges, so none of this behaviour is exercised by
+pallets/flask. These tests seed a fixture instead. Without them the fallback branch
+would ship unverified — and its failure mode is silent: an implementation that simply
+admits inferred edges in one pass returns answers that look entirely reasonable while
+quietly blending tiers.
+
+Requires a live database. Skipped when DATABASE_URL is unset, so the unit suite still
+runs standalone:
+
+    DATABASE_URL=postgresql://... python -m unittest discover -s tests
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+import psycopg
+
+from decision_graph import reasoning
+from decision_graph.reasoning import Mode
+
+DSN = os.environ.get("DATABASE_URL")
+
+
+@unittest.skipUnless(DSN, "DATABASE_URL not set")
+class TraversalFallbackTest(unittest.TestCase):
+    """Each test runs in its own transaction and rolls back — no fixture leaks."""
+
+    def setUp(self) -> None:
+        from decision_graph import db
+
+        self.conn = db.connect(DSN)
+        self.conn.execute("SET CONSTRAINTS ALL DEFERRED")
+        self._seq = 0
+
+    def tearDown(self) -> None:
+        self.conn.rollback()
+        self.conn.close()
+
+    # -- fixture helpers ---------------------------------------------------
+
+    def node(self, node_type: str, title: str = "") -> int:
+        self._seq += 1
+        row = self.conn.execute(
+            "INSERT INTO node (node_type, external_id, title) VALUES (%s, %s, %s) "
+            "RETURNING id",
+            (node_type, f"fixture-{id(self)}-{self._seq}", title),
+        ).fetchone()
+        return row["id"]
+
+    def edge(
+        self, src: int, dst: int, edge_type: str, *, inferred: bool = False, relevance=None
+    ) -> int:
+        tier = "inferred" if inferred else "explicit"
+        row = self.conn.execute(
+            """
+            INSERT INTO edge (src_node_id, dst_node_id, edge_type, tag, evidence_tier,
+                              extractor, relevance)
+            VALUES (%s, %s, %s, %s, %s, 'test_fixture', %s) RETURNING id
+            """,
+            (src, dst, edge_type, tier, tier, relevance if inferred else None),
+        ).fetchone()
+        return row["id"]
+
+    # -- §5.3 step 2: the fallback fires when nothing explicit connects -----
+
+    def test_impact_falls_back_to_inferred_when_no_explicit_path(self) -> None:
+        a = self.node("commit", "orphan commit")
+        b = self.node("issue", "unreachable issue")
+        self.edge(a, b, "depends_on", inferred=True, relevance=0.9)
+
+        answer = reasoning.reason(self.conn, a, Mode.IMPACT, max_depth=2)
+
+        self.assertTrue(answer.found, "fallback should have found the inferred route")
+        self.assertTrue(answer.used_inferred_fallback)
+        self.assertEqual(answer.paths[0].tier, "inferred")
+        self.assertIn(b, answer.paths[0].node_ids)
+
+    # -- §5.3 step 3: an explicit route excludes inferred edges ENTIRELY ----
+
+    def test_inferred_edges_never_blend_into_a_connected_explicit_path(self) -> None:
+        start = self.node("pull_request", "start pr")
+        explicit_target = self.node("issue", "explicitly closed issue")
+        inferred_target = self.node("issue", "merely similar issue")
+
+        self.edge(start, explicit_target, "closes")
+        self.edge(start, inferred_target, "depends_on", inferred=True, relevance=0.99)
+
+        answer = reasoning.reason(self.conn, start, Mode.IMPACT, max_depth=2)
+
+        self.assertTrue(answer.found)
+        self.assertFalse(
+            answer.used_inferred_fallback, "explicit path existed; fallback must not run"
+        )
+
+        reached = {n for p in answer.paths for n in p.node_ids}
+        self.assertIn(explicit_target, reached)
+        self.assertNotIn(
+            inferred_target,
+            reached,
+            "an inferred edge leaked into an already-connected explicit answer",
+        )
+        for path in answer.paths:
+            self.assertEqual(path.tier, "explicit")
+            for step in path.steps:
+                self.assertEqual(step.tag, "explicit")
+
+    def test_why_falls_back_across_an_inferred_bridge_at_depth_two(self) -> None:
+        # decision --implemented_by--> pr   (explicit)
+        #   artifact ~~depends_on~~> pr     (inferred bridge)
+        # Asking WHY the artifact exists is answerable only by crossing the bridge.
+        decision_node = self.node("decision", "fixture decision")
+        artifact_src = self.node("release", "formal artifact")
+        self.conn.execute(
+            "INSERT INTO decision (node_id, status, source_artifact_node_id) "
+            "VALUES (%s, 'explicit', %s)",
+            (decision_node, artifact_src),
+        )
+        pr = self.node("pull_request", "implementing pr")
+        orphan = self.node("commit", "orphan artifact")
+
+        self.edge(decision_node, pr, "implemented_by")
+        self.edge(orphan, pr, "references", inferred=True, relevance=0.85)
+
+        answer = reasoning.reason(self.conn, orphan, Mode.WHY, max_depth=3)
+
+        self.assertTrue(answer.found)
+        self.assertTrue(answer.used_inferred_fallback)
+        self.assertIn(decision_node, answer.paths[0].node_ids)
+        # Weakest-link tiering: one inferred hop makes the whole answer inferred.
+        self.assertEqual(answer.paths[0].tier, "inferred")
+
+    def test_no_path_at_all_reports_honestly(self) -> None:
+        lonely = self.node("commit", "entirely disconnected")
+        answer = reasoning.reason(self.conn, lonely, Mode.IMPACT, max_depth=3)
+
+        self.assertFalse(answer.found)
+        self.assertIn("no path found", answer.explanation)
+
+    # -- the §5.1 gate still binds during traversal-relevant writes --------
+
+    def test_gate_refuses_inferred_edge_below_threshold(self) -> None:
+        a, b = self.node("commit"), self.node("issue")
+        with self.assertRaises(psycopg.errors.CheckViolation):
+            with self.conn.transaction():
+                self.edge(a, b, "depends_on", inferred=True, relevance=0.10)
+
+    def test_gate_refuses_inferred_edge_touching_a_decision(self) -> None:
+        """Consequence worth stating: because no inferred edge may touch a Decision,
+        the WHY fallback can never fire on its FIRST hop from a Decision node. The
+        bridge always has to be further out, as in the depth-two test above."""
+        artifact = self.node("release", "artifact")
+        decision_node = self.node("decision", "guarded decision")
+        self.conn.execute(
+            "INSERT INTO decision (node_id, status, source_artifact_node_id) "
+            "VALUES (%s, 'explicit', %s)",
+            (decision_node, artifact),
+        )
+        commit = self.node("commit")
+        with self.assertRaises(psycopg.errors.CheckViolation):
+            with self.conn.transaction():
+                self.edge(commit, decision_node, "references", inferred=True, relevance=0.99)
+
+    def test_per_node_cap_binds(self) -> None:
+        hub = self.node("commit", "hub")
+        landed = 0
+        for _ in range(6):
+            partner = self.node("issue")
+            try:
+                with self.conn.transaction():
+                    self.edge(hub, partner, "relates_to", inferred=True, relevance=0.9)
+                landed += 1
+            except psycopg.errors.CheckViolation:
+                break
+        cap = self.conn.execute(
+            "SELECT value FROM graph_config WHERE key = 'inferred_edge_max_per_node'"
+        ).fetchone()["value"]
+        self.assertEqual(landed, int(cap))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #9. Engine 1.5 (§5.2) and Engine 2 (§5.3).

## One traversal, two modes

`_walk` is shared; only the start node and edge set differ. That's a requirement rather than an optimisation — two separate traversals would drift, and §5.3's fallback rule would then have to be correct twice.

Working against the real flask graph:

```
WHY  start=node:920
  2 explicit path(s) found; inferred edges not consulted

  [1] tier=explicit  depth=1
      decision:920 "Looser type annotations for send_file() path_or_file ar..."
        ==-> motivated_by [explicit] (synthesis_closes_cluster)
      issue:51 "Looser type annotations for send_file() path_or_file ar..."

IMPACT start=node:920
  [3] tier=explicit  depth=2
      decision:920 -> implemented_by -> pull_request:41 -> implements -> commit:43
  [5] tier=explicit  depth=2
      decision:920 -> deployed_by -> release:961 "3.1.2" <- deployed_by <- issue:51
```

Every step carries its edge type, evidence tier, and the extractor that produced it — the path data Explainability Mode (Phase 4) will render.

## The fallback order, encoded as an algorithm

1. Walk `explicit` edges only. Thanks to the tag/tier invariant from migration 0001, `tag='explicit'` is *exactly* the "explicit and corroborated" set §5.3 names.
2. Re-run admitting `inferred` edges **only** if pass 1 left the start disconnected from a plausible answer.
3. If an explicit path exists, inferred edges are excluded **entirely** — never fetched, not filtered out afterwards.

Clause 3 is the one that fails invisibly. A single pass that merely admits inferred edges returns answers that look perfectly reasonable while quietly blending tiers. The two-pass structure makes blending impossible, because pass 2 runs only when pass 1 returned nothing.

**A path's tier is its weakest link.** One inferred hop makes the whole answer inferred, however many explicit edges surround it.

## Verified against a seeded fixture, because the real graph can't

The graph holds **zero inferred edges**, so shipping this on flask evidence alone would leave the entire fallback branch unverified. 7 integration tests seed their own fixture and roll back:

| test | proves |
|---|---|
| fallback fires when nothing explicit connects | §5.3 step 2 |
| inferred edges never blend into a connected explicit answer | **§5.3 step 3** |
| WHY fallback across a depth-two inferred bridge | fallback works in both modes |
| no path at all reports honestly | no silent empty answers |
| threshold / per-node cap / Decision exemption still bind | §5.1 gate holds during traversal-relevant writes |

## Consequence found while writing the tests

Because no inferred edge may touch a Decision (§5.1 exemption), **the WHY fallback can never fire on its first hop from a Decision node** — any inferred bridge must be further out in the path. I originally tried to write the depth-one version of that test and the database refused it, which is the gate working exactly as intended. Documented in the test and README rather than worked around.

## Also included

- Point-in-time queries via `--as-of`, using the `valid_from`/`valid_to` window migration 0001 insisted on from v1. That schema decision now pays off.
- `dg-query` CLI — a thin view holding no logic of its own, per §6.

18 Python tests pass (11 unit, 7 integration).

## Not in scope

Explainability Mode presentation (Phase 4) and Evidence Ranking tier upgrades (Phase 3). Engine 2 returns the path data both will need; presenting and upgrading it are separate phases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pCAUDALD1g8DBsf8j8PuK