### PR TITLE
Phase 4: the §9 evaluation set and adjudication worksheet

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 Organizational Intelligence Engine — implementation of `PRD_v3.1_Organizational_Intelligence_Engine.md`.
 
-**Phases 1–3 built.** Time-versioned graph schema, extraction-first GitHub ingestion,
-Decision synthesis, candidate retrieval, the Why/Impact traversal engine, and evidence
-tiering. Phase 4 (Explainability Mode presentation, the §9 evaluation set) is not built;
-Engine 2 already returns the path data it will present.
+**Phases 1–4 built.** Time-versioned graph schema, extraction-first GitHub ingestion,
+Decision synthesis, candidate retrieval, the Why/Impact traversal engine, evidence
+tiering, and the §9 evaluation set.
 
 - **Code repo:** this repository.
 - **Ingestion target:** `pallets/flask`.
@@ -207,6 +206,30 @@ dg-ingest --resources issues --max-pages 1   # smoke test; leaves cursor mid-win
 
 `GITHUB_TOKEN` is required — unauthenticated access is capped at 60 req/hour, which
 cannot complete a backfill.
+
+## Tests
+
+## Evaluation (§9)
+
+```bash
+DATABASE_URL=... python -m decision_graph.evaluation   # runs eval/query_set.json
+python eval/render_report.py                            # -> eval/report.html
+```
+
+18 queries — 2 flagship plus 16 harder cases spanning causal reconstruction, impact,
+retrieval by identifier and paraphrase, point-in-time, and four **correct-refusal** cases.
+
+**The runner grades nothing.** §9 requires answers checked against the repository's real
+history; a system scoring its own output against its own graph measures self-consistency,
+not correctness. `verdict` is emitted null for every query and filled in by a human. The
+only automatic assertion is `contract` — mechanical properties of the engine such as
+"must return no answer for an artifact outside the window" — which are claims about the
+code rather than about flask.
+
+Current run: 12 answered, 6 returned nothing, 4/4 engine contracts held. The point-in-time
+control is the load-bearing one: F1 returns 1 path and drops to 0 when asked as of
+2025-06, while F2 returns 17 both now and as of 2026-12 — so the time filter restricts in
+one direction only, rather than being silently ignored.
 
 ## Tests
 

--- a/eval/query_set.json
+++ b/eval/query_set.json
@@ -1,0 +1,181 @@
+{
+  "about": {
+    "target_repo": "pallets/flask",
+    "window": "12 months",
+    "spec": "PRD v3.1 §9 — 2 flagship queries + 13-18 additional covering harder, less curated cases",
+    "adjudication": "Correctness is decided by a human against flask's actual history. The runner records what the system returned and never grades it. Where a 'contract' field appears, that is a mechanically checkable property of the engine (e.g. 'must return no answer'), not a claim about flask."
+  },
+  "queries": [
+    {
+      "id": "F1",
+      "category": "flagship",
+      "mode": "why",
+      "query": "change default redirect code to 303",
+      "depth": 3,
+      "intent": "Why did Flask change its default redirect status code?",
+      "verify": "Does the reconstructed chain (issue -> decision -> implementing PR/commit) match how this actually happened in flask? Is the motivating issue genuinely the 'why'?"
+    },
+    {
+      "id": "F2",
+      "category": "flagship",
+      "mode": "impact",
+      "query": "Looser type annotations for send_file() path_or_file argument",
+      "depth": 3,
+      "intent": "If this change were reverted, what is affected?",
+      "verify": "Are the reached artifacts (PR, commits, release 3.1.2) genuinely downstream of this change? Is release 3.1.2 the correct shipping vehicle?"
+    },
+
+    {
+      "id": "H1",
+      "category": "causal",
+      "mode": "why",
+      "query": "Config.from_file() missing ENOTDIR in silent error handling",
+      "depth": 3,
+      "intent": "Hardest clustering case: this issue was closed by FIVE distinct sources (3 PRs + 2 commits), all merged into one thread.",
+      "verify": "Should all five sources belong to one decision? Did flask really resolve this across multiple PRs, or are some unrelated?"
+    },
+    {
+      "id": "H2",
+      "category": "causal",
+      "mode": "why",
+      "query": "merge app and request contexts into a single context",
+      "depth": 3,
+      "intent": "A genuine architectural decision, not a bug fix.",
+      "verify": "Is the causal chain right? This is the kind of decision the system exists to reconstruct."
+    },
+    {
+      "id": "H3",
+      "category": "causal",
+      "mode": "why",
+      "query": "Recommend Warning and Safer Defaults for url_for(..., _external=True)",
+      "depth": 3,
+      "intent": "A CORROBORATED thread (3 of 4 categories, via ATTESTED). Tier should read corroborated, not explicit.",
+      "verify": "Is the chain correct, AND does the corroborated tier feel justified by the underlying evidence?"
+    },
+    {
+      "id": "H4",
+      "category": "causal",
+      "mode": "why",
+      "query": "deprecate `should_ignore_error`",
+      "depth": 3,
+      "intent": "A deprecation decision spanning 2 PRs and 3 commits.",
+      "verify": "Does the reconstruction capture the deprecation rationale?"
+    },
+    {
+      "id": "H5",
+      "category": "retrieval",
+      "mode": "why",
+      "query": "#5898",
+      "depth": 3,
+      "intent": "Bare identifier retrieval — the form an impact query normally arrives in.",
+      "verify": "Did retrieval resolve #5898 to the right artifact? Same answer as F1 reached by a different route?"
+    },
+    {
+      "id": "H6",
+      "category": "retrieval",
+      "mode": "why",
+      "query": "c8ecf241e3605c48ac84ab863c206f1072888668",
+      "depth": 3,
+      "intent": "Retrieval by full commit SHA.",
+      "verify": "Does the commit resolve, and does its Why chain reach the right decision?"
+    },
+    {
+      "id": "H7",
+      "category": "retrieval",
+      "mode": "why",
+      "query": "template_filter decorator broken",
+      "depth": 3,
+      "intent": "Fuzzy retrieval — the query wording does not match the issue title, which is 'The `template_filter` decorator doesn't work if you don't pass an argument'.",
+      "verify": "Did trigram matching find the right entity despite the paraphrase? Would a reasonable user consider this the right hit?"
+    },
+    {
+      "id": "H8",
+      "category": "impact",
+      "mode": "impact",
+      "query": "3.1.2",
+      "depth": 2,
+      "intent": "Impact from a release — what shipped in it?",
+      "verify": "Are the reached issues genuinely the contents of 3.1.2, per flask's actual release notes?"
+    },
+    {
+      "id": "H9",
+      "category": "impact",
+      "mode": "impact",
+      "query": "Config.from_file() missing ENOTDIR in silent error handling",
+      "depth": 3,
+      "intent": "Forward traversal over the 5-source cluster.",
+      "verify": "Does the blast radius look right, or does thread-merging over-connect unrelated work?"
+    },
+    {
+      "id": "H10",
+      "category": "impact",
+      "mode": "impact",
+      "query": "asgiref fails with gevent patching",
+      "depth": 3,
+      "intent": "Impact across a 2-PR / 2-commit thread.",
+      "verify": "Are all reached artifacts genuinely affected by a revert?"
+    },
+    {
+      "id": "N1",
+      "category": "negative",
+      "mode": "why",
+      "query": "package detection fails with namespace package in project layout",
+      "depth": 3,
+      "intent": "An issue in a thread with NO Decision — it did not meet the §5.1 rubric.",
+      "contract": "Must return no answer. The system must not invent a decision where the rubric declined to assert one.",
+      "verify": "Confirm flask genuinely has no recorded decision resolving this, i.e. the refusal is correct rather than a miss."
+    },
+    {
+      "id": "N2",
+      "category": "negative",
+      "mode": "impact",
+      "query": "davidism",
+      "depth": 2,
+      "intent": "Impact from a person. Authorship edges (`created`) are deliberately excluded from the impact edge set.",
+      "contract": "Must return no answer. 'Everything this person touched' is a Bus Factor / Expert Finder query, explicitly out of scope for v1 (§6).",
+      "verify": "Confirm the empty answer is the right behaviour rather than a gap worth closing."
+    },
+    {
+      "id": "N3",
+      "category": "negative",
+      "mode": "why",
+      "query": "quantum entanglement middleware autoscaler",
+      "depth": 3,
+      "intent": "Retrieval finds nothing at all.",
+      "contract": "Must return no candidates and say so, rather than fuzzy-matching to an unrelated entity.",
+      "verify": "Confirm no spurious candidate was returned above the 0.25 trigram floor."
+    },
+    {
+      "id": "N4",
+      "category": "negative",
+      "mode": "why",
+      "query": "#2581",
+      "depth": 3,
+      "intent": "An issue referenced by in-window artifacts but itself OUTSIDE the 12-month window. It sits unresolved in pending_reference with 7 attempts.",
+      "contract": "Must return no answer. The bounded window is a deliberate limit; the system must not fabricate a chain for an artifact it never ingested.",
+      "verify": "Confirm the honest 'not in graph' outcome, and that the pending queue records it rather than silently dropping it."
+    },
+    {
+      "id": "T1",
+      "category": "temporal",
+      "mode": "why",
+      "query": "change default redirect code to 303",
+      "depth": 3,
+      "as_of": "2025-06-01T00:00:00+00:00",
+      "intent": "Point-in-time query BEFORE this decision existed, using the valid_from/valid_to window.",
+      "contract": "Must return fewer paths than F1 — ideally none. Edges whose valid_from postdates the as-of instant must not be traversed.",
+      "verify": "Confirm the time filter genuinely restricts the answer rather than being ignored."
+    },
+    {
+      "id": "T2",
+      "category": "temporal",
+      "mode": "impact",
+      "query": "Looser type annotations for send_file() path_or_file argument",
+      "depth": 3,
+      "as_of": "2026-12-31T00:00:00+00:00",
+      "intent": "Point-in-time query AFTER everything — control for T1.",
+      "contract": "Must return the same paths as F2. If T1 shrinks and T2 does not, the time filter is working in both directions.",
+      "verify": "Compare against F2; they should match."
+    }
+  ]
+}

