### PR TITLE
Phase 3: the explicit -> corroborated evidence tier

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,10 @@
 
 Organizational Intelligence Engine — implementation of `PRD_v3.1_Organizational_Intelligence_Engine.md`.
 
-**Phase 1 only.** The knowledge graph schema and extraction-first GitHub ingestion.
-Retrieval, traversal, reasoning, and Decision synthesis (Phase 2+) are not built.
+**Phases 1–3 built.** Time-versioned graph schema, extraction-first GitHub ingestion,
+Decision synthesis, candidate retrieval, the Why/Impact traversal engine, and evidence
+tiering. Phase 4 (Explainability Mode presentation, the §9 evaluation set) is not built;
+Engine 2 already returns the path data it will present.
 
 - **Code repo:** this repository.
 - **Ingestion target:** `pallets/flask`.
@@ -11,10 +13,10 @@ Retrieval, traversal, reasoning, and Decision synthesis (Phase 2+) are not built
 ## Layout
 
 ```
-db/migrations/     schema (apply in numeric order)
-db/tests/          behavioural checks for the rubric + inferred-edge gate
-src/decision_graph/  ingestion
-tests/             unit tests for the parsers
+db/migrations/       schema, applied in numeric order
+db/tests/            behavioural checks — rubrics, gates, queue, tiering
+src/decision_graph/  ingestion, synthesis, retrieval, reasoning
+tests/               unit tests + traversal-fallback integration tests
 ```
 
 ## Schema
@@ -134,6 +136,35 @@ dg-query "#5898" --mode impact --depth 2
 dg-query "send_file type annotations" --mode why --as-of 2026-03-01T00:00:00Z
 ```
 
+## Evidence Ranking (Phase 3)
+
+An explicit edge upgrades to `corroborated` iff (1) its `edge_type` is evidence-carrying,
+(2) its endpoints share one thread cluster, and (3) that thread exhibits **≥3 of 4**
+categories:
+
+| category | edge + extractor | independent origin |
+|---|---|---|
+| DECLARED | `closes` via `body_closing_keyword`, dst an issue | the author's prose |
+| STRUCTURAL | `implements` via `pr_commit_list` | GitHub's PR↔commit structure |
+| ATTESTED | `reviewed` via `pr_review` | a reviewer's action |
+| PUBLISHED | `deployed_by` via `release_notes_reference` | a maintainer's release note |
+
+**Only observed edges count.** Every `synthesis_*` extractor is excluded, because
+`synthesis_closes_cluster` emits both `motivated_by` and `implemented_by` from a *single*
+underlying `closes` edge — counting them as two converging signals would be one signal
+wearing two hats. Note the deliberate asymmetry: synthesis edges are excluded from
+*counting* categories but remain *eligible* for upgrade, since a `motivated_by` edge is
+what a Why answer is made of and should carry the tier its thread earned.
+
+`apply_corroboration()` is idempotent **and reversible** — it withdraws the tier from
+threads whose evidence was later invalidated, not just grants it. It runs after every
+ingestion, reading `v_edge_corroboration_audit` so the rubric lives in exactly one place.
+
+A fifth category was drafted and rejected: "the same issue closed by ≥2 distinct source
+artifacts". All `closes` edges come from one extractor, so that condition always implies
+DECLARED and can never contribute an independent signal — nested, not independent. See
+issue #12 for the provenance-label work that would make such a category meaningful.
+
 ## Known limitations on `pallets/flask`
 
 Accepted deliberately rather than fixed by switching repos:
@@ -143,6 +174,15 @@ Accepted deliberately rather than fixed by switching repos:
   evaluation set cannot include ownership queries against flask.**
 - **`has_wiki: false`.** The `wiki_page` extractor no-ops. On this repo `motivated_by`
   therefore resolves only to issues and PR bodies, never wiki pages.
+- **The `corroborated` tier is sparse: 6 of 161 threads (33 of 811 explicit edges).**
+  flask merges largely without formal GitHub reviews — 11 `reviewed` edges across 145
+  PRs, and only 6 threads carry any review at all; 3 threads appear in release notes.
+  The rubric was chosen on independence grounds and not tuned to raise this number, so
+  §9 should report the tier as under-exercised on this repo rather than as a rubric
+  weakness. A repo with mandatory review would populate it heavily.
+- **Explicit-status Decisions are limited to what release notes itemise** (3 of 20).
+  flask's changelog lives in `CHANGES.rst`, a repo file, and file-content ingestion is
+  not built.
 - Cross-references to artifacts **outside** the 12-month window are skipped rather than
   fetched — fetching them would make the window unbounded by the back door. They are
   counted in the run summary under `*_target_not_ingested` rather than hidden.
@@ -173,6 +213,7 @@ cannot complete a backfill.
 ```bash
 psql "$DATABASE_URL" -f db/tests/0002_rubric_checks.sql             # 13 checks
 psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
+psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 DATABASE_URL=... python -m unittest discover -s tests               # 18 checks
 ```
 

--- a/db/migrations/0006_corroboration.sql
+++ b/db/migrations/0006_corroboration.sql
@@ -1,0 +1,197 @@
+-- 0006_corroboration.sql
+-- Engine 3, Evidence Ranking: the explicit -> corroborated upgrade (PRD v3.1 §5.4).
+--
+-- No schema change is required. `evidence_tier` already exists, and the tag/tier
+-- invariant from 0001 permits tag='explicit' with evidence_tier='corroborated' --
+-- (tag='inferred') = (tier='inferred') evaluates false = false. Only inference is
+-- locked to its tier; the corroborated upgrade was designed for from v1.
+--
+-- Packaged exactly like the Decision rubric in 0002: the rule exists once, as a view
+-- usable as a query, and the backfill is derived from it rather than restating it.
+--
+-- RUBRIC (mechanical, no model judgment). An explicit edge upgrades to `corroborated`
+-- iff all three hold:
+--
+--   1. Its edge_type is evidence-carrying. `created`, `mentions`, `references` and
+--      `depends_on` are excluded: authorship and loose mentions corroborate nothing.
+--   2. Its endpoints share one non-null thread cluster -- the same bounded-window
+--      definition as clause 3 of the §5.1 Decision rubric. Person-sourced edges
+--      (`reviewed`) are thread-less at the source, so only the destination must be in
+--      the thread.
+--   3. That thread exhibits >= 3 of 4 signal categories.
+--
+-- THE FOUR CATEGORIES, each pinned to an edge_type AND an extractor, both already
+-- stored on every edge so the tier is auditable after the fact:
+--
+--   DECLARED    `closes` via body_closing_keyword, dst an issue   -- the author's prose
+--   STRUCTURAL  `implements` via pr_commit_list                   -- GitHub's PR/commit structure
+--   ATTESTED    `reviewed` via pr_review                          -- a reviewer's action
+--   PUBLISHED   `deployed_by` via release_notes_reference         -- a maintainer's release note
+--
+-- ONLY OBSERVED EDGES COUNT. Categories are computed from extractors that read GitHub
+-- directly; every `synthesis_*` extractor is excluded. This is not a stylistic choice:
+-- synthesis_closes_cluster emits BOTH motivated_by and implemented_by from a SINGLE
+-- underlying `closes` edge, so counting them as two converging signals would be one
+-- signal wearing two hats -- circular self-corroboration.
+--
+-- Note the asymmetry, which is deliberate: synthesis-derived edges are EXCLUDED from
+-- counting categories but remain ELIGIBLE for upgrade. A motivated_by edge is what a
+-- Why answer is actually made of, so it should carry the tier its thread earned; it
+-- just must not vote on whether that tier is earned.
+--
+-- A REJECTED FIFTH CATEGORY. An earlier draft counted "the same issue closed by two or
+-- more distinct source artifacts" as independent convergence. It is not: all `closes`
+-- edges come from one extractor, so that condition always implies DECLARED and can
+-- never contribute an independent signal. Nested, not independent -- the same trap as
+-- the synthesis edges, reached through multiplicity instead of derivation. See #12 for
+-- the provenance-label work that would make such a category meaningful; it is not a
+-- reason to reintroduce it here.
+
+BEGIN;
+
+-- Which edge types can carry evidence at all (rubric clause 1).
+CREATE FUNCTION corroboration_eligible_edge_type(p_type edge_type) RETURNS boolean
+LANGUAGE sql IMMUTABLE AS $$
+    SELECT p_type IN ('closes', 'implements', 'reviewed',
+                      'motivated_by', 'implemented_by', 'deployed_by');
+$$;
+
+-- Per-thread category tally, observed edges only.
+CREATE VIEW v_thread_corroboration AS
+WITH threads AS (
+    SELECT DISTINCT thread_key FROM node WHERE thread_key IS NOT NULL
+),
+categories AS (
+    SELECT t.thread_key,
+
+           EXISTS (SELECT 1 FROM edge e
+                   JOIN node s ON s.id = e.src_node_id
+                   JOIN node d ON d.id = e.dst_node_id
+                   WHERE e.edge_type = 'closes'
+                     AND e.extractor = 'body_closing_keyword'
+                     AND e.tag = 'explicit' AND e.valid_to IS NULL
+                     AND d.node_type = 'issue'
+                     AND s.thread_key = t.thread_key
+                     AND d.thread_key = t.thread_key) AS declared,
+
+           EXISTS (SELECT 1 FROM edge e
+                   JOIN node s ON s.id = e.src_node_id
+                   JOIN node d ON d.id = e.dst_node_id
+                   WHERE e.edge_type = 'implements'
+                     AND e.extractor = 'pr_commit_list'
+                     AND e.tag = 'explicit' AND e.valid_to IS NULL
+                     AND s.thread_key = t.thread_key
+                     AND d.thread_key = t.thread_key) AS structural,
+
+           EXISTS (SELECT 1 FROM edge e
+                   JOIN node d ON d.id = e.dst_node_id
+                   WHERE e.edge_type = 'reviewed'
+                     AND e.extractor = 'pr_review'
+                     AND e.tag = 'explicit' AND e.valid_to IS NULL
+                     AND d.thread_key = t.thread_key) AS attested,
+
+           EXISTS (SELECT 1 FROM edge e
+                   JOIN node s ON s.id = e.src_node_id
+                   WHERE e.edge_type = 'deployed_by'
+                     AND e.extractor = 'release_notes_reference'
+                     AND e.tag = 'explicit' AND e.valid_to IS NULL
+                     AND s.thread_key = t.thread_key) AS published
+    FROM threads t
+)
+SELECT thread_key,
+       declared, structural, attested, published,
+       (declared::int + structural::int + attested::int + published::int) AS category_count,
+       (declared::int + structural::int + attested::int + published::int) >= 3 AS corroborates
+FROM categories;
+
+COMMENT ON VIEW v_thread_corroboration IS
+    'PRD v3.1 §5.4 corroboration categories per thread cluster. Observed extractors '
+    'only -- synthesis_* edges are excluded from counting because they are derived from '
+    'signals already counted here.';
+
+-- Every eligible edge with the rubric resolved. The backfill reads THIS, so the rule
+-- is never restated in two places that can drift apart.
+CREATE VIEW v_edge_corroboration_audit AS
+SELECT e.id AS edge_id,
+       e.edge_type,
+       e.tag,
+       e.evidence_tier,
+       e.extractor,
+       COALESCE(
+           -- Normal edges: both endpoints in one thread (clause 2).
+           CASE WHEN s.thread_key IS NOT NULL AND s.thread_key = d.thread_key
+                THEN s.thread_key END,
+           -- Person-sourced edges are thread-less at the source, so the destination
+           -- alone carries the thread.
+           CASE WHEN s.node_type = 'person' AND d.thread_key IS NOT NULL
+                THEN d.thread_key END
+       ) AS thread_key,
+       tc.category_count,
+       tc.declared, tc.structural, tc.attested, tc.published,
+       (
+           e.tag = 'explicit'
+           AND e.valid_to IS NULL
+           AND corroboration_eligible_edge_type(e.edge_type)
+           AND COALESCE(tc.corroborates, false)
+       ) AS qualifies
+FROM edge e
+JOIN node s ON s.id = e.src_node_id
+JOIN node d ON d.id = e.dst_node_id
+LEFT JOIN v_thread_corroboration tc
+       ON tc.thread_key = COALESCE(
+              CASE WHEN s.thread_key IS NOT NULL AND s.thread_key = d.thread_key
+                   THEN s.thread_key END,
+              CASE WHEN s.node_type = 'person' AND d.thread_key IS NOT NULL
+                   THEN d.thread_key END);
+
+COMMENT ON VIEW v_edge_corroboration_audit IS
+    'Rubric result per edge. Expected invariant after apply_corroboration(): no row '
+    'where qualifies <> (evidence_tier = ''corroborated'') among explicit edges.';
+
+-- Idempotent, and reversible. It downgrades as well as upgrades, because evidence can
+-- be invalidated later -- an edge whose thread loses its third category must lose the
+-- tier too, or the tier would record a claim the graph no longer supports.
+CREATE FUNCTION apply_corroboration()
+RETURNS TABLE (upgraded bigint, downgraded bigint)
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_up   bigint;
+    v_down bigint;
+BEGIN
+    WITH promoted AS (
+        UPDATE edge e
+        SET evidence_tier = 'corroborated'
+        FROM v_edge_corroboration_audit a
+        WHERE a.edge_id = e.id
+          AND a.qualifies
+          AND e.evidence_tier = 'explicit'
+        RETURNING e.id
+    )
+    SELECT count(*) INTO v_up FROM promoted;
+
+    WITH demoted AS (
+        UPDATE edge e
+        SET evidence_tier = 'explicit'
+        FROM v_edge_corroboration_audit a
+        WHERE a.edge_id = e.id
+          AND NOT a.qualifies
+          AND e.evidence_tier = 'corroborated'
+          -- Never touch inferred edges: the 0001 CHECK ties their tier to their tag.
+          AND e.tag = 'explicit'
+        RETURNING e.id
+    )
+    SELECT count(*) INTO v_down FROM demoted;
+
+    RETURN QUERY SELECT v_up, v_down;
+END;
+$$;
+
+COMMENT ON FUNCTION apply_corroboration() IS
+    'Backfill/refresh of §5.4 corroborated tiers. Idempotent and reversible: safe to '
+    'run after every ingestion. Reads v_edge_corroboration_audit so the rubric lives in '
+    'exactly one place.';
+
+-- Initial backfill.
+SELECT * FROM apply_corroboration();
+
+COMMIT;

--- a/db/tests/0006_corroboration_checks.sql
+++ b/db/tests/0006_corroboration_checks.sql
@@ -1,0 +1,208 @@
+-- 0006_corroboration_checks.sql
+-- Behavioural checks for the §5.4 corroboration rubric. Transactional; rolls back.
+--
+-- The real graph proves the upgrade path (33 edges across 6 threads). It cannot prove
+-- the parts that matter most: that a derived edge cannot self-corroborate, that a
+-- 2-of-4 thread is refused, and that the tier is REMOVED when evidence is invalidated.
+
+BEGIN;
+
+CREATE TEMP TABLE test_result (
+    seq int GENERATED ALWAYS AS IDENTITY,
+    name text, expect text, passed boolean, detail text
+);
+
+CREATE FUNCTION pg_temp.mk(p_type node_type, p_ext text, p_thread text DEFAULT NULL)
+RETURNS bigint LANGUAGE sql AS $fn$
+    INSERT INTO node (node_type, external_id, thread_key)
+    VALUES (p_type, p_ext, p_thread) RETURNING id;
+$fn$;
+
+CREATE FUNCTION pg_temp.mk_edge(p_src bigint, p_dst bigint, p_type edge_type,
+                                p_extractor text)
+RETURNS bigint LANGUAGE sql AS $fn$
+    INSERT INTO edge (src_node_id, dst_node_id, edge_type, tag, evidence_tier, extractor)
+    VALUES (p_src, p_dst, p_type, 'explicit', 'explicit', p_extractor) RETURNING id;
+$fn$;
+
+-- Builds a thread with a selectable subset of the four categories.
+CREATE FUNCTION pg_temp.build_thread(
+    p_key text, p_declared boolean, p_structural boolean,
+    p_attested boolean, p_published boolean)
+RETURNS bigint LANGUAGE plpgsql AS $fn$
+DECLARE pr bigint; iss bigint; c bigint; person bigint; rel bigint;
+BEGIN
+    pr  := pg_temp.mk('pull_request', p_key || '-pr', p_key);
+    iss := pg_temp.mk('issue',        p_key || '-issue', p_key);
+    c   := pg_temp.mk('commit',       p_key || '-commit', p_key);
+
+    IF p_declared THEN
+        PERFORM pg_temp.mk_edge(pr, iss, 'closes', 'body_closing_keyword');
+    END IF;
+    IF p_structural THEN
+        PERFORM pg_temp.mk_edge(pr, c, 'implements', 'pr_commit_list');
+    END IF;
+    IF p_attested THEN
+        person := pg_temp.mk('person', p_key || '-person');
+        PERFORM pg_temp.mk_edge(person, pr, 'reviewed', 'pr_review');
+    END IF;
+    IF p_published THEN
+        rel := pg_temp.mk('release', p_key || '-rel');
+        PERFORM pg_temp.mk_edge(iss, rel, 'deployed_by', 'release_notes_reference');
+    END IF;
+    RETURN pr;
+END;
+$fn$;
+
+
+-- T1  3 of 4 categories -> upgrade
+DO $t$
+DECLARE pr bigint; n int;
+BEGIN
+    pr := pg_temp.build_thread('test:t1', true, true, true, false);
+    PERFORM apply_corroboration();
+    SELECT count(*) INTO n FROM edge e
+    JOIN node s ON s.id = e.src_node_id
+    WHERE s.thread_key = 'test:t1' AND e.evidence_tier = 'corroborated';
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T1 three categories upgrade the thread', '>0 corroborated', n > 0,
+            'corroborated edges=' || n);
+END;
+$t$;
+
+
+-- T2  2 of 4 -> refused
+DO $t$
+DECLARE pr bigint; n int;
+BEGIN
+    pr := pg_temp.build_thread('test:t2', true, true, false, false);
+    PERFORM apply_corroboration();
+    SELECT count(*) INTO n FROM edge e
+    JOIN node s ON s.id = e.src_node_id
+    WHERE s.thread_key = 'test:t2' AND e.evidence_tier = 'corroborated';
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T2 two categories are refused', '0 corroborated', n = 0,
+            'corroborated edges=' || n);
+END;
+$t$;
+
+
+-- T3  Derived edges cannot manufacture a third category.
+--     A thread with DECLARED + STRUCTURAL plus a pile of synthesis_* edges must still
+--     be refused -- this is the self-corroboration trap the rubric exists to block.
+DO $t$
+DECLARE pr bigint; dec bigint; iss bigint; n int; cats int;
+BEGIN
+    pr  := pg_temp.build_thread('test:t3', true, true, false, false);
+    SELECT id INTO iss FROM node WHERE thread_key = 'test:t3' AND node_type = 'issue';
+
+    dec := pg_temp.mk('decision', 'test:t3-dec', 'test:t3');
+    INSERT INTO decision (node_id, status) VALUES (dec, 'reconstructed');
+    PERFORM pg_temp.mk_edge(dec, iss, 'motivated_by',   'synthesis_closes_cluster');
+    PERFORM pg_temp.mk_edge(dec, pr,  'implemented_by', 'synthesis_closes_cluster');
+
+    PERFORM apply_corroboration();
+    SELECT category_count INTO cats FROM v_thread_corroboration WHERE thread_key = 'test:t3';
+    SELECT count(*) INTO n FROM edge e
+    JOIN node s ON s.id = e.src_node_id
+    WHERE s.thread_key = 'test:t3' AND e.evidence_tier = 'corroborated';
+
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T3 synthesis edges cannot self-corroborate', '0 corroborated',
+            n = 0 AND cats = 2, 'category_count=' || cats || ' corroborated=' || n);
+END;
+$t$;
+
+
+-- T4  REVERSIBILITY: invalidate a category, the tier must be withdrawn.
+DO $t$
+DECLARE pr bigint; before_n int; after_n int; down bigint;
+BEGIN
+    pr := pg_temp.build_thread('test:t4', true, true, true, false);
+    PERFORM apply_corroboration();
+    SELECT count(*) INTO before_n FROM edge e JOIN node s ON s.id = e.src_node_id
+    WHERE s.thread_key = 'test:t4' AND e.evidence_tier = 'corroborated';
+
+    -- Withdraw ATTESTED by invalidating the review edge (time-versioned, not deleted).
+    -- valid_to must exceed valid_from per the 0001 CHECK, and inside one transaction
+    -- now() is frozen -- so an edge cannot be invalidated in the same transaction that
+    -- created it. Real invalidations always happen in a later run; the interval models
+    -- that elapsed time.
+    UPDATE edge SET valid_to = now() + interval '1 second'
+    WHERE edge_type = 'reviewed' AND dst_node_id = pr;
+
+    SELECT downgraded INTO down FROM apply_corroboration();
+    SELECT count(*) INTO after_n FROM edge e JOIN node s ON s.id = e.src_node_id
+    WHERE s.thread_key = 'test:t4' AND e.evidence_tier = 'corroborated';
+
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T4 tier withdrawn when evidence is invalidated', 'before>0, after=0',
+            before_n > 0 AND after_n = 0,
+            'before=' || before_n || ' after=' || after_n || ' downgraded=' || down);
+END;
+$t$;
+
+
+-- T5  Non-evidence-carrying edge types never upgrade, even in a qualifying thread.
+DO $t$
+DECLARE pr bigint; iss bigint; person bigint; tier evidence_tier;
+BEGIN
+    pr := pg_temp.build_thread('test:t5', true, true, true, false);
+    SELECT id INTO iss FROM node WHERE thread_key = 'test:t5' AND node_type = 'issue';
+    person := pg_temp.mk('person', 'test:t5-author');
+    UPDATE node SET thread_key = 'test:t5' WHERE id = person;
+    PERFORM pg_temp.mk_edge(person, iss, 'created', 'issue_author');
+
+    PERFORM apply_corroboration();
+    SELECT e.evidence_tier INTO tier FROM edge e
+    WHERE e.src_node_id = person AND e.edge_type = 'created';
+
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T5 authorship edges never corroborate', 'stays explicit',
+            tier = 'explicit', 'tier=' || tier);
+END;
+$t$;
+
+
+-- T6  Inferred edges are never touched -- the 0001 CHECK ties their tier to their tag.
+DO $t$
+DECLARE pr bigint; c bigint; tier evidence_tier; ok boolean := true;
+BEGIN
+    pr := pg_temp.build_thread('test:t6', true, true, true, false);
+    c  := pg_temp.mk('commit', 'test:t6-extra', 'test:t6');
+    INSERT INTO edge (src_node_id, dst_node_id, edge_type, tag, evidence_tier,
+                      extractor, relevance)
+    VALUES (pr, c, 'depends_on', 'inferred', 'inferred', 'llm_similarity_v1', 0.9);
+
+    PERFORM apply_corroboration();
+    SELECT e.evidence_tier INTO tier FROM edge e
+    WHERE e.src_node_id = pr AND e.dst_node_id = c AND e.tag = 'inferred';
+
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T6 inferred edges untouched by backfill', 'stays inferred',
+            tier = 'inferred', 'tier=' || tier);
+END;
+$t$;
+
+
+-- T7  Idempotence: a second application changes nothing.
+DO $t$
+DECLARE up bigint; down bigint;
+BEGIN
+    SELECT upgraded, downgraded INTO up, down FROM apply_corroboration();
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T7 second application is a no-op', '0 up / 0 down',
+            up = 0 AND down = 0, 'upgraded=' || up || ' downgraded=' || down);
+END;
+$t$;
+
+
+SELECT seq, CASE WHEN passed THEN 'PASS' ELSE 'FAIL' END AS result, name, expect,
+       left(COALESCE(detail, ''), 46) AS detail
+FROM test_result ORDER BY seq;
+
+SELECT count(*) FILTER (WHERE passed) AS passed,
+       count(*) FILTER (WHERE NOT passed) AS failed, count(*) AS total
+FROM test_result;
+
+ROLLBACK;

--- a/src/decision_graph/run.py
+++ b/src/decision_graph/run.py
@@ -87,6 +87,19 @@ def ingest(
             for refusal in outcome.refusals:
                 log.warning("  refused %s", refusal)
 
+        # Evidence Ranking (§5.4). Runs after synthesis so this run's new edges are
+        # scored, and before inference so tier assignment never sees a speculative edge.
+        # Idempotent and reversible: it withdraws the tier from threads whose supporting
+        # evidence was invalidated, as well as granting it.
+        tiers = conn.execute("SELECT * FROM apply_corroboration()").fetchone()
+        conn.commit()
+        if tiers and (tiers["upgraded"] or tiers["downgraded"]):
+            log.info(
+                "evidence tiers: %s upgraded to corroborated, %s withdrawn",
+                tiers["upgraded"],
+                tiers["downgraded"],
+            )
+
         # Gated inference runs last: it may only bridge gaps that explicit extraction
         # left behind, so it must not run before extraction has had its say (§5.1).
         inference.persist(conn, inference.propose(conn, repo_node_id))


### PR DESCRIPTION
Engine 3, Evidence Ranking (§5.4). Implements the rubric signed off on #12.

## The rule

An explicit edge upgrades to `corroborated` iff **(1)** its `edge_type` is evidence-carrying, **(2)** its endpoints share one thread cluster, and **(3)** that thread exhibits **≥3 of 4** categories:

| category | edge + extractor | independent origin |
|---|---|---|
| DECLARED | `closes` via `body_closing_keyword`, dst an issue | the author's prose |
| STRUCTURAL | `implements` via `pr_commit_list` | GitHub's PR↔commit structure |
| ATTESTED | `reviewed` via `pr_review` | a reviewer's action |
| PUBLISHED | `deployed_by` via `release_notes_reference` | a maintainer's release note |

Each category is pinned to an `edge_type` **and** an `extractor` — both already stored on every edge, so any tier can be audited after the fact rather than taken on trust.

## Only observed edges count

Every `synthesis_*` extractor is excluded, because `synthesis_closes_cluster` emits *both* `motivated_by` and `implemented_by` from a **single** underlying `closes` edge. Counting those as two converging signals is one signal wearing two hats.

The asymmetry is deliberate: synthesis edges are excluded from **counting** categories but remain **eligible** for upgrade. A `motivated_by` edge is what a Why answer is actually made of, so it should carry the tier its thread earned — it just must not vote on whether that tier is earned.

## The rejected fifth category

"The same issue closed by ≥2 distinct source artifacts" looked like independent convergence. It isn't: all 34 `closes` edges come from **one** extractor, so the condition always implies DECLARED and can never contribute an independent signal. Nested, not independent — the same trap as the synthesis edges, reached through multiplicity instead of derivation. Two of the seven candidate issues were closed by two PRs and no commit at all.

#12 tracks the provenance-label work that would make such a category meaningful. It's justified there on precision grounds only, explicitly *not* on the thread count it would recover.

## No schema change

`evidence_tier` already exists, and the 0001 tag/tier CHECK permits `tag='explicit'` with `tier='corroborated'` — `(false) = (false)`. The upgrade path was designed for from v1; only inference is locked to its tier.

## Idempotent *and* reversible

`apply_corroboration()` withdraws the tier from threads whose evidence was later invalidated, not just grants it — otherwise the tier would record a claim the graph no longer supports. It reads `v_edge_corroboration_audit`, so the rubric exists in exactly one place rather than being restated in the backfill. Runs after synthesis (this run's edges get scored) and before inference (tier assignment never sees a speculative edge).

## Result on flask

| metric | value |
|---|---|
| corroborated threads | **6 of 161** |
| corroborated edges | **33 of 811** |
| invariant violations | 0 |
| second application | 0 upgraded / 0 downgraded |

The 6 split cleanly — 3 via ATTESTED, 3 via PUBLISHED, zero overlap.

## Fifth documented limitation

flask merges largely without formal GitHub review — 11 `reviewed` edges across 145 PRs, only 6 threads with any review. So the tier is under-exercised here, and §9 should report it as a target-repo property rather than a rubric weakness. A repo with mandatory review would populate it heavily. **The rubric was chosen on independence grounds and deliberately not tuned to raise this number.**

## Tests

7 new behavioural checks covering what the real data can't prove: a 2-of-4 thread refused, synthesis edges unable to self-corroborate, authorship edges never upgrading, inferred edges untouched, idempotence, and reversibility.

Writing the reversibility test surfaced a genuine constraint interaction: `valid_to` must exceed `valid_from`, and `now()` is frozen inside a transaction — so **an edge cannot be invalidated in the same transaction that created it**. Harmless in production, since invalidations always happen in a later run, but it took a real test failure to notice and it's now documented in the test.

Totals: 24 SQL checks across four suites, 20 Python tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pCAUDALD1g8DBsf8j8PuK