--- a/eval/render_report.py
+++ b/eval/render_report.py
@@ -1,0 +1,518 @@
+"""Render eval/results.json into a reviewable adjudication worksheet.
+
+Generated from results.json rather than hand-written, so re-running the evaluation
+regenerates the report and the two cannot drift.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent
+RESULTS = ROOT / "results.json"
+OUT = ROOT / "report.html"
+
+CATEGORY_LABEL = {
+    "flagship": "Flagship",
+    "causal": "Causal reconstruction",
+    "impact": "Impact analysis",
+    "retrieval": "Retrieval",
+    "negative": "Correct refusal",
+    "temporal": "Point-in-time",
+}
+
+MAX_VISIBLE_PATHS = 5
+
+
+def e(text) -> str:
+    return html.escape(str(text if text is not None else ""))
+
+
+def render_step(step: dict) -> str:
+    arrow = "→" if step["direction"] == "forward" else "←"
+    ref = (
+        f'<span class="ref">{e(step["source_ref"])}</span>'
+        if step.get("source_ref")
+        else ""
+    )
+    return f"""
+      <div class="step">
+        <span class="conn">{arrow}</span>
+        <span class="etype">{e(step["edge_type"])}</span>
+        <span class="tier tier-{e(step["tier"])}">{e(step["tier"])}</span>
+        <span class="extractor">{e(step["extractor"])}</span>
+        {ref}
+      </div>
+      <div class="node">{e(step["to_node"])}</div>"""
+
+
+def render_path(path: dict, index: int) -> str:
+    steps = "".join(render_step(s) for s in path["steps"])
+    return f"""
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path {index}</span>
+        <span class="tier tier-{e(path["tier"])}">{e(path["tier"])}</span>
+        <span class="depth">{path["depth"]} hop{"s" if path["depth"] != 1 else ""}</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">{e(path["start"])}</div>{steps}
+      </div>
+    </li>"""
+
+
+def render_candidates(candidates: list[dict]) -> str:
+    if not candidates:
+        return '<p class="empty">No candidate start node matched.</p>'
+    rows = "".join(
+        f"""<tr{' class="chosen"' if i == 0 else ''}>
+              <td class="mono">{e(c["node_type"])}:{e(c["node_id"])}</td>
+              <td>{e(c["title"] or c["external_id"])}</td>
+              <td class="mono">{e(c["match"])}</td>
+              <td class="num">{c["score"]:.2f}</td>
+            </tr>"""
+        for i, c in enumerate(candidates)
+    )
+    return f"""
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody>{rows}</tbody>
+      </table>"""
+
+
+def render_query(r: dict) -> str:
+    paths = r["paths"]
+    visible = paths[:MAX_VISIBLE_PATHS]
+    hidden = paths[MAX_VISIBLE_PATHS:]
+
+    path_html = "".join(render_path(p, i + 1) for i, p in enumerate(visible))
+    if hidden:
+        rest = "".join(
+            render_path(p, i + 1 + MAX_VISIBLE_PATHS) for i, p in enumerate(hidden)
+        )
+        path_html += f"""
+        <li class="more">
+          <details>
+            <summary>{len(hidden)} further path{"s" if len(hidden) != 1 else ""}</summary>
+            <ul class="paths">{rest}</ul>
+          </details>
+        </li>"""
+
+    if not paths:
+        path_html = f'<li class="empty">No path returned. <span class="mono">{e(r["explanation"])}</span></li>'
+
+    contract = ""
+    if r.get("contract"):
+        check = r.get("contract_check") or ""
+        cls = {"HELD": "held", "VIOLATED": "violated", "COMPARE": "compare"}.get(check, "")
+        contract = f"""
+        <div class="contract {cls}">
+          <span class="contract-label">Engine contract</span>
+          <span class="contract-state">{e(check)}</span>
+          <p>{e(r["contract"])}</p>
+        </div>"""
+
+    as_of = (
+        f'<span class="meta-chip">as of {e(r["as_of"][:10])}</span>' if r.get("as_of") else ""
+    )
+
+    verify = (
+        f'<div class="verify"><span class="verify-label">Check against flask</span><p>{e(r["verify"])}</p></div>'
+        if r.get("verify")
+        else ""
+    )
+
+    qid = e(r["id"])
+    return f"""
+  <article class="q" id="q-{qid}">
+    <header class="q-head">
+      <div class="q-id">{qid}</div>
+      <div class="q-meta">
+        <span class="cat">{e(CATEGORY_LABEL.get(r["category"], r["category"]))}</span>
+        <span class="meta-chip mode-{e(r["mode"])}">{e(r["mode"])}</span>
+        <span class="meta-chip">depth {r["depth"]}</span>
+        {as_of}
+        <span class="meta-chip {'ans' if r['answered'] else 'noans'}">{"answered" if r["answered"] else "no answer"}</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>{e(r["query"])}</code></p>
+    <p class="intent">{e(r["intent"])}</p>
+
+    {contract}
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      {render_candidates(r["candidates"])}
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">{len(paths)} path{"s" if len(paths) != 1 else ""}</span></h4>
+      <ul class="paths">{path_html}</ul>
+    </section>
+
+    {verify}
+
+    <footer class="verdict" data-q="{qid}">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-{qid}" value="correct"> correct</label>
+      <label><input type="radio" name="v-{qid}" value="partial"> partial</label>
+      <label><input type="radio" name="v-{qid}" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="{qid}">
+    </footer>
+  </article>"""
+
+
+def build() -> str:
+    data = json.loads(RESULTS.read_text(encoding="utf-8"))
+    s = data["summary"]
+    results = data["results"]
+
+    f1 = next(r for r in results if r["id"] == "F1")
+    t1 = next(r for r in results if r["id"] == "T1")
+    f2 = next(r for r in results if r["id"] == "F2")
+    t2 = next(r for r in results if r["id"] == "T2")
+
+    tiers: dict[str, int] = {}
+    for r in results:
+        for p in r["paths"]:
+            tiers[p["tier"]] = tiers.get(p["tier"], 0) + 1
+
+    cards = "".join(render_query(r) for r in results)
+
+    tier_bar = "".join(
+        f'<span class="tb tier-{k}" style="flex:{v}"><span>{k} {v}</span></span>'
+        for k, v in sorted(tiers.items(), key=lambda kv: -kv[1])
+    )
+
+    return TEMPLATE.format(
+        cards=cards,
+        total=s["total"],
+        answered=s["answered"],
+        refused=s["returned_no_answer"],
+        contracts_held=s["contracts_held"],
+        contracts_checked=s["contracts_checked"],
+        f1_paths=len(f1["paths"]),
+        t1_paths=len(t1["paths"]),
+        f2_paths=len(f2["paths"]),
+        t2_paths=len(t2["paths"]),
+        tier_bar=tier_bar,
+        generated=data["generated_at"][:16].replace("T", " "),
+    )
+
+
+TEMPLATE = """<title>Decision Graph — Evaluation Worksheet</title>
+<style>
+:root {{
+  --ground:   #F6F7F9;
+  --surface:  #FFFFFF;
+  --sunk:     #EEF1F4;
+  --ink:      #171A1F;
+  --muted:    #5C6672;
+  --faint:    #8A939E;
+  --rule:     #DCE1E7;
+  --accent:   #1B6B63;
+  --accent-soft: #E4F0EE;
+  --explicit:     #4A6C88;
+  --corroborated: #2E7D5B;
+  --inferred:     #A6742E;
+  --held:     #2E7D5B;
+  --violated: #B04A3E;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --serif: ui-serif, "Iowan Old Style", Georgia, "Times New Roman", serif;
+  --mono: ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, monospace;
+}}
+@media (prefers-color-scheme: dark) {{
+  :root:not([data-theme="light"]) {{
+    --ground:   #101317;
+    --surface:  #171B21;
+    --sunk:     #1D222A;
+    --ink:      #E4E8ED;
+    --muted:    #98A2AE;
+    --faint:    #6B7683;
+    --rule:     #272E37;
+    --accent:   #58B5A8;
+    --accent-soft: #16302E;
+    --explicit:     #7FA3C2;
+    --corroborated: #5DB98C;
+    --inferred:     #D2A055;
+    --held:     #5DB98C;
+    --violated: #D97A6C;
+  }}
+}}
+:root[data-theme="dark"] {{
+  --ground:#101317; --surface:#171B21; --sunk:#1D222A; --ink:#E4E8ED;
+  --muted:#98A2AE; --faint:#6B7683; --rule:#272E37; --accent:#58B5A8;
+  --accent-soft:#16302E; --explicit:#7FA3C2; --corroborated:#5DB98C;
+  --inferred:#D2A055; --held:#5DB98C; --violated:#D97A6C;
+}}
+
+* {{ box-sizing: border-box; }}
+body {{
+  margin: 0; background: var(--ground); color: var(--ink);
+  font-family: var(--sans); font-size: 15px; line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}}
+.wrap {{ max-width: 62rem; margin: 0 auto; padding: 3.5rem 1.5rem 6rem; }}
+.lede {{ max-width: 38rem; }}
+
+h1 {{
+  font-family: var(--serif); font-size: clamp(1.9rem, 4vw, 2.6rem);
+  line-height: 1.15; margin: 0 0 .4rem; text-wrap: balance; font-weight: 600;
+}}
+.sub {{ color: var(--muted); margin: 0 0 2rem; font-size: 1.02rem; }}
+h2 {{
+  font-family: var(--serif); font-size: 1.35rem; font-weight: 600;
+  margin: 3.5rem 0 1rem; padding-bottom: .5rem; border-bottom: 1px solid var(--rule);
+}}
+h4 {{
+  font-size: .72rem; text-transform: uppercase; letter-spacing: .09em;
+  color: var(--faint); margin: 0 0 .55rem; font-weight: 600;
+}}
+h4 .count {{ text-transform: none; letter-spacing: 0; color: var(--muted); font-weight: 400; }}
+p {{ margin: 0 0 .9rem; }}
+code, .mono {{ font-family: var(--mono); font-size: .86em; }}
+
+.note {{
+  background: var(--accent-soft); border-left: 3px solid var(--accent);
+  padding: 1rem 1.15rem; margin: 1.5rem 0 0; max-width: 38rem;
+}}
+.note p {{ margin: 0; font-size: .93rem; }}
+.note strong {{ color: var(--accent); }}
+
+.stats {{ display: flex; flex-wrap: wrap; gap: 1px; background: var(--rule);
+  border: 1px solid var(--rule); margin: 2rem 0 .75rem; }}
+.stat {{ background: var(--surface); padding: .9rem 1.15rem; flex: 1 1 8rem; }}
+.stat .n {{ font-size: 1.6rem; font-family: var(--serif); font-variant-numeric: tabular-nums;
+  line-height: 1.1; display: block; }}
+.stat .l {{ font-size: .72rem; text-transform: uppercase; letter-spacing: .07em; color: var(--faint); }}
+.stat.good .n {{ color: var(--held); }}
+
+.tiers {{ display: flex; height: 2rem; border: 1px solid var(--rule); overflow: hidden; }}
+.tb {{ display: flex; align-items: center; justify-content: center; min-width: 0; }}
+.tb span {{ font-size: .7rem; color: #fff; letter-spacing: .04em; white-space: nowrap;
+  padding: 0 .4rem; overflow: hidden; text-overflow: ellipsis; }}
+.tb.tier-explicit {{ background: var(--explicit); }}
+.tb.tier-corroborated {{ background: var(--corroborated); }}
+.tb.tier-inferred {{ background: var(--inferred); }}
+.caption {{ font-size: .82rem; color: var(--faint); margin: .5rem 0 0; }}
+
+.q {{
+  background: var(--surface); border: 1px solid var(--rule);
+  padding: 1.5rem 1.6rem 1.1rem; margin: 0 0 1.25rem;
+}}
+.q-head {{ display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap;
+  padding-bottom: .85rem; margin-bottom: .95rem; border-bottom: 1px solid var(--rule); }}
+.q-id {{ font-family: var(--mono); font-size: 1.05rem; font-weight: 700; color: var(--accent); }}
+.q-meta {{ display: flex; gap: .45rem; flex-wrap: wrap; align-items: center; margin-left: auto; }}
+.cat {{ font-size: .82rem; color: var(--muted); }}
+.meta-chip {{
+  font-family: var(--mono); font-size: .7rem; padding: .16rem .5rem;
+  background: var(--sunk); color: var(--muted); border-radius: 2px; white-space: nowrap;
+}}
+.meta-chip.mode-why {{ color: var(--accent); }}
+.meta-chip.mode-impact {{ color: var(--explicit); }}
+.meta-chip.ans {{ color: var(--held); }}
+.meta-chip.noans {{ color: var(--muted); }}
+
+.query {{ margin-bottom: .45rem; }}
+.q-label, .v-label, .verify-label, .contract-label {{
+  font-size: .68rem; text-transform: uppercase; letter-spacing: .09em;
+  color: var(--faint); font-weight: 600; margin-right: .5rem;
+}}
+.query code {{ background: var(--sunk); padding: .18rem .45rem; border-radius: 2px; }}
+.intent {{ color: var(--muted); font-size: .93rem; max-width: 46rem; }}
+
+.contract {{ background: var(--sunk); padding: .75rem .95rem; margin: 0 0 1.1rem;
+  border-left: 3px solid var(--faint); }}
+.contract.held {{ border-left-color: var(--held); }}
+.contract.violated {{ border-left-color: var(--violated); }}
+.contract p {{ margin: .3rem 0 0; font-size: .88rem; color: var(--muted); }}
+.contract-state {{ font-family: var(--mono); font-size: .74rem; font-weight: 700; }}
+.contract.held .contract-state {{ color: var(--held); }}
+.contract.violated .contract-state {{ color: var(--violated); }}
+
+.block {{ margin: 0 0 1.15rem; }}
+table.cands {{ width: 100%; border-collapse: collapse; font-size: .86rem; }}
+table.cands th {{ text-align: left; font-weight: 600; font-size: .7rem;
+  text-transform: uppercase; letter-spacing: .06em; color: var(--faint);
+  padding: .25rem .5rem .25rem 0; border-bottom: 1px solid var(--rule); }}
+table.cands td {{ padding: .32rem .5rem .32rem 0; border-bottom: 1px solid var(--rule);
+  vertical-align: top; }}
+table.cands tr.chosen td {{ font-weight: 600; }}
+table.cands tr.chosen td:first-child {{ box-shadow: inset 2px 0 0 var(--accent); padding-left: .5rem; }}
+td.num {{ font-variant-numeric: tabular-nums; text-align: right; }}
+
+ul.paths {{ list-style: none; margin: 0; padding: 0; display: flex;
+  flex-direction: column; gap: .75rem; }}
+.path-head {{ display: flex; gap: .5rem; align-items: center; margin-bottom: .3rem; }}
+.path-n {{ font-size: .7rem; text-transform: uppercase; letter-spacing: .07em; color: var(--faint); }}
+.depth {{ font-size: .74rem; color: var(--faint); font-family: var(--mono); }}
+.trace {{ font-family: var(--mono); font-size: .8rem; background: var(--sunk);
+  padding: .7rem .85rem; overflow-x: auto; border-radius: 2px; }}
+.node {{ white-space: nowrap; padding: .1rem 0; }}
+.node-start {{ font-weight: 700; }}
+.step {{ display: flex; gap: .5rem; align-items: center; padding: .12rem 0 .12rem 1.1rem;
+  border-left: 1px solid var(--rule); margin-left: .35rem; white-space: nowrap; }}
+.conn {{ color: var(--faint); }}
+.etype {{ color: var(--ink); font-weight: 600; }}
+.extractor {{ color: var(--faint); font-size: .92em; }}
+.ref {{ color: var(--faint); font-size: .88em; opacity: .75; }}
+
+.tier {{ font-size: .66rem; text-transform: uppercase; letter-spacing: .05em;
+  padding: .08rem .4rem; border-radius: 2px; color: #fff; font-weight: 600;
+  font-family: var(--mono); }}
+.tier-explicit {{ background: var(--explicit); }}
+.tier-corroborated {{ background: var(--corroborated); }}
+.tier-inferred {{ background: var(--inferred); }}
+
+.empty {{ color: var(--muted); font-size: .89rem; font-style: italic; list-style: none; }}
+.more summary {{ cursor: pointer; font-size: .82rem; color: var(--accent); padding: .2rem 0; }}
+.more ul {{ margin-top: .7rem; }}
+
+.verify {{ border-top: 1px solid var(--rule); padding-top: .8rem; margin-top: .3rem; }}
+.verify p {{ margin: .25rem 0 0; font-size: .9rem; color: var(--muted); max-width: 46rem; }}
+
+.verdict {{ display: flex; align-items: center; gap: .9rem; flex-wrap: wrap;
+  margin-top: 1rem; padding-top: .85rem; border-top: 2px solid var(--rule); }}
+.verdict label {{ font-size: .87rem; display: flex; align-items: center; gap: .3rem;
+  cursor: pointer; color: var(--muted); }}
+.verdict input[type=radio] {{ accent-color: var(--accent); }}
+.verdict.done {{ border-top-color: var(--accent); }}
+.v-note {{ flex: 1 1 12rem; min-width: 8rem; font-family: var(--sans); font-size: .85rem;
+  padding: .3rem .5rem; border: 1px solid var(--rule); background: var(--ground);
+  color: var(--ink); border-radius: 2px; }}
+input:focus-visible, summary:focus-visible {{ outline: 2px solid var(--accent); outline-offset: 2px; }}
+
+.bar {{ position: sticky; bottom: 0; background: var(--surface); border-top: 1px solid var(--rule);
+  padding: .8rem 1.5rem; display: flex; gap: 1rem; align-items: center; flex-wrap: wrap;
+  margin: 2rem -1.5rem -6rem; }}
+.bar .prog {{ font-size: .88rem; color: var(--muted); font-variant-numeric: tabular-nums; }}
+button {{ font-family: var(--sans); font-size: .86rem; padding: .42rem .9rem;
+  background: var(--accent); color: #fff; border: none; border-radius: 2px; cursor: pointer; }}
+button.ghost {{ background: transparent; color: var(--muted); border: 1px solid var(--rule); }}
+button:hover {{ opacity: .9; }}
+@media (prefers-reduced-motion: reduce) {{ * {{ transition: none !important; }} }}
+</style>
+
+<div class="wrap">
+  <div class="lede">
+    <h1>Evaluation worksheet</h1>
+    <p class="sub">Decision Graph against <code>pallets/flask</code> — PRD v3.1 §9.
+    18 queries: 2 flagship plus 16 harder cases. Generated {generated}.</p>
+
+    <div class="note">
+      <p><strong>Nothing here is graded.</strong> §9 requires answers checked against the
+      repository's real history, and a system scoring its own output against its own graph
+      would be measuring self-consistency, not correctness. Every verdict below is blank
+      and waiting for you. The one thing the runner does assert is the
+      <em>engine contract</em> — mechanical properties like “must return no answer for an
+      artifact outside the window” — because those are claims about the code, not about flask.</p>
+    </div>
+  </div>
+
+  <div class="stats">
+    <div class="stat"><span class="n">{total}</span><span class="l">queries</span></div>
+    <div class="stat"><span class="n">{answered}</span><span class="l">answered</span></div>
+    <div class="stat"><span class="n">{refused}</span><span class="l">returned nothing</span></div>
+    <div class="stat good"><span class="n">{contracts_held}/{contracts_checked}</span><span class="l">contracts held</span></div>
+  </div>
+
+  <div class="tiers">{tier_bar}</div>
+  <p class="caption">Evidence tier across every path returned. No path used the inferred
+  fallback — the graph holds no inferred edges, so that branch is exercised only by the
+  seeded fixture in the test suite.</p>
+
+  <h2>Point-in-time control</h2>
+  <p>T1 and T2 re-run the two flagship queries through the <code>valid_from</code>/<code>valid_to</code>
+  window. If the time filter were silently ignored, both would be unchanged.</p>
+  <div class="stats">
+    <div class="stat"><span class="n">{f1_paths} → {t1_paths}</span><span class="l">F1 → T1, as of 2025-06</span></div>
+    <div class="stat"><span class="n">{f2_paths} → {t2_paths}</span><span class="l">F2 → T2, as of 2026-12</span></div>
+  </div>
+  <p class="caption">The past query collapses to nothing; the future query is unchanged.
+  The filter restricts in one direction only, which is the expected behaviour.</p>
+
+  <h2>Queries</h2>
+  {cards}
+
+  <div class="bar">
+    <span class="prog" id="prog">0 of {total} adjudicated</span>
+    <button id="export">Copy verdicts</button>
+    <button class="ghost" id="clear">Clear all</button>
+  </div>
+</div>
+
+<script>
+(function () {{
+  var KEY = "dg-eval-verdicts-v1";
+  var store = {{}};
+  try {{ store = JSON.parse(localStorage.getItem(KEY) || "{{}}"); }} catch (err) {{ store = {{}}; }}
+
+  function persist() {{
+    try {{ localStorage.setItem(KEY, JSON.stringify(store)); }} catch (err) {{ /* private mode */ }}
+  }}
+
+  function refresh() {{
+    var ids = Object.keys(store).filter(function (k) {{ return store[k] && store[k].v; }});
+    document.querySelectorAll(".verdict").forEach(function (f) {{
+      var rec = store[f.dataset.q];
+      f.classList.toggle("done", !!(rec && rec.v));
+    }});
+    document.getElementById("prog").textContent =
+      ids.length + " of " + document.querySelectorAll(".verdict").length + " adjudicated";
+  }}
+
+  document.querySelectorAll(".verdict").forEach(function (f) {{
+    var id = f.dataset.q;
+    var rec = store[id] || {{}};
+    if (rec.v) {{
+      var hit = f.querySelector('input[value="' + rec.v + '"]');
+      if (hit) hit.checked = true;
+    }}
+    var note = f.querySelector(".v-note");
+    if (rec.n) note.value = rec.n;
+
+    f.addEventListener("change", function (ev) {{
+      if (ev.target.type !== "radio") return;
+      store[id] = Object.assign({{}}, store[id], {{ v: ev.target.value }});
+      persist(); refresh();
+    }});
+    note.addEventListener("input", function () {{
+      store[id] = Object.assign({{}}, store[id], {{ n: note.value }});
+      persist();
+    }});
+  }});
+
+  document.getElementById("export").addEventListener("click", function () {{
+    var lines = ["Decision Graph — §9 adjudication", ""];
+    document.querySelectorAll(".verdict").forEach(function (f) {{
+      var id = f.dataset.q, rec = store[id] || {{}};
+      lines.push(id + ": " + (rec.v || "—") + (rec.n ? "  // " + rec.n : ""));
+    }});
+    var text = lines.join("\\n");
+    var btn = document.getElementById("export");
+    function done() {{ btn.textContent = "Copied"; setTimeout(function () {{ btn.textContent = "Copy verdicts"; }}, 1600); }}
+    if (navigator.clipboard) {{
+      navigator.clipboard.writeText(text).then(done, function () {{ window.prompt("Copy:", text); }});
+    }} else {{ window.prompt("Copy:", text); }}
+  }});
+
+  document.getElementById("clear").addEventListener("click", function () {{
+    store = {{}}; persist();
+    document.querySelectorAll(".verdict input[type=radio]").forEach(function (r) {{ r.checked = false; }});
+    document.querySelectorAll(".v-note").forEach(function (n) {{ n.value = ""; }});
+    refresh();
+  }});
+
+  refresh();
+}})();
+</script>
+"""
+
+
+if __name__ == "__main__":
+    OUT.write_text(build(), encoding="utf-8")
+    print(f"wrote {OUT} ({OUT.stat().st_size:,} bytes)")

--- a/eval/report.html
+++ b/eval/report.html
@@ -1,0 +1,3033 @@
+<title>Decision Graph — Evaluation Worksheet</title>
+<style>
+:root {
+  --ground:   #F6F7F9;
+  --surface:  #FFFFFF;
+  --sunk:     #EEF1F4;
+  --ink:      #171A1F;
+  --muted:    #5C6672;
+  --faint:    #8A939E;
+  --rule:     #DCE1E7;
+  --accent:   #1B6B63;
+  --accent-soft: #E4F0EE;
+  --explicit:     #4A6C88;
+  --corroborated: #2E7D5B;
+  --inferred:     #A6742E;
+  --held:     #2E7D5B;
+  --violated: #B04A3E;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --serif: ui-serif, "Iowan Old Style", Georgia, "Times New Roman", serif;
+  --mono: ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, monospace;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    --ground:   #101317;
+    --surface:  #171B21;
+    --sunk:     #1D222A;
+    --ink:      #E4E8ED;
+    --muted:    #98A2AE;
+    --faint:    #6B7683;
+    --rule:     #272E37;
+    --accent:   #58B5A8;
+    --accent-soft: #16302E;
+    --explicit:     #7FA3C2;
+    --corroborated: #5DB98C;
+    --inferred:     #D2A055;
+    --held:     #5DB98C;
+    --violated: #D97A6C;
+  }
+}
+:root[data-theme="dark"] {
+  --ground:#101317; --surface:#171B21; --sunk:#1D222A; --ink:#E4E8ED;
+  --muted:#98A2AE; --faint:#6B7683; --rule:#272E37; --accent:#58B5A8;
+  --accent-soft:#16302E; --explicit:#7FA3C2; --corroborated:#5DB98C;
+  --inferred:#D2A055; --held:#5DB98C; --violated:#D97A6C;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0; background: var(--ground); color: var(--ink);
+  font-family: var(--sans); font-size: 15px; line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+}
+.wrap { max-width: 62rem; margin: 0 auto; padding: 3.5rem 1.5rem 6rem; }
+.lede { max-width: 38rem; }
+
+h1 {
+  font-family: var(--serif); font-size: clamp(1.9rem, 4vw, 2.6rem);
+  line-height: 1.15; margin: 0 0 .4rem; text-wrap: balance; font-weight: 600;
+}
+.sub { color: var(--muted); margin: 0 0 2rem; font-size: 1.02rem; }
+h2 {
+  font-family: var(--serif); font-size: 1.35rem; font-weight: 600;
+  margin: 3.5rem 0 1rem; padding-bottom: .5rem; border-bottom: 1px solid var(--rule);
+}
+h4 {
+  font-size: .72rem; text-transform: uppercase; letter-spacing: .09em;
+  color: var(--faint); margin: 0 0 .55rem; font-weight: 600;
+}
+h4 .count { text-transform: none; letter-spacing: 0; color: var(--muted); font-weight: 400; }
+p { margin: 0 0 .9rem; }
+code, .mono { font-family: var(--mono); font-size: .86em; }
+
+.note {
+  background: var(--accent-soft); border-left: 3px solid var(--accent);
+  padding: 1rem 1.15rem; margin: 1.5rem 0 0; max-width: 38rem;
+}
+.note p { margin: 0; font-size: .93rem; }
+.note strong { color: var(--accent); }
+
+.stats { display: flex; flex-wrap: wrap; gap: 1px; background: var(--rule);
+  border: 1px solid var(--rule); margin: 2rem 0 .75rem; }
+.stat { background: var(--surface); padding: .9rem 1.15rem; flex: 1 1 8rem; }
+.stat .n { font-size: 1.6rem; font-family: var(--serif); font-variant-numeric: tabular-nums;
+  line-height: 1.1; display: block; }
+.stat .l { font-size: .72rem; text-transform: uppercase; letter-spacing: .07em; color: var(--faint); }
+.stat.good .n { color: var(--held); }
+
+.tiers { display: flex; height: 2rem; border: 1px solid var(--rule); overflow: hidden; }
+.tb { display: flex; align-items: center; justify-content: center; min-width: 0; }
+.tb span { font-size: .7rem; color: #fff; letter-spacing: .04em; white-space: nowrap;
+  padding: 0 .4rem; overflow: hidden; text-overflow: ellipsis; }
+.tb.tier-explicit { background: var(--explicit); }
+.tb.tier-corroborated { background: var(--corroborated); }
+.tb.tier-inferred { background: var(--inferred); }
+.caption { font-size: .82rem; color: var(--faint); margin: .5rem 0 0; }
+
+.q {
+  background: var(--surface); border: 1px solid var(--rule);
+  padding: 1.5rem 1.6rem 1.1rem; margin: 0 0 1.25rem;
+}
+.q-head { display: flex; align-items: baseline; gap: 1rem; flex-wrap: wrap;
+  padding-bottom: .85rem; margin-bottom: .95rem; border-bottom: 1px solid var(--rule); }
+.q-id { font-family: var(--mono); font-size: 1.05rem; font-weight: 700; color: var(--accent); }
+.q-meta { display: flex; gap: .45rem; flex-wrap: wrap; align-items: center; margin-left: auto; }
+.cat { font-size: .82rem; color: var(--muted); }
+.meta-chip {
+  font-family: var(--mono); font-size: .7rem; padding: .16rem .5rem;
+  background: var(--sunk); color: var(--muted); border-radius: 2px; white-space: nowrap;
+}
+.meta-chip.mode-why { color: var(--accent); }
+.meta-chip.mode-impact { color: var(--explicit); }
+.meta-chip.ans { color: var(--held); }
+.meta-chip.noans { color: var(--muted); }
+
+.query { margin-bottom: .45rem; }
+.q-label, .v-label, .verify-label, .contract-label {
+  font-size: .68rem; text-transform: uppercase; letter-spacing: .09em;
+  color: var(--faint); font-weight: 600; margin-right: .5rem;
+}
+.query code { background: var(--sunk); padding: .18rem .45rem; border-radius: 2px; }
+.intent { color: var(--muted); font-size: .93rem; max-width: 46rem; }
+
+.contract { background: var(--sunk); padding: .75rem .95rem; margin: 0 0 1.1rem;
+  border-left: 3px solid var(--faint); }
+.contract.held { border-left-color: var(--held); }
+.contract.violated { border-left-color: var(--violated); }
+.contract p { margin: .3rem 0 0; font-size: .88rem; color: var(--muted); }
+.contract-state { font-family: var(--mono); font-size: .74rem; font-weight: 700; }
+.contract.held .contract-state { color: var(--held); }
+.contract.violated .contract-state { color: var(--violated); }
+
+.block { margin: 0 0 1.15rem; }
+table.cands { width: 100%; border-collapse: collapse; font-size: .86rem; }
+table.cands th { text-align: left; font-weight: 600; font-size: .7rem;
+  text-transform: uppercase; letter-spacing: .06em; color: var(--faint);
+  padding: .25rem .5rem .25rem 0; border-bottom: 1px solid var(--rule); }
+table.cands td { padding: .32rem .5rem .32rem 0; border-bottom: 1px solid var(--rule);
+  vertical-align: top; }
+table.cands tr.chosen td { font-weight: 600; }
+table.cands tr.chosen td:first-child { box-shadow: inset 2px 0 0 var(--accent); padding-left: .5rem; }
+td.num { font-variant-numeric: tabular-nums; text-align: right; }
+
+ul.paths { list-style: none; margin: 0; padding: 0; display: flex;
+  flex-direction: column; gap: .75rem; }
+.path-head { display: flex; gap: .5rem; align-items: center; margin-bottom: .3rem; }
+.path-n { font-size: .7rem; text-transform: uppercase; letter-spacing: .07em; color: var(--faint); }
+.depth { font-size: .74rem; color: var(--faint); font-family: var(--mono); }
+.trace { font-family: var(--mono); font-size: .8rem; background: var(--sunk);
+  padding: .7rem .85rem; overflow-x: auto; border-radius: 2px; }
+.node { white-space: nowrap; padding: .1rem 0; }
+.node-start { font-weight: 700; }
+.step { display: flex; gap: .5rem; align-items: center; padding: .12rem 0 .12rem 1.1rem;
+  border-left: 1px solid var(--rule); margin-left: .35rem; white-space: nowrap; }
+.conn { color: var(--faint); }
+.etype { color: var(--ink); font-weight: 600; }
+.extractor { color: var(--faint); font-size: .92em; }
+.ref { color: var(--faint); font-size: .88em; opacity: .75; }
+
+.tier { font-size: .66rem; text-transform: uppercase; letter-spacing: .05em;
+  padding: .08rem .4rem; border-radius: 2px; color: #fff; font-weight: 600;
+  font-family: var(--mono); }
+.tier-explicit { background: var(--explicit); }
+.tier-corroborated { background: var(--corroborated); }
+.tier-inferred { background: var(--inferred); }
+
+.empty { color: var(--muted); font-size: .89rem; font-style: italic; list-style: none; }
+.more summary { cursor: pointer; font-size: .82rem; color: var(--accent); padding: .2rem 0; }
+.more ul { margin-top: .7rem; }
+
+.verify { border-top: 1px solid var(--rule); padding-top: .8rem; margin-top: .3rem; }
+.verify p { margin: .25rem 0 0; font-size: .9rem; color: var(--muted); max-width: 46rem; }
+
+.verdict { display: flex; align-items: center; gap: .9rem; flex-wrap: wrap;
+  margin-top: 1rem; padding-top: .85rem; border-top: 2px solid var(--rule); }
+.verdict label { font-size: .87rem; display: flex; align-items: center; gap: .3rem;
+  cursor: pointer; color: var(--muted); }
+.verdict input[type=radio] { accent-color: var(--accent); }
+.verdict.done { border-top-color: var(--accent); }
+.v-note { flex: 1 1 12rem; min-width: 8rem; font-family: var(--sans); font-size: .85rem;
+  padding: .3rem .5rem; border: 1px solid var(--rule); background: var(--ground);
+  color: var(--ink); border-radius: 2px; }
+input:focus-visible, summary:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+
+.bar { position: sticky; bottom: 0; background: var(--surface); border-top: 1px solid var(--rule);
+  padding: .8rem 1.5rem; display: flex; gap: 1rem; align-items: center; flex-wrap: wrap;
+  margin: 2rem -1.5rem -6rem; }
+.bar .prog { font-size: .88rem; color: var(--muted); font-variant-numeric: tabular-nums; }
+button { font-family: var(--sans); font-size: .86rem; padding: .42rem .9rem;
+  background: var(--accent); color: #fff; border: none; border-radius: 2px; cursor: pointer; }
+button.ghost { background: transparent; color: var(--muted); border: 1px solid var(--rule); }
+button:hover { opacity: .9; }
+@media (prefers-reduced-motion: reduce) { * { transition: none !important; } }
+</style>
+
+<div class="wrap">
+  <div class="lede">
+    <h1>Evaluation worksheet</h1>
+    <p class="sub">Decision Graph against <code>pallets/flask</code> — PRD v3.1 §9.
+    18 queries: 2 flagship plus 16 harder cases. Generated 2026-08-12 19:52.</p>
+
+    <div class="note">
+      <p><strong>Nothing here is graded.</strong> §9 requires answers checked against the
+      repository's real history, and a system scoring its own output against its own graph
+      would be measuring self-consistency, not correctness. Every verdict below is blank
+      and waiting for you. The one thing the runner does assert is the
+      <em>engine contract</em> — mechanical properties like “must return no answer for an
+      artifact outside the window” — because those are claims about the code, not about flask.</p>
+    </div>
+  </div>
+
+  <div class="stats">
+    <div class="stat"><span class="n">18</span><span class="l">queries</span></div>
+    <div class="stat"><span class="n">12</span><span class="l">answered</span></div>
+    <div class="stat"><span class="n">6</span><span class="l">returned nothing</span></div>
+    <div class="stat good"><span class="n">4/4</span><span class="l">contracts held</span></div>
+  </div>
+
+  <div class="tiers"><span class="tb tier-explicit" style="flex:41"><span>explicit 41</span></span><span class="tb tier-corroborated" style="flex:30"><span>corroborated 30</span></span></div>
+  <p class="caption">Evidence tier across every path returned. No path used the inferred
+  fallback — the graph holds no inferred edges, so that branch is exercised only by the
+  seeded fixture in the test suite.</p>
+
+  <h2>Point-in-time control</h2>
+  <p>T1 and T2 re-run the two flagship queries through the <code>valid_from</code>/<code>valid_to</code>
+  window. If the time filter were silently ignored, both would be unchanged.</p>
+  <div class="stats">
+    <div class="stat"><span class="n">1 → 0</span><span class="l">F1 → T1, as of 2025-06</span></div>
+    <div class="stat"><span class="n">17 → 17</span><span class="l">F2 → T2, as of 2026-12</span></div>
+  </div>
+  <p class="caption">The past query collapses to nothing; the future query is unchanged.
+  The filter restricts in one direction only, which is the expected behaviour.</p>
+
+  <h2>Queries</h2>
+  
+  <article class="q" id="q-F1">
+    <header class="q-head">
+      <div class="q-id">F1</div>
+      <div class="q-meta">
+        <span class="cat">Flagship</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>change default redirect code to 303</code></p>
+    <p class="intent">Why did Flask change its default redirect status code?</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:485</td>
+              <td>change default redirect code to 303</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">decision:930</td>
+              <td>change default redirect code to 303</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:530</td>
+              <td>redirect defaults to 303</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.62</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">1 path</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:485 — change default redirect code to 303</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">motivated_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5898</span>
+      </div>
+      <div class="node">decision:930 — change default redirect code to 303</div>
+      </div>
+    </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Does the reconstructed chain (issue -&gt; decision -&gt; implementing PR/commit) match how this actually happened in flask? Is the motivating issue genuinely the &#x27;why&#x27;?</p></div>
+
+    <footer class="verdict" data-q="F1">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-F1" value="correct"> correct</label>
+      <label><input type="radio" name="v-F1" value="partial"> partial</label>
+      <label><input type="radio" name="v-F1" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="F1">
+    </footer>
+  </article>
+  <article class="q" id="q-F2">
+    <header class="q-head">
+      <div class="q-id">F2</div>
+      <div class="q-meta">
+        <span class="cat">Flagship</span>
+        <span class="meta-chip mode-impact">impact</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>Looser type annotations for send_file() path_or_file argument</code></p>
+    <p class="intent">If this change were reverted, what is affected?</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:51</td>
+              <td>Looser type annotations for send_file() path_or_file argument</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">decision:920</td>
+              <td>Looser type annotations for send_file() path_or_file argument</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:41</td>
+              <td>Loosen send_file type annotation to include typing.IO[bytes]</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.40</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">17 paths</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 2</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
+      </div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 3</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 4</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">45eb69f8bac0e4905c8f511a86b8c6705d33ff74</span>
+      </div>
+      <div class="node">commit:43 — Update helpers.pyLoosen send_file type annotation to include t.IO[bytes]  Include typing.IO[bytes] to align with Werkzeug and resolve issue #5776.</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 5</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:53 — Session is not updated on redirect target endpoint in tests</div>
+      </div>
+    </li>
+        <li class="more">
+          <details>
+            <summary>12 further paths</summary>
+            <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 6</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
+      </div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">d44f1c65239c3e33509224aa1931631243dbfa7f</span>
+      </div>
+      <div class="node">commit:66 — relax type hint for bytes io</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 7</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:104 — `stream_with_context` does not work with async routes</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 8</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5777</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 9</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5776</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 10</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5786</span>
+      </div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 11</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5774</span>
+      </div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 12</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5776</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5777</span>
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 13</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:53 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5797</span>
+      </div>
+      <div class="node">pull_request:76 — push preserved contexts in correct order</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 14</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5786</span>
+      </div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5797</span>
+      </div>
+      <div class="node">pull_request:76 — push preserved contexts in correct order</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 15</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:104 — `stream_with_context` does not work with async routes</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:100 — refactor stream_with_context for async views</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 16</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5774</span>
+      </div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5799</span>
+      </div>
+      <div class="node">pull_request:100 — refactor stream_with_context for async views</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 17</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5777</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5776</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      </div>
+    </li></ul>
+          </details>
+        </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Are the reached artifacts (PR, commits, release 3.1.2) genuinely downstream of this change? Is release 3.1.2 the correct shipping vehicle?</p></div>
+
+    <footer class="verdict" data-q="F2">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-F2" value="correct"> correct</label>
+      <label><input type="radio" name="v-F2" value="partial"> partial</label>
+      <label><input type="radio" name="v-F2" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="F2">
+    </footer>
+  </article>
+  <article class="q" id="q-H1">
+    <header class="q-head">
+      <div class="q-id">H1</div>
+      <div class="q-meta">
+        <span class="cat">Causal reconstruction</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>Config.from_file() missing ENOTDIR in silent error handling</code></p>
+    <p class="intent">Hardest clustering case: this issue was closed by FIVE distinct sources (3 PRs + 2 commits), all merged into one thread.</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:576</td>
+              <td>Config.from_file() missing ENOTDIR in silent error handling</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">decision:932</td>
+              <td>Config.from_file() missing ENOTDIR in silent error handling</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:704</td>
+              <td>Fix Config.from_file silent error handling to include ENOTDIR</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.72</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">1 path</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">motivated_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5913</span>
+      </div>
+      <div class="node">decision:932 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      </div>
+    </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Should all five sources belong to one decision? Did flask really resolve this across multiple PRs, or are some unrelated?</p></div>
+
+    <footer class="verdict" data-q="H1">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H1" value="correct"> correct</label>
+      <label><input type="radio" name="v-H1" value="partial"> partial</label>
+      <label><input type="radio" name="v-H1" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H1">
+    </footer>
+  </article>
+  <article class="q" id="q-H2">
+    <header class="q-head">
+      <div class="q-id">H2</div>
+      <div class="q-meta">
+        <span class="cat">Causal reconstruction</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>merge app and request contexts into a single context</code></p>
+    <p class="intent">A genuine architectural decision, not a bug fix.</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:198</td>
+              <td>merge app and request contexts into a single context</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">decision:923</td>
+              <td>merge app and request contexts into a single context</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:786</td>
+              <td>merge app and request context</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.66</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">1 path</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:198 — merge app and request contexts into a single context</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">motivated_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5812</span>
+      </div>
+      <div class="node">decision:923 — merge app and request contexts into a single context</div>
+      </div>
+    </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Is the causal chain right? This is the kind of decision the system exists to reconstruct.</p></div>
+
+    <footer class="verdict" data-q="H2">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H2" value="correct"> correct</label>
+      <label><input type="radio" name="v-H2" value="partial"> partial</label>
+      <label><input type="radio" name="v-H2" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H2">
+    </footer>
+  </article>
+  <article class="q" id="q-H3">
+    <header class="q-head">
+      <div class="q-id">H3</div>
+      <div class="q-meta">
+        <span class="cat">Causal reconstruction</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>Recommend Warning and Safer Defaults for url_for(..., _external=True)</code></p>
+    <p class="intent">A CORROBORATED thread (3 of 4 categories, via ATTESTED). Tier should read corroborated, not explicit.</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:49</td>
+              <td>Recommend Warning and Safer Defaults for url_for(..., _external=True)</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">decision:918</td>
+              <td>Recommend Warning and Safer Defaults for url_for(..., _external=True)</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:55</td>
+              <td>docs: add warning and best practices for url_for(..., _external=True)…</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.44</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">1 path</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:49 — Recommend Warning and Safer Defaults for url_for(..., _external=True)</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">motivated_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5722</span>
+      </div>
+      <div class="node">decision:918 — Recommend Warning and Safer Defaults for url_for(..., _external=True)</div>
+      </div>
+    </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Is the chain correct, AND does the corroborated tier feel justified by the underlying evidence?</p></div>
+
+    <footer class="verdict" data-q="H3">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H3" value="correct"> correct</label>
+      <label><input type="radio" name="v-H3" value="partial"> partial</label>
+      <label><input type="radio" name="v-H3" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H3">
+    </footer>
+  </article>
+  <article class="q" id="q-H4">
+    <header class="q-head">
+      <div class="q-id">H4</div>
+      <div class="q-meta">
+        <span class="cat">Causal reconstruction</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>deprecate `should_ignore_error`</code></p>
+    <p class="intent">A deprecation decision spanning 2 PRs and 3 commits.</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:481</td>
+              <td>deprecate `should_ignore_error`</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:491</td>
+              <td>deprecate `should_ignore_error`</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">commit:493</td>
+              <td>deprecate should_ignore_error</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">1 path</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:481 — deprecate `should_ignore_error`</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">motivated_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5867</span>
+      </div>
+      <div class="node">decision:928 — deprecate `should_ignore_error`</div>
+      </div>
+    </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Does the reconstruction capture the deprecation rationale?</p></div>
+
+    <footer class="verdict" data-q="H4">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H4" value="correct"> correct</label>
+      <label><input type="radio" name="v-H4" value="partial"> partial</label>
+      <label><input type="radio" name="v-H4" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H4">
+    </footer>
+  </article>
+  <article class="q" id="q-H5">
+    <header class="q-head">
+      <div class="q-id">H5</div>
+      <div class="q-meta">
+        <span class="cat">Retrieval</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>#5898</code></p>
+    <p class="intent">Bare identifier retrieval — the form an impact query normally arrives in.</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">pull_request:530</td>
+              <td>redirect defaults to 303</td>
+              <td class="mono">identifier</td>
+              <td class="num">0.95</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">1 path</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">pull_request:530 — redirect defaults to 303</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5898</span>
+      </div>
+      <div class="node">decision:930 — change default redirect code to 303</div>
+      </div>
+    </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Did retrieval resolve #5898 to the right artifact? Same answer as F1 reached by a different route?</p></div>
+
+    <footer class="verdict" data-q="H5">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H5" value="correct"> correct</label>
+      <label><input type="radio" name="v-H5" value="partial"> partial</label>
+      <label><input type="radio" name="v-H5" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H5">
+    </footer>
+  </article>
+  <article class="q" id="q-H6">
+    <header class="q-head">
+      <div class="q-id">H6</div>
+      <div class="q-meta">
+        <span class="cat">Retrieval</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip noans">no answer</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>c8ecf241e3605c48ac84ab863c206f1072888668</code></p>
+    <p class="intent">Retrieval by full commit SHA.</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">commit:574</td>
+              <td>Fix Config.from_file() silent mode not handling ENOTDIR</td>
+              <td class="mono">identifier</td>
+              <td class="num">0.95</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">0 paths</span></h4>
+      <ul class="paths"><li class="empty">No path returned. <span class="mono">no path found, explicit or inferred</span></li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Does the commit resolve, and does its Why chain reach the right decision?</p></div>
+
+    <footer class="verdict" data-q="H6">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H6" value="correct"> correct</label>
+      <label><input type="radio" name="v-H6" value="partial"> partial</label>
+      <label><input type="radio" name="v-H6" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H6">
+    </footer>
+  </article>
+  <article class="q" id="q-H7">
+    <header class="q-head">
+      <div class="q-id">H7</div>
+      <div class="q-meta">
+        <span class="cat">Retrieval</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>template_filter decorator broken</code></p>
+    <p class="intent">Fuzzy retrieval — the query wording does not match the issue title, which is &#x27;The `template_filter` decorator doesn&#x27;t work if you don&#x27;t pass an argument&#x27;.</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:80</td>
+              <td>The `template_filter` decorator doesn&#x27;t work if you don&#x27;t pass an argument</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.36</td>
+            </tr><tr>
+              <td class="mono">decision:919</td>
+              <td>The `template_filter` decorator doesn&#x27;t work if you don&#x27;t pass an argument</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.36</td>
+            </tr><tr>
+              <td class="mono">commit:94</td>
+              <td>rewrite docs, clean up typing for template decorators</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.32</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">1 path</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:80 — The `template_filter` decorator doesn&#x27;t work if you don&#x27;t pass an argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">motivated_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5735</span>
+      </div>
+      <div class="node">decision:919 — The `template_filter` decorator doesn&#x27;t work if you don&#x27;t pass an argument</div>
+      </div>
+    </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Did trigram matching find the right entity despite the paraphrase? Would a reasonable user consider this the right hit?</p></div>
+
+    <footer class="verdict" data-q="H7">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H7" value="correct"> correct</label>
+      <label><input type="radio" name="v-H7" value="partial"> partial</label>
+      <label><input type="radio" name="v-H7" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H7">
+    </footer>
+  </article>
+  <article class="q" id="q-H8">
+    <header class="q-head">
+      <div class="q-id">H8</div>
+      <div class="q-meta">
+        <span class="cat">Impact analysis</span>
+        <span class="meta-chip mode-impact">impact</span>
+        <span class="meta-chip">depth 2</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>3.1.2</code></p>
+    <p class="intent">Impact from a release — what shipped in it?</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">release:961</td>
+              <td>3.1.2</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">release:971</td>
+              <td>2.3.1</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">release:978</td>
+              <td>2.1.3</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">13 paths</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 2</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:53 — Session is not updated on redirect target endpoint in tests</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 3</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:104 — `stream_with_context` does not work with async routes</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 4</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5776</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 5</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5786</span>
+      </div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      </div>
+    </li>
+        <li class="more">
+          <details>
+            <summary>8 further paths</summary>
+            <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 6</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5774</span>
+      </div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 7</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 8</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5776</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5777</span>
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 9</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
+      </div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 10</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:53 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5797</span>
+      </div>
+      <div class="node">pull_request:76 — push preserved contexts in correct order</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 11</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5786</span>
+      </div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5797</span>
+      </div>
+      <div class="node">pull_request:76 — push preserved contexts in correct order</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 12</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:104 — `stream_with_context` does not work with async routes</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:100 — refactor stream_with_context for async views</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 13</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5774</span>
+      </div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5799</span>
+      </div>
+      <div class="node">pull_request:100 — refactor stream_with_context for async views</div>
+      </div>
+    </li></ul>
+          </details>
+        </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Are the reached issues genuinely the contents of 3.1.2, per flask&#x27;s actual release notes?</p></div>
+
+    <footer class="verdict" data-q="H8">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H8" value="correct"> correct</label>
+      <label><input type="radio" name="v-H8" value="partial"> partial</label>
+      <label><input type="radio" name="v-H8" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H8">
+    </footer>
+  </article>
+  <article class="q" id="q-H9">
+    <header class="q-head">
+      <div class="q-id">H9</div>
+      <div class="q-meta">
+        <span class="cat">Impact analysis</span>
+        <span class="meta-chip mode-impact">impact</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>Config.from_file() missing ENOTDIR in silent error handling</code></p>
+    <p class="intent">Forward traversal over the 5-source cluster.</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:576</td>
+              <td>Config.from_file() missing ENOTDIR in silent error handling</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">decision:932</td>
+              <td>Config.from_file() missing ENOTDIR in silent error handling</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:704</td>
+              <td>Fix Config.from_file silent error handling to include ENOTDIR</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.72</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">12 paths</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:572 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 2</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">commit:574 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 3</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5914</span>
+      </div>
+      <div class="node">pull_request:578 — add ENOTDIR to from_file silent error handling</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 4</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5944</span>
+      </div>
+      <div class="node">pull_request:651 — Add ENOTDIR handling to Config.from_file with silent=True</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 5</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">6422bf669e29db4dccebb17becf1f22f1a1634bf</span>
+      </div>
+      <div class="node">commit:706 — Fix Config.from_file silent error handling to include ENOTDIR</div>
+      </div>
+    </li>
+        <li class="more">
+          <details>
+            <summary>7 further paths</summary>
+            <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 6</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">commit:574 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">c8ecf241e3605c48ac84ab863c206f1072888668</span>
+      </div>
+      <div class="node">pull_request:572 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 7</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:572 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">c8ecf241e3605c48ac84ab863c206f1072888668</span>
+      </div>
+      <div class="node">commit:574 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 8</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5914</span>
+      </div>
+      <div class="node">pull_request:578 — add ENOTDIR to from_file silent error handling</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">560ea7fd409c839bc85382a05b6e1bd1d7ca8795</span>
+      </div>
+      <div class="node">commit:580 — add ENOTDIR to from_file silent error handling</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 9</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5944</span>
+      </div>
+      <div class="node">pull_request:651 — Add ENOTDIR handling to Config.from_file with silent=True</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">14c80085434894d5a26a4e1cee7f4f4f3b97d9ce</span>
+      </div>
+      <div class="node">commit:653 — Add ENOTDIR handling to Config.from_file with silent=True</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 10</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">6422bf669e29db4dccebb17becf1f22f1a1634bf</span>
+      </div>
+      <div class="node">commit:706 — Fix Config.from_file silent error handling to include ENOTDIR</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">6422bf669e29db4dccebb17becf1f22f1a1634bf</span>
+      </div>
+      <div class="node">pull_request:704 — Fix Config.from_file silent error handling to include ENOTDIR</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 11</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:572 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5913</span>
+      </div>
+      <div class="node">decision:932 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 12</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">commit:574 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">c8ecf241e3605c48ac84ab863c206f1072888668</span>
+      </div>
+      <div class="node">pull_request:572 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5913</span>
+      </div>
+      <div class="node">decision:932 — Config.from_file() missing ENOTDIR in silent error handling</div>
+      </div>
+    </li></ul>
+          </details>
+        </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Does the blast radius look right, or does thread-merging over-connect unrelated work?</p></div>
+
+    <footer class="verdict" data-q="H9">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H9" value="correct"> correct</label>
+      <label><input type="radio" name="v-H9" value="partial"> partial</label>
+      <label><input type="radio" name="v-H9" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H9">
+    </footer>
+  </article>
+  <article class="q" id="q-H10">
+    <header class="q-head">
+      <div class="q-id">H10</div>
+      <div class="q-meta">
+        <span class="cat">Impact analysis</span>
+        <span class="meta-chip mode-impact">impact</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>asgiref fails with gevent patching</code></p>
+    <p class="intent">Impact across a 2-PR / 2-commit thread.</p>
+
+    
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:477</td>
+              <td>asgiref fails with gevent patching</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">decision:929</td>
+              <td>asgiref fails with gevent patching</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:439</td>
+              <td>clarify async view incompatibility with gevent monkey patching</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.31</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">5 paths</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:477 — asgiref fails with gevent patching</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:439 — clarify async view incompatibility with gevent monkey patching</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 2</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:477 — asgiref fails with gevent patching</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5900</span>
+      </div>
+      <div class="node">pull_request:487 — document using gevent for async</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 3</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:477 — asgiref fails with gevent patching</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:439 — clarify async view incompatibility with gevent monkey patching</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">bec6b5ba460c0d0af9daf1707219ded5eb11f321</span>
+      </div>
+      <div class="node">commit:441 — clarify async view incompatibility with gevent monkey patching</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 4</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:477 — asgiref fails with gevent patching</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5900</span>
+      </div>
+      <div class="node">pull_request:487 — document using gevent for async</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">ac5664d2281533eacafd64f5cc7d5edcdaccab60</span>
+      </div>
+      <div class="node">commit:489 — document using gevent for async</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 5</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:477 — asgiref fails with gevent patching</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:439 — clarify async view incompatibility with gevent monkey patching</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5885</span>
+      </div>
+      <div class="node">decision:929 — asgiref fails with gevent patching</div>
+      </div>
+    </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Are all reached artifacts genuinely affected by a revert?</p></div>
+
+    <footer class="verdict" data-q="H10">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-H10" value="correct"> correct</label>
+      <label><input type="radio" name="v-H10" value="partial"> partial</label>
+      <label><input type="radio" name="v-H10" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="H10">
+    </footer>
+  </article>
+  <article class="q" id="q-N1">
+    <header class="q-head">
+      <div class="q-id">N1</div>
+      <div class="q-meta">
+        <span class="cat">Correct refusal</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip noans">no answer</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>package detection fails with namespace package in project layout</code></p>
+    <p class="intent">An issue in a thread with NO Decision — it did not meet the §5.1 rubric.</p>
+
+    
+        <div class="contract held">
+          <span class="contract-label">Engine contract</span>
+          <span class="contract-state">HELD</span>
+          <p>Must return no answer. The system must not invent a decision where the rubric declined to assert one.</p>
+        </div>
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:536</td>
+              <td>package detection fails with namespace package in editable mode</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.60</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">0 paths</span></h4>
+      <ul class="paths"><li class="empty">No path returned. <span class="mono">no path found, explicit or inferred</span></li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Confirm flask genuinely has no recorded decision resolving this, i.e. the refusal is correct rather than a miss.</p></div>
+
+    <footer class="verdict" data-q="N1">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-N1" value="correct"> correct</label>
+      <label><input type="radio" name="v-N1" value="partial"> partial</label>
+      <label><input type="radio" name="v-N1" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="N1">
+    </footer>
+  </article>
+  <article class="q" id="q-N2">
+    <header class="q-head">
+      <div class="q-id">N2</div>
+      <div class="q-meta">
+        <span class="cat">Correct refusal</span>
+        <span class="meta-chip mode-impact">impact</span>
+        <span class="meta-chip">depth 2</span>
+        
+        <span class="meta-chip noans">no answer</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>davidism</code></p>
+    <p class="intent">Impact from a person. Authorship edges (`created`) are deliberately excluded from the impact edge set.</p>
+
+    
+        <div class="contract held">
+          <span class="contract-label">Engine contract</span>
+          <span class="contract-state">HELD</span>
+          <p>Must return no answer. &#x27;Everything this person touched&#x27; is a Bus Factor / Expert Finder query, explicitly out of scope for v1 (§6).</p>
+        </div>
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">person:57</td>
+              <td>davidism</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">0 paths</span></h4>
+      <ul class="paths"><li class="empty">No path returned. <span class="mono">no path found, explicit or inferred</span></li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Confirm the empty answer is the right behaviour rather than a gap worth closing.</p></div>
+
+    <footer class="verdict" data-q="N2">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-N2" value="correct"> correct</label>
+      <label><input type="radio" name="v-N2" value="partial"> partial</label>
+      <label><input type="radio" name="v-N2" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="N2">
+    </footer>
+  </article>
+  <article class="q" id="q-N3">
+    <header class="q-head">
+      <div class="q-id">N3</div>
+      <div class="q-meta">
+        <span class="cat">Correct refusal</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip noans">no answer</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>quantum entanglement middleware autoscaler</code></p>
+    <p class="intent">Retrieval finds nothing at all.</p>
+
+    
+        <div class="contract held">
+          <span class="contract-label">Engine contract</span>
+          <span class="contract-state">HELD</span>
+          <p>Must return no candidates and say so, rather than fuzzy-matching to an unrelated entity.</p>
+        </div>
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      <p class="empty">No candidate start node matched.</p>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">0 paths</span></h4>
+      <ul class="paths"><li class="empty">No path returned. <span class="mono">retrieval returned no candidate start node</span></li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Confirm no spurious candidate was returned above the 0.25 trigram floor.</p></div>
+
+    <footer class="verdict" data-q="N3">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-N3" value="correct"> correct</label>
+      <label><input type="radio" name="v-N3" value="partial"> partial</label>
+      <label><input type="radio" name="v-N3" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="N3">
+    </footer>
+  </article>
+  <article class="q" id="q-N4">
+    <header class="q-head">
+      <div class="q-id">N4</div>
+      <div class="q-meta">
+        <span class="cat">Correct refusal</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        
+        <span class="meta-chip noans">no answer</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>#2581</code></p>
+    <p class="intent">An issue referenced by in-window artifacts but itself OUTSIDE the 12-month window. It sits unresolved in pending_reference with 7 attempts.</p>
+
+    
+        <div class="contract held">
+          <span class="contract-label">Engine contract</span>
+          <span class="contract-state">HELD</span>
+          <p>Must return no answer. The bounded window is a deliberate limit; the system must not fabricate a chain for an artifact it never ingested.</p>
+        </div>
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      <p class="empty">No candidate start node matched.</p>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">0 paths</span></h4>
+      <ul class="paths"><li class="empty">No path returned. <span class="mono">retrieval returned no candidate start node</span></li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Confirm the honest &#x27;not in graph&#x27; outcome, and that the pending queue records it rather than silently dropping it.</p></div>
+
+    <footer class="verdict" data-q="N4">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-N4" value="correct"> correct</label>
+      <label><input type="radio" name="v-N4" value="partial"> partial</label>
+      <label><input type="radio" name="v-N4" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="N4">
+    </footer>
+  </article>
+  <article class="q" id="q-T1">
+    <header class="q-head">
+      <div class="q-id">T1</div>
+      <div class="q-meta">
+        <span class="cat">Point-in-time</span>
+        <span class="meta-chip mode-why">why</span>
+        <span class="meta-chip">depth 3</span>
+        <span class="meta-chip">as of 2025-06-01</span>
+        <span class="meta-chip noans">no answer</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>change default redirect code to 303</code></p>
+    <p class="intent">Point-in-time query BEFORE this decision existed, using the valid_from/valid_to window.</p>
+
+    
+        <div class="contract compare">
+          <span class="contract-label">Engine contract</span>
+          <span class="contract-state">COMPARE</span>
+          <p>Must return fewer paths than F1 — ideally none. Edges whose valid_from postdates the as-of instant must not be traversed.</p>
+        </div>
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:485</td>
+              <td>change default redirect code to 303</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">decision:930</td>
+              <td>change default redirect code to 303</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:530</td>
+              <td>redirect defaults to 303</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.62</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">0 paths</span></h4>
+      <ul class="paths"><li class="empty">No path returned. <span class="mono">no path found, explicit or inferred</span></li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Confirm the time filter genuinely restricts the answer rather than being ignored.</p></div>
+
+    <footer class="verdict" data-q="T1">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-T1" value="correct"> correct</label>
+      <label><input type="radio" name="v-T1" value="partial"> partial</label>
+      <label><input type="radio" name="v-T1" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="T1">
+    </footer>
+  </article>
+  <article class="q" id="q-T2">
+    <header class="q-head">
+      <div class="q-id">T2</div>
+      <div class="q-meta">
+        <span class="cat">Point-in-time</span>
+        <span class="meta-chip mode-impact">impact</span>
+        <span class="meta-chip">depth 3</span>
+        <span class="meta-chip">as of 2026-12-31</span>
+        <span class="meta-chip ans">answered</span>
+      </div>
+    </header>
+
+    <p class="query"><span class="q-label">Query</span> <code>Looser type annotations for send_file() path_or_file argument</code></p>
+    <p class="intent">Point-in-time query AFTER everything — control for T1.</p>
+
+    
+        <div class="contract compare">
+          <span class="contract-label">Engine contract</span>
+          <span class="contract-state">COMPARE</span>
+          <p>Must return the same paths as F2. If T1 shrinks and T2 does not, the time filter is working in both directions.</p>
+        </div>
+
+    <section class="block">
+      <h4>Retrieval candidates</h4>
+      
+      <table class="cands">
+        <thead><tr><th>node</th><th>title</th><th>match</th><th>score</th></tr></thead>
+        <tbody><tr class="chosen">
+              <td class="mono">issue:51</td>
+              <td>Looser type annotations for send_file() path_or_file argument</td>
+              <td class="mono">exact</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">decision:920</td>
+              <td>Looser type annotations for send_file() path_or_file argument</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">1.00</td>
+            </tr><tr>
+              <td class="mono">pull_request:41</td>
+              <td>Loosen send_file type annotation to include typing.IO[bytes]</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.40</td>
+            </tr></tbody>
+      </table>
+    </section>
+
+    <section class="block">
+      <h4>Traversal <span class="count">17 paths</span></h4>
+      <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 1</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 2</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
+      </div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 3</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">1 hop</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 4</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">45eb69f8bac0e4905c8f511a86b8c6705d33ff74</span>
+      </div>
+      <div class="node">commit:43 — Update helpers.pyLoosen send_file type annotation to include t.IO[bytes]  Include typing.IO[bytes] to align with Werkzeug and resolve issue #5776.</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 5</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:53 — Session is not updated on redirect target endpoint in tests</div>
+      </div>
+    </li>
+        <li class="more">
+          <details>
+            <summary>12 further paths</summary>
+            <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 6</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
+      </div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">d44f1c65239c3e33509224aa1931631243dbfa7f</span>
+      </div>
+      <div class="node">commit:66 — relax type hint for bytes io</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 7</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:104 — `stream_with_context` does not work with async routes</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 8</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5777</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 9</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5776</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 10</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5786</span>
+      </div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 11</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">2 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5774</span>
+      </div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 12</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5776</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5777</span>
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 13</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:53 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5797</span>
+      </div>
+      <div class="node">pull_request:76 — push preserved contexts in correct order</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 14</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5786</span>
+      </div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5797</span>
+      </div>
+      <div class="node">pull_request:76 — push preserved contexts in correct order</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 15</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">issue:104 — `stream_with_context` does not work with async routes</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:100 — refactor stream_with_context for async views</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 16</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5774</span>
+      </div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5799</span>
+      </div>
+      <div class="node">pull_request:100 — refactor stream_with_context for async views</div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 17</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">body_closing_keyword</span>
+        
+      </div>
+      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">implemented_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5777</span>
+      </div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">deployed_by</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5776</span>
+      </div>
+      <div class="node">release:961 — 3.1.2</div>
+      </div>
+    </li></ul>
+          </details>
+        </li></ul>
+    </section>
+
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Compare against F2; they should match.</p></div>
+
+    <footer class="verdict" data-q="T2">
+      <span class="v-label">Verdict</span>
+      <label><input type="radio" name="v-T2" value="correct"> correct</label>
+      <label><input type="radio" name="v-T2" value="partial"> partial</label>
+      <label><input type="radio" name="v-T2" value="incorrect"> incorrect</label>
+      <input class="v-note" type="text" placeholder="note (optional)" data-note="T2">
+    </footer>
+  </article>
+
+  <div class="bar">
+    <span class="prog" id="prog">0 of 18 adjudicated</span>
+    <button id="export">Copy verdicts</button>
+    <button class="ghost" id="clear">Clear all</button>
+  </div>
+</div>
+
+<script>
+(function () {
+  var KEY = "dg-eval-verdicts-v1";
+  var store = {};
+  try { store = JSON.parse(localStorage.getItem(KEY) || "{}"); } catch (err) { store = {}; }
+
+  function persist() {
+    try { localStorage.setItem(KEY, JSON.stringify(store)); } catch (err) { /* private mode */ }
+  }
+
+  function refresh() {
+    var ids = Object.keys(store).filter(function (k) { return store[k] && store[k].v; });
+    document.querySelectorAll(".verdict").forEach(function (f) {
+      var rec = store[f.dataset.q];
+      f.classList.toggle("done", !!(rec && rec.v));
+    });
+    document.getElementById("prog").textContent =
+      ids.length + " of " + document.querySelectorAll(".verdict").length + " adjudicated";
+  }
+
+  document.querySelectorAll(".verdict").forEach(function (f) {
+    var id = f.dataset.q;
+    var rec = store[id] || {};
+    if (rec.v) {
+      var hit = f.querySelector('input[value="' + rec.v + '"]');
+      if (hit) hit.checked = true;
+    }
+    var note = f.querySelector(".v-note");
+    if (rec.n) note.value = rec.n;
+
+    f.addEventListener("change", function (ev) {
+      if (ev.target.type !== "radio") return;
+      store[id] = Object.assign({}, store[id], { v: ev.target.value });
+      persist(); refresh();
+    });
+    note.addEventListener("input", function () {
+      store[id] = Object.assign({}, store[id], { n: note.value });
+      persist();
+    });
+  });
+
+  document.getElementById("export").addEventListener("click", function () {
+    var lines = ["Decision Graph — §9 adjudication", ""];
+    document.querySelectorAll(".verdict").forEach(function (f) {
+      var id = f.dataset.q, rec = store[id] || {};
+      lines.push(id + ": " + (rec.v || "—") + (rec.n ? "  // " + rec.n : ""));
+    });
+    var text = lines.join("\n");
+    var btn = document.getElementById("export");
+    function done() { btn.textContent = "Copied"; setTimeout(function () { btn.textContent = "Copy verdicts"; }, 1600); }
+    if (navigator.clipboard) {
+      navigator.clipboard.writeText(text).then(done, function () { window.prompt("Copy:", text); });
+    } else { window.prompt("Copy:", text); }
+  });
+
+  document.getElementById("clear").addEventListener("click", function () {
+    store = {}; persist();
+    document.querySelectorAll(".verdict input[type=radio]").forEach(function (r) { r.checked = false; });
+    document.querySelectorAll(".v-note").forEach(function (n) { n.value = ""; });
+    refresh();
+  });
+
+  refresh();
+})();
+</script>

--- a/eval/results.json
+++ b/eval/results.json
@@ -1,0 +1,2368 @@
+{
+  "about": {
+    "target_repo": "pallets/flask",
+    "window": "12 months",
+    "spec": "PRD v3.1 \u00a79 \u2014 2 flagship queries + 13-18 additional covering harder, less curated cases",
+    "adjudication": "Correctness is decided by a human against flask's actual history. The runner records what the system returned and never grades it. Where a 'contract' field appears, that is a mechanically checkable property of the engine (e.g. 'must return no answer'), not a claim about flask."
+  },
+  "generated_at": "2026-08-12T19:52:18.687698+05:30",
+  "summary": {
+    "total": 18,
+    "answered": 12,
+    "returned_no_answer": 6,
+    "contracts_checked": 4,
+    "contracts_held": 4,
+    "used_inferred_fallback": 4,
+    "adjudicated": 0
+  },
+  "results": [
+    {
+      "id": "F1",
+      "category": "flagship",
+      "mode": "why",
+      "query": "change default redirect code to 303",
+      "intent": "Why did Flask change its default redirect status code?",
+      "verify": "Does the reconstructed chain (issue -> decision -> implementing PR/commit) match how this actually happened in flask? Is the motivating issue genuinely the 'why'?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 485,
+          "node_type": "issue",
+          "external_id": "5895",
+          "title": "change default redirect code to 303",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 930,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5898",
+          "title": "change default redirect code to 303",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 530,
+          "node_type": "pull_request",
+          "external_id": "5898",
+          "title": "redirect defaults to 303",
+          "match": "fuzzy",
+          "score": 0.622
+        }
+      ],
+      "paths": [
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:485 \u2014 change default redirect code to 303",
+          "steps": [
+            {
+              "edge_type": "motivated_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5898",
+              "direction": "reverse",
+              "to_node": "decision:930 \u2014 change default redirect code to 303"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "1 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "F2",
+      "category": "flagship",
+      "mode": "impact",
+      "query": "Looser type annotations for send_file() path_or_file argument",
+      "intent": "If this change were reverted, what is affected?",
+      "verify": "Are the reached artifacts (PR, commits, release 3.1.2) genuinely downstream of this change? Is release 3.1.2 the correct shipping vehicle?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 51,
+          "node_type": "issue",
+          "external_id": "5776",
+          "title": "Looser type annotations for send_file() path_or_file argument",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 920,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5777",
+          "title": "Looser type annotations for send_file() path_or_file argument",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 41,
+          "node_type": "pull_request",
+          "external_id": "5794",
+          "title": "Loosen send_file type annotation to include typing.IO[bytes]",
+          "match": "fuzzy",
+          "score": 0.395
+        }
+      ],
+      "paths": [
+        {
+          "tier": "corroborated",
+          "depth": 1,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 1,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5777",
+              "direction": "reverse",
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "45eb69f8bac0e4905c8f511a86b8c6705d33ff74",
+              "direction": "forward",
+              "to_node": "commit:43 \u2014 Update helpers.pyLoosen send_file type annotation to include t.IO[bytes]  Include typing.IO[bytes] to align with Werkzeug and resolve issue #5776."
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:53 \u2014 Session is not updated on redirect target endpoint in tests"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5777",
+              "direction": "reverse",
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "d44f1c65239c3e33509224aa1931631243dbfa7f",
+              "direction": "forward",
+              "to_node": "commit:66 \u2014 relax type hint for bytes io"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:104 \u2014 `stream_with_context` does not work with async routes"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5777",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5776",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5786",
+              "direction": "reverse",
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5774",
+              "direction": "reverse",
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5776",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5777",
+              "direction": "forward",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:53 \u2014 Session is not updated on redirect target endpoint in tests"
+            },
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5797",
+              "direction": "reverse",
+              "to_node": "pull_request:76 \u2014 push preserved contexts in correct order"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5786",
+              "direction": "reverse",
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5797",
+              "direction": "forward",
+              "to_node": "pull_request:76 \u2014 push preserved contexts in correct order"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:104 \u2014 `stream_with_context` does not work with async routes"
+            },
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:100 \u2014 refactor stream_with_context for async views"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5774",
+              "direction": "reverse",
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5799",
+              "direction": "forward",
+              "to_node": "pull_request:100 \u2014 refactor stream_with_context for async views"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5777",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5776",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "17 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H1",
+      "category": "causal",
+      "mode": "why",
+      "query": "Config.from_file() missing ENOTDIR in silent error handling",
+      "intent": "Hardest clustering case: this issue was closed by FIVE distinct sources (3 PRs + 2 commits), all merged into one thread.",
+      "verify": "Should all five sources belong to one decision? Did flask really resolve this across multiple PRs, or are some unrelated?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 576,
+          "node_type": "issue",
+          "external_id": "5912",
+          "title": "Config.from_file() missing ENOTDIR in silent error handling",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 932,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5913",
+          "title": "Config.from_file() missing ENOTDIR in silent error handling",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 704,
+          "node_type": "pull_request",
+          "external_id": "5955",
+          "title": "Fix Config.from_file silent error handling to include ENOTDIR",
+          "match": "fuzzy",
+          "score": 0.719
+        }
+      ],
+      "paths": [
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "motivated_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5913",
+              "direction": "reverse",
+              "to_node": "decision:932 \u2014 Config.from_file() missing ENOTDIR in silent error handling"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "1 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H2",
+      "category": "causal",
+      "mode": "why",
+      "query": "merge app and request contexts into a single context",
+      "intent": "A genuine architectural decision, not a bug fix.",
+      "verify": "Is the causal chain right? This is the kind of decision the system exists to reconstruct.",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 198,
+          "node_type": "issue",
+          "external_id": "5639",
+          "title": "merge app and request contexts into a single context",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 923,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5812",
+          "title": "merge app and request contexts into a single context",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 786,
+          "node_type": "pull_request",
+          "external_id": "5812",
+          "title": "merge app and request context",
+          "match": "fuzzy",
+          "score": 0.659
+        }
+      ],
+      "paths": [
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:198 \u2014 merge app and request contexts into a single context",
+          "steps": [
+            {
+              "edge_type": "motivated_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5812",
+              "direction": "reverse",
+              "to_node": "decision:923 \u2014 merge app and request contexts into a single context"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "1 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H3",
+      "category": "causal",
+      "mode": "why",
+      "query": "Recommend Warning and Safer Defaults for url_for(..., _external=True)",
+      "intent": "A CORROBORATED thread (3 of 4 categories, via ATTESTED). Tier should read corroborated, not explicit.",
+      "verify": "Is the chain correct, AND does the corroborated tier feel justified by the underlying evidence?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 49,
+          "node_type": "issue",
+          "external_id": "5718",
+          "title": "Recommend Warning and Safer Defaults for url_for(..., _external=True)",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 918,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5722",
+          "title": "Recommend Warning and Safer Defaults for url_for(..., _external=True)",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 55,
+          "node_type": "pull_request",
+          "external_id": "5722",
+          "title": "docs: add warning and best practices for url_for(..., _external=True)\u2026",
+          "match": "fuzzy",
+          "score": 0.438
+        }
+      ],
+      "paths": [
+        {
+          "tier": "corroborated",
+          "depth": 1,
+          "start": "issue:49 \u2014 Recommend Warning and Safer Defaults for url_for(..., _external=True)",
+          "steps": [
+            {
+              "edge_type": "motivated_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5722",
+              "direction": "reverse",
+              "to_node": "decision:918 \u2014 Recommend Warning and Safer Defaults for url_for(..., _external=True)"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "1 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H4",
+      "category": "causal",
+      "mode": "why",
+      "query": "deprecate `should_ignore_error`",
+      "intent": "A deprecation decision spanning 2 PRs and 3 commits.",
+      "verify": "Does the reconstruction capture the deprecation rationale?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 481,
+          "node_type": "issue",
+          "external_id": "5816",
+          "title": "deprecate `should_ignore_error`",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 491,
+          "node_type": "pull_request",
+          "external_id": "5899",
+          "title": "deprecate `should_ignore_error`",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 493,
+          "node_type": "commit",
+          "external_id": "c77a5203438fe772d41f6a47303ad3f57a4efe6d",
+          "title": "deprecate should_ignore_error",
+          "match": "fuzzy",
+          "score": 1.0
+        }
+      ],
+      "paths": [
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:481 \u2014 deprecate `should_ignore_error`",
+          "steps": [
+            {
+              "edge_type": "motivated_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5867",
+              "direction": "reverse",
+              "to_node": "decision:928 \u2014 deprecate `should_ignore_error`"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "1 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H5",
+      "category": "retrieval",
+      "mode": "why",
+      "query": "#5898",
+      "intent": "Bare identifier retrieval \u2014 the form an impact query normally arrives in.",
+      "verify": "Did retrieval resolve #5898 to the right artifact? Same answer as F1 reached by a different route?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 530,
+          "node_type": "pull_request",
+          "external_id": "5898",
+          "title": "redirect defaults to 303",
+          "match": "identifier",
+          "score": 0.95
+        }
+      ],
+      "paths": [
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "pull_request:530 \u2014 redirect defaults to 303",
+          "steps": [
+            {
+              "edge_type": "implemented_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5898",
+              "direction": "reverse",
+              "to_node": "decision:930 \u2014 change default redirect code to 303"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "1 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H6",
+      "category": "retrieval",
+      "mode": "why",
+      "query": "c8ecf241e3605c48ac84ab863c206f1072888668",
+      "intent": "Retrieval by full commit SHA.",
+      "verify": "Does the commit resolve, and does its Why chain reach the right decision?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 574,
+          "node_type": "commit",
+          "external_id": "c8ecf241e3605c48ac84ab863c206f1072888668",
+          "title": "Fix Config.from_file() silent mode not handling ENOTDIR",
+          "match": "identifier",
+          "score": 0.95
+        }
+      ],
+      "paths": [],
+      "used_inferred_fallback": true,
+      "explanation": "no path found, explicit or inferred",
+      "answered": false,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H7",
+      "category": "retrieval",
+      "mode": "why",
+      "query": "template_filter decorator broken",
+      "intent": "Fuzzy retrieval \u2014 the query wording does not match the issue title, which is 'The `template_filter` decorator doesn't work if you don't pass an argument'.",
+      "verify": "Did trigram matching find the right entity despite the paraphrase? Would a reasonable user consider this the right hit?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 80,
+          "node_type": "issue",
+          "external_id": "5729",
+          "title": "The `template_filter` decorator doesn't work if you don't pass an argument",
+          "match": "fuzzy",
+          "score": 0.361
+        },
+        {
+          "node_id": 919,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5735",
+          "title": "The `template_filter` decorator doesn't work if you don't pass an argument",
+          "match": "fuzzy",
+          "score": 0.361
+        },
+        {
+          "node_id": 94,
+          "node_type": "commit",
+          "external_id": "edebd3704437f19b5b137eaffe97130fe817d144",
+          "title": "rewrite docs, clean up typing for template decorators",
+          "match": "fuzzy",
+          "score": 0.317
+        }
+      ],
+      "paths": [
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:80 \u2014 The `template_filter` decorator doesn't work if you don't pass an argument",
+          "steps": [
+            {
+              "edge_type": "motivated_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5735",
+              "direction": "reverse",
+              "to_node": "decision:919 \u2014 The `template_filter` decorator doesn't work if you don't pass an argument"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "1 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H8",
+      "category": "impact",
+      "mode": "impact",
+      "query": "3.1.2",
+      "intent": "Impact from a release \u2014 what shipped in it?",
+      "verify": "Are the reached issues genuinely the contents of 3.1.2, per flask's actual release notes?",
+      "contract": null,
+      "as_of": null,
+      "depth": 2,
+      "candidates": [
+        {
+          "node_id": 961,
+          "node_type": "release",
+          "external_id": "3.1.2",
+          "title": "3.1.2",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 971,
+          "node_type": "release",
+          "external_id": "2.3.1",
+          "title": "2.3.1",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 978,
+          "node_type": "release",
+          "external_id": "2.1.3",
+          "title": "2.1.3",
+          "match": "fuzzy",
+          "score": 1.0
+        }
+      ],
+      "paths": [
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:53 \u2014 Session is not updated on redirect target endpoint in tests"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:104 \u2014 `stream_with_context` does not work with async routes"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5776",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5786",
+              "direction": "reverse",
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5774",
+              "direction": "reverse",
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument"
+            },
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5776",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5777",
+              "direction": "forward",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument"
+            },
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5777",
+              "direction": "reverse",
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:53 \u2014 Session is not updated on redirect target endpoint in tests"
+            },
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5797",
+              "direction": "reverse",
+              "to_node": "pull_request:76 \u2014 push preserved contexts in correct order"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5786",
+              "direction": "reverse",
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5797",
+              "direction": "forward",
+              "to_node": "pull_request:76 \u2014 push preserved contexts in correct order"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:104 \u2014 `stream_with_context` does not work with async routes"
+            },
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:100 \u2014 refactor stream_with_context for async views"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5774",
+              "direction": "reverse",
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5799",
+              "direction": "forward",
+              "to_node": "pull_request:100 \u2014 refactor stream_with_context for async views"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "13 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H9",
+      "category": "impact",
+      "mode": "impact",
+      "query": "Config.from_file() missing ENOTDIR in silent error handling",
+      "intent": "Forward traversal over the 5-source cluster.",
+      "verify": "Does the blast radius look right, or does thread-merging over-connect unrelated work?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 576,
+          "node_type": "issue",
+          "external_id": "5912",
+          "title": "Config.from_file() missing ENOTDIR in silent error handling",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 932,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5913",
+          "title": "Config.from_file() missing ENOTDIR in silent error handling",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 704,
+          "node_type": "pull_request",
+          "external_id": "5955",
+          "title": "Fix Config.from_file silent error handling to include ENOTDIR",
+          "match": "fuzzy",
+          "score": 0.719
+        }
+      ],
+      "paths": [
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:572 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "commit:574 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5914",
+              "direction": "reverse",
+              "to_node": "pull_request:578 \u2014 add ENOTDIR to from_file silent error handling"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5944",
+              "direction": "reverse",
+              "to_node": "pull_request:651 \u2014 Add ENOTDIR handling to Config.from_file with silent=True"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "6422bf669e29db4dccebb17becf1f22f1a1634bf",
+              "direction": "reverse",
+              "to_node": "commit:706 \u2014 Fix Config.from_file silent error handling to include ENOTDIR"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "commit:574 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "c8ecf241e3605c48ac84ab863c206f1072888668",
+              "direction": "reverse",
+              "to_node": "pull_request:572 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:572 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "c8ecf241e3605c48ac84ab863c206f1072888668",
+              "direction": "forward",
+              "to_node": "commit:574 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5914",
+              "direction": "reverse",
+              "to_node": "pull_request:578 \u2014 add ENOTDIR to from_file silent error handling"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "560ea7fd409c839bc85382a05b6e1bd1d7ca8795",
+              "direction": "forward",
+              "to_node": "commit:580 \u2014 add ENOTDIR to from_file silent error handling"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5944",
+              "direction": "reverse",
+              "to_node": "pull_request:651 \u2014 Add ENOTDIR handling to Config.from_file with silent=True"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "14c80085434894d5a26a4e1cee7f4f4f3b97d9ce",
+              "direction": "forward",
+              "to_node": "commit:653 \u2014 Add ENOTDIR handling to Config.from_file with silent=True"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "6422bf669e29db4dccebb17becf1f22f1a1634bf",
+              "direction": "reverse",
+              "to_node": "commit:706 \u2014 Fix Config.from_file silent error handling to include ENOTDIR"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "6422bf669e29db4dccebb17becf1f22f1a1634bf",
+              "direction": "reverse",
+              "to_node": "pull_request:704 \u2014 Fix Config.from_file silent error handling to include ENOTDIR"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:572 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5913",
+              "direction": "reverse",
+              "to_node": "decision:932 \u2014 Config.from_file() missing ENOTDIR in silent error handling"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 3,
+          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "commit:574 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "c8ecf241e3605c48ac84ab863c206f1072888668",
+              "direction": "reverse",
+              "to_node": "pull_request:572 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5913",
+              "direction": "reverse",
+              "to_node": "decision:932 \u2014 Config.from_file() missing ENOTDIR in silent error handling"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "12 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "H10",
+      "category": "impact",
+      "mode": "impact",
+      "query": "asgiref fails with gevent patching",
+      "intent": "Impact across a 2-PR / 2-commit thread.",
+      "verify": "Are all reached artifacts genuinely affected by a revert?",
+      "contract": null,
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 477,
+          "node_type": "issue",
+          "external_id": "5881",
+          "title": "asgiref fails with gevent patching",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 929,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5885",
+          "title": "asgiref fails with gevent patching",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 439,
+          "node_type": "pull_request",
+          "external_id": "5885",
+          "title": "clarify async view incompatibility with gevent monkey patching",
+          "match": "fuzzy",
+          "score": 0.311
+        }
+      ],
+      "paths": [
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:477 \u2014 asgiref fails with gevent patching",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:439 \u2014 clarify async view incompatibility with gevent monkey patching"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:477 \u2014 asgiref fails with gevent patching",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5900",
+              "direction": "reverse",
+              "to_node": "pull_request:487 \u2014 document using gevent for async"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:477 \u2014 asgiref fails with gevent patching",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:439 \u2014 clarify async view incompatibility with gevent monkey patching"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "bec6b5ba460c0d0af9daf1707219ded5eb11f321",
+              "direction": "forward",
+              "to_node": "commit:441 \u2014 clarify async view incompatibility with gevent monkey patching"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:477 \u2014 asgiref fails with gevent patching",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5900",
+              "direction": "reverse",
+              "to_node": "pull_request:487 \u2014 document using gevent for async"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "ac5664d2281533eacafd64f5cc7d5edcdaccab60",
+              "direction": "forward",
+              "to_node": "commit:489 \u2014 document using gevent for async"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:477 \u2014 asgiref fails with gevent patching",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:439 \u2014 clarify async view incompatibility with gevent monkey patching"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5885",
+              "direction": "reverse",
+              "to_node": "decision:929 \u2014 asgiref fails with gevent patching"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "5 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": null
+    },
+    {
+      "id": "N1",
+      "category": "negative",
+      "mode": "why",
+      "query": "package detection fails with namespace package in project layout",
+      "intent": "An issue in a thread with NO Decision \u2014 it did not meet the \u00a75.1 rubric.",
+      "verify": "Confirm flask genuinely has no recorded decision resolving this, i.e. the refusal is correct rather than a miss.",
+      "contract": "Must return no answer. The system must not invent a decision where the rubric declined to assert one.",
+      "as_of": null,
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 536,
+          "node_type": "issue",
+          "external_id": "5897",
+          "title": "package detection fails with namespace package in editable mode",
+          "match": "fuzzy",
+          "score": 0.603
+        }
+      ],
+      "paths": [],
+      "used_inferred_fallback": true,
+      "explanation": "no path found, explicit or inferred",
+      "answered": false,
+      "verdict": null,
+      "notes": null,
+      "contract_check": "HELD"
+    },
+    {
+      "id": "N2",
+      "category": "negative",
+      "mode": "impact",
+      "query": "davidism",
+      "intent": "Impact from a person. Authorship edges (`created`) are deliberately excluded from the impact edge set.",
+      "verify": "Confirm the empty answer is the right behaviour rather than a gap worth closing.",
+      "contract": "Must return no answer. 'Everything this person touched' is a Bus Factor / Expert Finder query, explicitly out of scope for v1 (\u00a76).",
+      "as_of": null,
+      "depth": 2,
+      "candidates": [
+        {
+          "node_id": 57,
+          "node_type": "person",
+          "external_id": "davidism",
+          "title": "davidism",
+          "match": "exact",
+          "score": 1.0
+        }
+      ],
+      "paths": [],
+      "used_inferred_fallback": true,
+      "explanation": "no path found, explicit or inferred",
+      "answered": false,
+      "verdict": null,
+      "notes": null,
+      "contract_check": "HELD"
+    },
+    {
+      "id": "N3",
+      "category": "negative",
+      "mode": "why",
+      "query": "quantum entanglement middleware autoscaler",
+      "intent": "Retrieval finds nothing at all.",
+      "verify": "Confirm no spurious candidate was returned above the 0.25 trigram floor.",
+      "contract": "Must return no candidates and say so, rather than fuzzy-matching to an unrelated entity.",
+      "as_of": null,
+      "depth": 3,
+      "candidates": [],
+      "paths": [],
+      "used_inferred_fallback": false,
+      "explanation": "retrieval returned no candidate start node",
+      "answered": false,
+      "verdict": null,
+      "notes": null,
+      "contract_check": "HELD"
+    },
+    {
+      "id": "N4",
+      "category": "negative",
+      "mode": "why",
+      "query": "#2581",
+      "intent": "An issue referenced by in-window artifacts but itself OUTSIDE the 12-month window. It sits unresolved in pending_reference with 7 attempts.",
+      "verify": "Confirm the honest 'not in graph' outcome, and that the pending queue records it rather than silently dropping it.",
+      "contract": "Must return no answer. The bounded window is a deliberate limit; the system must not fabricate a chain for an artifact it never ingested.",
+      "as_of": null,
+      "depth": 3,
+      "candidates": [],
+      "paths": [],
+      "used_inferred_fallback": false,
+      "explanation": "retrieval returned no candidate start node",
+      "answered": false,
+      "verdict": null,
+      "notes": null,
+      "contract_check": "HELD"
+    },
+    {
+      "id": "T1",
+      "category": "temporal",
+      "mode": "why",
+      "query": "change default redirect code to 303",
+      "intent": "Point-in-time query BEFORE this decision existed, using the valid_from/valid_to window.",
+      "verify": "Confirm the time filter genuinely restricts the answer rather than being ignored.",
+      "contract": "Must return fewer paths than F1 \u2014 ideally none. Edges whose valid_from postdates the as-of instant must not be traversed.",
+      "as_of": "2025-06-01T00:00:00+00:00",
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 485,
+          "node_type": "issue",
+          "external_id": "5895",
+          "title": "change default redirect code to 303",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 930,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5898",
+          "title": "change default redirect code to 303",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 530,
+          "node_type": "pull_request",
+          "external_id": "5898",
+          "title": "redirect defaults to 303",
+          "match": "fuzzy",
+          "score": 0.622
+        }
+      ],
+      "paths": [],
+      "used_inferred_fallback": true,
+      "explanation": "no path found, explicit or inferred",
+      "answered": false,
+      "verdict": null,
+      "notes": null,
+      "contract_check": "COMPARE"
+    },
+    {
+      "id": "T2",
+      "category": "temporal",
+      "mode": "impact",
+      "query": "Looser type annotations for send_file() path_or_file argument",
+      "intent": "Point-in-time query AFTER everything \u2014 control for T1.",
+      "verify": "Compare against F2; they should match.",
+      "contract": "Must return the same paths as F2. If T1 shrinks and T2 does not, the time filter is working in both directions.",
+      "as_of": "2026-12-31T00:00:00+00:00",
+      "depth": 3,
+      "candidates": [
+        {
+          "node_id": 51,
+          "node_type": "issue",
+          "external_id": "5776",
+          "title": "Looser type annotations for send_file() path_or_file argument",
+          "match": "exact",
+          "score": 1.0
+        },
+        {
+          "node_id": 920,
+          "node_type": "decision",
+          "external_id": "thread:30:pr-5777",
+          "title": "Looser type annotations for send_file() path_or_file argument",
+          "match": "fuzzy",
+          "score": 1.0
+        },
+        {
+          "node_id": 41,
+          "node_type": "pull_request",
+          "external_id": "5794",
+          "title": "Loosen send_file type annotation to include typing.IO[bytes]",
+          "match": "fuzzy",
+          "score": 0.395
+        }
+      ],
+      "paths": [
+        {
+          "tier": "corroborated",
+          "depth": 1,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 1,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5777",
+              "direction": "reverse",
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 1,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "45eb69f8bac0e4905c8f511a86b8c6705d33ff74",
+              "direction": "forward",
+              "to_node": "commit:43 \u2014 Update helpers.pyLoosen send_file type annotation to include t.IO[bytes]  Include typing.IO[bytes] to align with Werkzeug and resolve issue #5776."
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:53 \u2014 Session is not updated on redirect target endpoint in tests"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5777",
+              "direction": "reverse",
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "d44f1c65239c3e33509224aa1931631243dbfa7f",
+              "direction": "forward",
+              "to_node": "commit:66 \u2014 relax type hint for bytes io"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:104 \u2014 `stream_with_context` does not work with async routes"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5777",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5776",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5786",
+              "direction": "reverse",
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+            }
+          ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 2,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5774",
+              "direction": "reverse",
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5776",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5777",
+              "direction": "forward",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:53 \u2014 Session is not updated on redirect target endpoint in tests"
+            },
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5797",
+              "direction": "reverse",
+              "to_node": "pull_request:76 \u2014 push preserved contexts in correct order"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5786",
+              "direction": "reverse",
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5797",
+              "direction": "forward",
+              "to_node": "pull_request:76 \u2014 push preserved contexts in correct order"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "reverse",
+              "to_node": "issue:104 \u2014 `stream_with_context` does not work with async routes"
+            },
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:100 \u2014 refactor stream_with_context for async views"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "release_notes_reference",
+              "source_ref": "3.1.2",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5774",
+              "direction": "reverse",
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5799",
+              "direction": "forward",
+              "to_node": "pull_request:100 \u2014 refactor stream_with_context for async views"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:51 \u2014 Looser type annotations for send_file() path_or_file argument",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": null,
+              "direction": "reverse",
+              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5777",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            },
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5776",
+              "direction": "forward",
+              "to_node": "release:961 \u2014 3.1.2"
+            }
+          ]
+        }
+      ],
+      "used_inferred_fallback": false,
+      "explanation": "17 explicit path(s) found; inferred edges not consulted",
+      "answered": true,
+      "verdict": null,
+      "notes": null,
+      "contract_check": "COMPARE"
+    }
+  ]
+}

--- a/src/decision_graph/evaluation.py
+++ b/src/decision_graph/evaluation.py
@@ -1,0 +1,227 @@
+"""Evaluation runner (PRD v3.1 §9).
+
+Runs the hand-curated query set and records, for every query, exactly what the engines
+returned — candidates, paths, per-step evidence tiers, and the extractor behind each
+edge.
+
+**This module does not grade anything.** §9 calls for answers "manually checked against
+the repo's actual history", and a system scoring its own output against its own graph
+would be checking self-consistency, not correctness. The runner emits `verdict: null`
+for every query; a human fills it in.
+
+The one thing it does assert is `contract` — mechanically checkable properties of the
+engine itself, like "must return no answer for an artifact outside the window". Those
+are statements about the code's contract, not about flask, so the runner can check them
+without grading itself.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sys
+from dataclasses import asdict, dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any
+
+from . import db, reasoning, retrieval
+from .reasoning import Mode
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class StepRecord:
+    edge_type: str
+    tier: str
+    tag: str
+    extractor: str
+    source_ref: str | None
+    direction: str
+    to_node: str
+
+
+@dataclass
+class PathRecord:
+    tier: str
+    depth: int
+    start: str
+    steps: list[StepRecord]
+
+
+@dataclass
+class QueryResult:
+    id: str
+    category: str
+    mode: str
+    query: str
+    intent: str
+    verify: str | None
+    contract: str | None
+    as_of: str | None
+    depth: int
+
+    candidates: list[dict[str, Any]] = field(default_factory=list)
+    paths: list[PathRecord] = field(default_factory=list)
+    used_inferred_fallback: bool = False
+    explanation: str = ""
+    answered: bool = False
+
+    # Filled by a human. §9 requires manual verification against real history.
+    verdict: str | None = None
+    notes: str | None = None
+
+
+def _describe(path: reasoning.Path, node_id: int) -> str:
+    node_type = path.types.get(node_id) or "?"
+    title = (path.titles.get(node_id) or "").strip()
+    return f"{node_type}:{node_id}" + (f" — {title}" if title else "")
+
+
+def run_query(conn, spec: dict[str, Any]) -> QueryResult:
+    as_of = datetime.fromisoformat(spec["as_of"]) if spec.get("as_of") else None
+    depth = spec.get("depth", reasoning.DEFAULT_MAX_DEPTH)
+
+    result = QueryResult(
+        id=spec["id"],
+        category=spec["category"],
+        mode=spec["mode"],
+        query=spec["query"],
+        intent=spec["intent"],
+        verify=spec.get("verify"),
+        contract=spec.get("contract"),
+        as_of=spec.get("as_of"),
+        depth=depth,
+    )
+
+    candidates = retrieval.find_candidates(conn, spec["query"], limit=3)
+    result.candidates = [
+        {
+            "node_id": c.node_id,
+            "node_type": c.node_type,
+            "external_id": c.external_id,
+            "title": c.title,
+            "match": c.match,
+            "score": round(c.score, 3),
+        }
+        for c in candidates
+    ]
+
+    if not candidates:
+        result.explanation = "retrieval returned no candidate start node"
+        return result
+
+    # Only the top candidate is answered, so the record shows what a user would
+    # actually see rather than the best of several attempts.
+    start = candidates[0]
+    answer = reasoning.reason(
+        conn, start.node_id, Mode(spec["mode"]), max_depth=depth, as_of=as_of
+    )
+
+    result.answered = answer.found
+    result.used_inferred_fallback = answer.used_inferred_fallback
+    result.explanation = answer.explanation
+
+    for path in sorted(answer.paths, key=lambda p: (p.depth, p.target_id)):
+        steps = []
+        for step, node_id in zip(path.steps, path.node_ids[1:]):
+            steps.append(
+                StepRecord(
+                    edge_type=step.edge_type,
+                    tier=step.evidence_tier,
+                    tag=step.tag,
+                    extractor=step.extractor,
+                    source_ref=step.source_ref,
+                    direction="forward" if step.to_node_id == node_id else "reverse",
+                    to_node=_describe(path, node_id),
+                )
+            )
+        result.paths.append(
+            PathRecord(
+                tier=path.tier,
+                depth=path.depth,
+                start=_describe(path, path.node_ids[0]),
+                steps=steps,
+            )
+        )
+
+    return result
+
+
+def check_contract(result: QueryResult) -> str | None:
+    """Verify engine-contract properties only. Never judges factual correctness."""
+    if not result.contract:
+        return None
+    text = result.contract.lower()
+
+    if "no candidates" in text:
+        return "HELD" if not result.candidates else "VIOLATED: candidates were returned"
+    if "no answer" in text:
+        return "HELD" if not result.answered else "VIOLATED: an answer was returned"
+    if "fewer paths" in text or "same paths" in text:
+        return "COMPARE"  # resolved against its sibling query during review
+    return None
+
+
+def run_all(dsn: str, query_set_path: Path) -> dict[str, Any]:
+    spec = json.loads(query_set_path.read_text(encoding="utf-8"))
+    conn = db.connect(dsn)
+
+    results = []
+    for query_spec in spec["queries"]:
+        log.info("running %s: %s", query_spec["id"], query_spec["query"])
+        result = run_query(conn, query_spec)
+        payload = asdict(result)
+        payload["contract_check"] = check_contract(result)
+        results.append(payload)
+
+    conn.close()
+
+    answered = sum(1 for r in results if r["answered"])
+    contracts = [r for r in results if r["contract_check"] in ("HELD", "VIOLATED")]
+
+    return {
+        "about": spec["about"],
+        "generated_at": datetime.now().astimezone().isoformat(),
+        "summary": {
+            "total": len(results),
+            "answered": answered,
+            "returned_no_answer": len(results) - answered,
+            "contracts_checked": len(contracts),
+            "contracts_held": sum(1 for r in contracts if r["contract_check"] == "HELD"),
+            "used_inferred_fallback": sum(1 for r in results if r["used_inferred_fallback"]),
+            "adjudicated": 0,
+        },
+        "results": results,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(message)s")
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        print("error: DATABASE_URL is not set", file=sys.stderr)
+        return 2
+
+    root = Path(__file__).resolve().parents[2]
+    query_set = root / "eval" / "query_set.json"
+    out = root / "eval" / "results.json"
+
+    report = run_all(dsn, query_set)
+    out.write_text(json.dumps(report, indent=2, default=str), encoding="utf-8")
+
+    s = report["summary"]
+    log.info("")
+    log.info("queries              : %s", s["total"])
+    log.info("answered             : %s", s["answered"])
+    log.info("returned no answer   : %s", s["returned_no_answer"])
+    log.info("engine contracts held: %s/%s", s["contracts_held"], s["contracts_checked"])
+    log.info("wrote %s", out)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
18 hand-curated queries — 2 flagship plus 16 harder cases — with full evidence traces, in a reviewable worksheet.

**Worksheet:** https://claude.ai/code/artifact/e5a2927b-b783-4b15-8b0c-5eee0ea6af00

## The runner grades nothing

§9 requires answers checked against the repository's real history. A system scoring its own output against its own graph measures self-consistency, not correctness — so `verdict` is emitted `null` for every query and filled in by a human.

The one automatic assertion is `contract`: mechanical properties of the engine such as *"must return no answer for an artifact outside the window"*. Those are claims about the code, not about flask, so the runner can check them without grading itself.

## Coverage

| category | queries |
|---|---|
| flagship | F1 (why), F2 (impact) |
| causal reconstruction | H1–H4, incl. the 5-source cluster and a corroborated thread |
| retrieval | H5 bare `#5898`, H6 full SHA, H7 paraphrase |
| impact | H8–H10, incl. impact-from-a-release |
| correct refusal | N1–N4 |
| point-in-time | T1, T2 |

The four refusal cases matter as much as the answers: a thread with no Decision, impact-from-a-person (out of scope per §6), a query matching nothing, and an artifact outside the 12-month window. All four contracts held.

## Result

12 answered, 6 returned nothing, **4/4 engine contracts held**. Across every path returned: 41 explicit, 30 corroborated, 0 inferred.

**The point-in-time pair is the load-bearing control.** F1 returns 1 path and drops to **0** asked as of 2025-06; F2 returns 17 both now and as of 2026-12. The filter restricts in one direction only — a single temporal query could not have distinguished a working filter from an ignored one.

## An honest failure: H6, reported not fixed

`dg-query c8ecf24... --mode why` resolves the commit but returns **no path**. The same commit in `--mode impact` returns 15.

The commit's only edges are `created`, `implements` (in), and `closes` (out) — **none are in `WHY_EDGES`**, so backward traversal has nothing to walk. Because synthesis picks exactly one implementer per thread, this affects nearly every commit in the graph: 213 commit nodes against 20 `implemented_by` edges.

Filed as #14 with a fix direction. I deliberately did not change `WHY_EDGES` while running the evaluation — editing the engine to make an eval query pass is tuning to the test, and the failure is more useful recorded than quietly removed.

## Reproducibility

The report is generated from `results.json`, not hand-written, so re-running the evaluation regenerates it and the two cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pCAUDALD1g8DBsf8j8PuK