### PR TITLE
Require that work landed before asserting a Decision

### DIFF
--- a/PRD_v3.1_Organizational_Intelligence_Engine.md
+++ b/PRD_v3.1_Organizational_Intelligence_Engine.md
@@ -172,6 +172,25 @@ Formal precision/recall evaluation at scale is out of scope for v1 given the eff
 - **Phase 4:** Explainability Mode; evaluation set and accuracy reporting.
 - **Phase 5 (future, out of scope here):** Webhook-driven ingestion, additional sources (Slack, Jira), permission modeling, Bus Factor / Architecture View / Expert Finder, ranked/embedding-based retrieval.
 
+> **Roadmap note — rejected decisions as a first-class outcome (Phase 5+).**
+> Implementation surfaced a category the current model cannot express. A cluster where
+> maintainers *declined* to act — an issue closed as `not_planned`, with closing PRs left
+> unmerged — is a real decision, and against one real repository window they are not rare:
+> 28 of 54 closed issues, and 7 of the 20 clusters that initially qualified as Decisions.
+>
+> v1 handles these by exclusion. §5.1 Validation requires that work landed, so a declined
+> cluster produces no Decision node and its artifacts stay queryable as plain artifacts.
+> That is correct for v1 and prevents the system asserting a change was made when it was
+> refused — but it means the graph is silent about a decision that demonstrably occurred,
+> and the answer to "why doesn't Flask do X?" is often more valuable than "why does it?".
+>
+> Modelling these properly is not a rubric tweak. It needs rejection-rationale extraction
+> that does not exist yet: the *why* of a refusal lives in closing comments and review
+> discussion, not in the structured signals (`closes`, `implements`, `reviewed`) the
+> extraction-first design currently reads. Adding a `rejected` outcome without that would
+> reintroduce exactly the failure §5.1 exists to prevent — asserting a decision whose
+> rationale the system cannot evidence.
+
 ## 12. Success Criteria
 
 - Why Engine and Impact Analysis both return correct, evidence-tiered answers against a real repository's history.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,16 @@ a higher tier. §5.3's "explicit and corroborated first" pass is then just `tag=
   `motivated_by` edge that justified it
 
 Motivation is mandatory; Implementation or Validation must also be present; all rubric
-edges must share one PR/issue thread. `decision_status` has no `inferred` member — a
+edges must share one PR/issue thread; and **something in that thread must have merged**.
+
+That last clause is not an addition — §5.1 always defined Validation as "that it landed",
+and §5.1's own worked example says "a *merged*, reviewed PR". The original implementation
+accepted a `closes` edge as proof, but a closing keyword is typed by a contributor before
+the outcome is known and survives rejection completely intact. 12 of the first 20
+Decisions turned out to rest on pull requests that were never merged (issues #16/#17).
+`thread_landed()` now checks merge state, and `retract_unsupported_decisions()` withdraws
+Decisions whose evidence stops holding — the deferred guard only re-validates rows
+something touches, so a claim made under an older rule would otherwise survive forever. `decision_status` has no `inferred` member — a
 Decision that cannot reach explicit or reconstructed is simply not created.
 
 **`thread_key` is the v1 stand-in for §5.1's "bounded time window"** and is the most
@@ -173,7 +182,7 @@ Accepted deliberately rather than fixed by switching repos:
   evaluation set cannot include ownership queries against flask.**
 - **`has_wiki: false`.** The `wiki_page` extractor no-ops. On this repo `motivated_by`
   therefore resolves only to issues and PR bodies, never wiki pages.
-- **The `corroborated` tier is sparse: 6 of 161 threads (33 of 811 explicit edges).**
+- **The `corroborated` tier is sparse: 6 of 161 threads.**
   flask merges largely without formal GitHub reviews — 11 `reviewed` edges across 145
   PRs, and only 6 threads carry any review at all; 3 threads appear in release notes.
   The rubric was chosen on independence grounds and not tuned to raise this number, so
@@ -226,7 +235,7 @@ only automatic assertion is `contract` — mechanical properties of the engine s
 "must return no answer for an artifact outside the window" — which are claims about the
 code rather than about flask.
 
-Current run: 12 answered, 6 returned nothing, 4/4 engine contracts held. The point-in-time
+Current run: 10 answered, 8 returned nothing, 5/5 engine contracts held. The point-in-time
 control is the load-bearing one: F1 returns 1 path and drops to 0 when asked as of
 2025-06, while F2 returns 17 both now and as of 2026-12 — so the time filter restricts in
 one direction only, rather than being silently ignored.

--- a/db/migrations/0007_landed_state.sql
+++ b/db/migrations/0007_landed_state.sql
@@ -1,0 +1,58 @@
+-- 0007_landed_state.sql
+-- Persist the two fields that tell us whether work actually LANDED (issue #16).
+--
+-- `pull_request.merged_at` has existed since 0001 and was never once populated:
+-- extract_issue_or_pr read `payload.get("merged_at")`, but the /issues endpoint nests
+-- merge state under payload["pull_request"]["merged_at"]. Nothing read the column, so
+-- nothing failed — the schema looked complete while 27 of 145 merges were discarded.
+--
+-- `issue.state_reason` was never modelled at all. It distinguishes an issue closed as
+-- `completed` from one closed as `not_planned` — i.e. resolved versus declined. 28 of
+-- 54 closed issues in this window are `not_planned`.
+--
+-- Both are backfilled from the `raw` JSONB we already store, so this costs no API calls
+-- and does not widen the bounded backfill window.
+
+BEGIN;
+
+ALTER TABLE issue ADD COLUMN state_reason text;
+
+COMMENT ON COLUMN issue.state_reason IS
+    'GitHub state_reason: completed | not_planned | reopened | null. An issue closed as '
+    'not_planned records a decision NOT to act -- see the §5.1 rubric, which requires '
+    'evidence that work landed before asserting a Decision.';
+
+-- Backfill merge state from the payloads already in the graph.
+UPDATE pull_request p
+SET merged_at = (n.raw->'pull_request'->>'merged_at')::timestamptz
+FROM node n
+WHERE n.id = p.node_id
+  AND n.raw->'pull_request'->>'merged_at' IS NOT NULL;
+
+UPDATE issue i
+SET state_reason = n.raw->>'state_reason'
+FROM node n
+WHERE n.id = i.node_id
+  AND n.raw->>'state_reason' IS NOT NULL;
+
+-- "Did the work in this thread actually land?" -- the question the §5.1 rubric was
+-- always asking under the name Validation, but never actually checked.
+CREATE FUNCTION thread_landed(p_thread_key text) RETURNS boolean
+LANGUAGE sql STABLE AS $$
+    SELECT p_thread_key IS NOT NULL AND EXISTS (
+        SELECT 1
+        FROM node n
+        JOIN pull_request p ON p.node_id = n.id
+        WHERE n.thread_key = p_thread_key
+          AND p.merged_at IS NOT NULL
+    );
+$$;
+
+COMMENT ON FUNCTION thread_landed(text) IS
+    'True when a thread cluster contains at least one MERGED pull request. A closing '
+    'keyword is written by a contributor before the outcome is known and survives '
+    'rejection intact; a merge does not.';
+
+CREATE INDEX pull_request_merged_idx ON pull_request (merged_at) WHERE merged_at IS NOT NULL;
+
+COMMIT;

--- a/db/migrations/0008_rubric_requires_landing.sql
+++ b/db/migrations/0008_rubric_requires_landing.sql
@@ -1,0 +1,169 @@
+-- 0008_rubric_requires_landing.sql
+-- Correct an under-implementation of §5.1 Validation (issue #17).
+--
+-- The rubric always defined Validation as "that it landed". It was implemented as
+-- "a `reviewed` or `closes` edge exists" -- but a closing keyword is typed by a
+-- contributor BEFORE the outcome is known and survives rejection completely intact.
+-- The result: 12 of 20 Decisions rested on pull requests that were never merged, and
+-- 4 were motivated by issues the maintainers closed as `not_planned`. The system
+-- asserted that a decision was taken where the actual decision was to refuse.
+--
+-- WHY THIS ALSO GATES IMPLEMENTATION, not only Validation.
+-- Rubric clause 2 is an OR: Motivation plus *either* Implementation or Validation. All
+-- 20 existing Decisions satisfy BOTH, so tightening Validation alone would have changed
+-- nothing -- every rejected cluster would still qualify through Implementation. Gating
+-- only one branch of an OR is inert.
+--
+-- Gating both is faithful to the PRD rather than an extension of it. §5.1's own worked
+-- example reads: "a merged, reviewed PR with no linked issue describes *that* something
+-- happened and *that* it landed, but not *why*". The rubric's picture of Implementation
+-- was always a MERGED pull request; the code simply never checked.
+--
+-- Motivation is deliberately left alone. An issue closed as `not_planned` is excluded
+-- as a side effect -- all four such clusters contain no merged PR at all -- so no
+-- separate rule is needed, and none is added. Modelling "decided not to do this" as a
+-- first-class Decision outcome is a Phase 5+ item: it needs rejection-rationale
+-- extraction that does not exist yet.
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION decision_rubric(p_decision_id bigint)
+RETURNS TABLE (
+    decision_node_id   bigint,
+    has_motivation     boolean,
+    has_implementation boolean,
+    has_validation     boolean,
+    cluster_thread_key text,
+    thread_coherent    boolean,
+    passes             boolean,
+    failure_reason     text
+)
+LANGUAGE plpgsql STABLE AS $$
+DECLARE
+    v_motivation boolean;
+    v_impl       boolean;
+    v_validation boolean;
+    v_threads    text[];
+    v_thread     text;
+    v_coherent   boolean;
+    v_landed     boolean;
+    v_passes     boolean;
+    v_reason     text;
+BEGIN
+    -- Clause 1: Motivation -- mandatory, unchanged. Answers "why".
+    SELECT EXISTS (
+        SELECT 1
+        FROM edge e
+        JOIN node n ON n.id = e.dst_node_id
+        WHERE e.src_node_id = p_decision_id
+          AND e.edge_type   = 'motivated_by'
+          AND e.tag         = 'explicit'
+          AND e.valid_to IS NULL
+          AND n.node_type IN ('issue', 'pull_request', 'wiki_page')
+    ) INTO v_motivation;
+
+    -- Clause 3 first: the thread cluster, which the landing check needs.
+    SELECT array_agg(DISTINCT n.thread_key)
+    INTO v_threads
+    FROM edge e
+    JOIN node n ON n.id = e.dst_node_id
+    WHERE e.src_node_id = p_decision_id
+      AND e.edge_type IN ('motivated_by', 'implemented_by')
+      AND e.tag = 'explicit'
+      AND e.valid_to IS NULL;
+
+    v_coherent := v_threads IS NOT NULL
+                  AND array_length(v_threads, 1) = 1
+                  AND v_threads[1] IS NOT NULL;
+    v_thread := CASE WHEN v_coherent THEN v_threads[1] END;
+
+    -- Did anything in this cluster actually merge?
+    v_landed := thread_landed(v_thread);
+
+    -- Clause 2a: Implementation. Answers "what was done" -- and it must have landed.
+    SELECT v_landed AND EXISTS (
+        SELECT 1
+        FROM edge e
+        JOIN node n ON n.id = e.dst_node_id
+        WHERE e.src_node_id = p_decision_id
+          AND e.edge_type   = 'implemented_by'
+          AND e.tag         = 'explicit'
+          AND e.valid_to IS NULL
+          AND n.node_type IN ('commit', 'pull_request')
+    ) INTO v_impl;
+
+    -- Clause 2b: Validation. Answers "that it landed" -- now actually checked.
+    IF v_thread IS NULL OR NOT v_landed THEN
+        v_validation := false;
+    ELSE
+        SELECT EXISTS (
+            SELECT 1
+            FROM edge e
+            JOIN node s ON s.id = e.src_node_id
+            JOIN node d ON d.id = e.dst_node_id
+            WHERE e.edge_type IN ('reviewed', 'closes')
+              AND e.tag = 'explicit'
+              AND e.valid_to IS NULL
+              AND (s.thread_key = v_thread OR d.thread_key = v_thread)
+        ) INTO v_validation;
+    END IF;
+
+    v_passes := v_motivation AND (v_impl OR v_validation) AND v_coherent;
+
+    v_reason := CASE
+        WHEN v_passes THEN NULL
+        WHEN NOT v_motivation THEN
+            'clause 1: no explicit motivated_by edge to an issue/PR/wiki page'
+        WHEN NOT v_coherent THEN
+            'clause 3: rubric edges span ' || COALESCE(array_length(v_threads, 1), 0) ||
+            ' thread(s) or an unthreaded node'
+        WHEN NOT v_landed THEN
+            'clause 2: nothing in thread ' || COALESCE(v_thread, '<none>') ||
+            ' was ever merged -- a closing keyword survives rejection, a merge does not'
+        ELSE
+            'clause 2: neither implemented_by nor a reviewed/closes edge in thread ' ||
+            COALESCE(v_thread, '<none>')
+    END;
+
+    RETURN QUERY SELECT
+        p_decision_id, v_motivation, v_impl, v_validation,
+        v_thread, v_coherent, v_passes, v_reason;
+END;
+$$;
+
+-- Retraction. A Decision asserted under the old rule must be withdrawn, not left
+-- standing: the deferred guard only re-validates rows it is asked to touch, so nothing
+-- would otherwise revisit the 12 clusters that no longer qualify.
+--
+-- Same principle as apply_corroboration() being reversible -- if evidence stops
+-- supporting a claim, the claim goes. Deleting the node cascades its edges.
+CREATE FUNCTION retract_unsupported_decisions()
+RETURNS TABLE (retracted bigint, thread_keys text[])
+LANGUAGE plpgsql AS $$
+DECLARE
+    v_ids     bigint[];
+    v_threads text[];
+BEGIN
+    SELECT array_agg(a.node_id), array_agg(n.thread_key)
+    INTO v_ids, v_threads
+    FROM v_decision_rubric_audit a
+    JOIN node n ON n.id = a.node_id
+    WHERE a.status = 'reconstructed' AND NOT a.passes;
+
+    IF v_ids IS NULL THEN
+        RETURN QUERY SELECT 0::bigint, ARRAY[]::text[];
+        RETURN;
+    END IF;
+
+    DELETE FROM node WHERE id = ANY(v_ids);
+
+    RETURN QUERY SELECT array_length(v_ids, 1)::bigint, v_threads;
+END;
+$$;
+
+COMMENT ON FUNCTION retract_unsupported_decisions() IS
+    'Withdraws reconstructed Decisions that no longer satisfy the §5.1 rubric. Run after '
+    'any rule change or evidence invalidation -- a Decision the graph no longer supports '
+    'must not survive merely because nothing happened to touch its row.';
+
+COMMIT;

--- a/db/tests/0002_rubric_checks.sql
+++ b/db/tests/0002_rubric_checks.sql
@@ -21,11 +21,27 @@ CREATE TEMP TABLE test_result (
     detail  text
 );
 
+CREATE SEQUENCE pg_temp.fixture_num;
+
+-- Since migration 0008 the rubric requires that something in the thread actually
+-- MERGED, so a pull_request fixture now carries a real detail row with merged_at set.
+-- Without it every case below would fail on the landing clause and the tests would pass
+-- for the wrong reason -- "rejected because nothing merged" instead of "rejected because
+-- there is no motivation". Each test still isolates the clause it names.
 CREATE FUNCTION pg_temp.mk(p_type node_type, p_ext text, p_thread text DEFAULT NULL)
-RETURNS bigint LANGUAGE sql AS $fn$
+RETURNS bigint LANGUAGE plpgsql AS $fn$
+DECLARE v_id bigint;
+BEGIN
     INSERT INTO node (node_type, external_id, thread_key)
     VALUES (p_type, p_ext, p_thread)
-    RETURNING id;
+    RETURNING id INTO v_id;
+
+    IF p_type = 'pull_request' THEN
+        INSERT INTO pull_request (node_id, number, state, merged_at)
+        VALUES (v_id, nextval('pg_temp.fixture_num'), 'closed', now() - interval '1 day');
+    END IF;
+    RETURN v_id;
+END;
 $fn$;
 
 CREATE FUNCTION pg_temp.mk_edge(
@@ -115,6 +131,10 @@ BEGIN
     SET CONSTRAINTS ALL DEFERRED;
     BEGIN
         i := pg_temp.mk('issue', 't3-issue', 'thread:t3');
+        -- A merged PR in the thread, but NO implemented_by / reviewed / closes edge:
+        -- landing holds, so the refusal below is genuinely about clause 2 having
+        -- neither Implementation nor Validation.
+        PERFORM pg_temp.mk('pull_request', 't3-pr', 'thread:t3');
         d := pg_temp.mk_decision('t3-dec');
         PERFORM pg_temp.mk_edge(d, i, 'motivated_by');
         SET CONSTRAINTS ALL IMMEDIATE;

--- a/db/tests/0008_landing_checks.sql
+++ b/db/tests/0008_landing_checks.sql
@@ -1,0 +1,160 @@
+-- 0008_landing_checks.sql
+-- Regression checks for the landing gate (issues #16/#17). Transactional; rolls back.
+--
+-- The defect these pin: a closing keyword is written by a contributor BEFORE the outcome
+-- is known and survives rejection intact, so `closes` alone never showed that anything
+-- landed. 12 of 20 Decisions rested on pull requests that were never merged.
+
+BEGIN;
+
+CREATE TEMP TABLE test_result (
+    seq int GENERATED ALWAYS AS IDENTITY,
+    name text, expect text, passed boolean, detail text
+);
+
+CREATE FUNCTION pg_temp.mk(p_type node_type, p_ext text, p_thread text DEFAULT NULL)
+RETURNS bigint LANGUAGE sql AS $fn$
+    INSERT INTO node (node_type, external_id, thread_key)
+    VALUES (p_type, p_ext, p_thread) RETURNING id;
+$fn$;
+
+CREATE FUNCTION pg_temp.mk_edge(p_src bigint, p_dst bigint, p_type edge_type)
+RETURNS bigint LANGUAGE sql AS $fn$
+    INSERT INTO edge (src_node_id, dst_node_id, edge_type, tag, evidence_tier, extractor)
+    VALUES (p_src, p_dst, p_type, 'explicit', 'explicit', 'test_fixture') RETURNING id;
+$fn$;
+
+-- A cluster: issue + PR that closes it, with selectable merge state.
+CREATE FUNCTION pg_temp.build(p_key text, p_merged boolean)
+RETURNS bigint LANGUAGE plpgsql AS $fn$
+DECLARE pr bigint; iss bigint; dec bigint;
+BEGIN
+    pr  := pg_temp.mk('pull_request', p_key || '-pr', p_key);
+    iss := pg_temp.mk('issue', p_key || '-issue', p_key);
+    INSERT INTO pull_request (node_id, number, state, merged_at)
+    VALUES (pr, 1, 'closed', CASE WHEN p_merged THEN now() - interval '1 day' END);
+    INSERT INTO issue (node_id, number, state) VALUES (iss, 2, 'closed');
+
+    PERFORM pg_temp.mk_edge(pr, iss, 'closes');
+
+    dec := pg_temp.mk('decision', p_key || '-dec', p_key);
+    INSERT INTO decision (node_id, status) VALUES (dec, 'reconstructed');
+    PERFORM pg_temp.mk_edge(dec, iss, 'motivated_by');
+    PERFORM pg_temp.mk_edge(dec, pr, 'implemented_by');
+    RETURN dec;
+END;
+$fn$;
+
+
+-- T1  A cluster whose PR was NEVER MERGED must be refused, however many closing
+--     keywords point at the issue. This is the exact 5912 case.
+DO $t$
+DECLARE dec bigint; ok boolean; err text;
+BEGIN
+    SET CONSTRAINTS ALL DEFERRED;
+    BEGIN
+        dec := pg_temp.build('test:unmerged', false);
+        SET CONSTRAINTS ALL IMMEDIATE;
+        ok := true;
+    EXCEPTION WHEN others THEN ok := false; err := SQLERRM;
+    END;
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T1 unmerged cluster refused', 'rejected', NOT ok, left(COALESCE(err,''), 70));
+END;
+$t$;
+
+
+-- T2  The same cluster WITH a merge is accepted -- the gate must not reject everything.
+DO $t$
+DECLARE dec bigint; ok boolean; err text;
+BEGIN
+    SET CONSTRAINTS ALL DEFERRED;
+    BEGIN
+        dec := pg_temp.build('test:merged', true);
+        SET CONSTRAINTS ALL IMMEDIATE;
+        ok := true;
+    EXCEPTION WHEN others THEN ok := false; err := SQLERRM;
+    END;
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T2 merged cluster accepted', 'accepted', ok, left(COALESCE(err,''), 70));
+END;
+$t$;
+
+
+-- T3  thread_landed() reads merge state, not closing keywords.
+DO $t$
+DECLARE a boolean; b boolean;
+BEGIN
+    a := thread_landed('test:merged');
+    b := thread_landed('test:unmerged');
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T3 thread_landed tracks merges only', 'true / false',
+            a AND NOT b, format('merged=%s unmerged=%s', a, b));
+END;
+$t$;
+
+
+-- T4  RETRACTION: a Decision standing under the old rule is withdrawn once its merge
+--     is taken away. Nothing else would revisit it -- the deferred guard only
+--     re-validates rows something touches.
+DO $t$
+DECLARE dec bigint; before_n int; retracted bigint; after_n int;
+BEGIN
+    SET CONSTRAINTS ALL DEFERRED;
+    dec := pg_temp.build('test:retract', true);
+    SET CONSTRAINTS ALL IMMEDIATE;
+    SELECT count(*) INTO before_n FROM decision WHERE node_id = dec;
+
+    -- Evidence withdrawn: the merge is revoked.
+    UPDATE pull_request SET merged_at = NULL
+    WHERE node_id IN (SELECT id FROM node WHERE thread_key='test:retract'
+                        AND node_type='pull_request');
+
+    SELECT r.retracted INTO retracted FROM retract_unsupported_decisions() r;
+    SELECT count(*) INTO after_n FROM decision WHERE node_id = dec;
+
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T4 Decision retracted when merge withdrawn', 'before 1, after 0',
+            before_n = 1 AND after_n = 0,
+            format('before=%s retracted=%s after=%s', before_n, retracted, after_n));
+END;
+$t$;
+
+
+-- T5  A Decision whose evidence still holds is NOT retracted -- retraction must be
+--     targeted, not a blanket purge.
+DO $t$
+DECLARE n int;
+BEGIN
+    PERFORM retract_unsupported_decisions();
+    SELECT count(*) INTO n FROM node WHERE thread_key='test:merged' AND node_type='decision';
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T5 supported Decision survives retraction', 'still 1', n = 1, 'decisions=' || n);
+END;
+$t$;
+
+
+-- T6  The failure message names the landing clause, so an operator can tell "nothing
+--     merged" apart from "no motivation".
+DO $t$
+DECLARE reason text;
+BEGIN
+    SET CONSTRAINTS ALL DEFERRED;
+    PERFORM pg_temp.build('test:reason', false);
+    SELECT failure_reason INTO reason FROM v_decision_rubric_audit
+    WHERE cluster_thread_key = 'test:reason';
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T6 failure reason cites the merge', 'mentions merged',
+            reason ILIKE '%merged%', left(COALESCE(reason, '<none>'), 66));
+END;
+$t$;
+
+
+SELECT seq, CASE WHEN passed THEN 'PASS' ELSE 'FAIL' END AS result, name, expect, detail
+FROM test_result ORDER BY seq;
+
+SELECT count(*) FILTER (WHERE passed) AS passed,
+       count(*) FILTER (WHERE NOT passed) AS failed, count(*) AS total
+FROM test_result;
+
+ROLLBACK;

--- a/eval/query_set.json
+++ b/eval/query_set.json
@@ -2,8 +2,9 @@
   "about": {
     "target_repo": "pallets/flask",
     "window": "12 months",
-    "spec": "PRD v3.1 §9 — 2 flagship queries + 13-18 additional covering harder, less curated cases",
-    "adjudication": "Correctness is decided by a human against flask's actual history. The runner records what the system returned and never grades it. Where a 'contract' field appears, that is a mechanically checkable property of the engine (e.g. 'must return no answer'), not a claim about flask."
+    "spec": "PRD v3.1 \u00a79 \u2014 2 flagship queries + 13-18 additional covering harder, less curated cases",
+    "adjudication": "Correctness is decided by a human against flask's actual history. The runner records what the system returned and never grades it. Where a 'contract' field appears, that is a mechanically checkable property of the engine (e.g. 'must return no answer'), not a claim about flask.",
+    "revision": "Regenerated after issues #16/#17. The landing gate retracted 7 Decisions that rested on unmerged work; 13 remain, all with a merged implementer."
   },
   "queries": [
     {
@@ -24,15 +25,15 @@
       "intent": "If this change were reverted, what is affected?",
       "verify": "Are the reached artifacts (PR, commits, release 3.1.2) genuinely downstream of this change? Is release 3.1.2 the correct shipping vehicle?"
     },
-
     {
       "id": "H1",
-      "category": "causal",
+      "category": "negative",
       "mode": "why",
       "query": "Config.from_file() missing ENOTDIR in silent error handling",
       "depth": 3,
-      "intent": "Hardest clustering case: this issue was closed by FIVE distinct sources (3 PRs + 2 commits), all merged into one thread.",
-      "verify": "Should all five sources belong to one decision? Did flask really resolve this across multiple PRs, or are some unrelated?"
+      "intent": "The defect case. Issue 5912 was closed as NOT PLANNED and its three closing PRs were all rejected unmerged, yet every one contains 'fixes #5912'. Before the landing gate the system asserted a Decision here.",
+      "verify": "Confirm flask really did decline this work, i.e. the refusal is correct. The artifacts themselves remain queryable \u2014 only the Decision is withheld.",
+      "contract": "Must return no answer. Nothing in this thread ever merged, so no Decision may be asserted. This is the regression guard for issues #16/#17."
     },
     {
       "id": "H2",
@@ -67,7 +68,7 @@
       "mode": "why",
       "query": "#5898",
       "depth": 3,
-      "intent": "Bare identifier retrieval — the form an impact query normally arrives in.",
+      "intent": "Bare identifier retrieval \u2014 the form an impact query normally arrives in.",
       "verify": "Did retrieval resolve #5898 to the right artifact? Same answer as F1 reached by a different route?"
     },
     {
@@ -85,8 +86,8 @@
       "mode": "why",
       "query": "template_filter decorator broken",
       "depth": 3,
-      "intent": "Fuzzy retrieval — the query wording does not match the issue title, which is 'The `template_filter` decorator doesn't work if you don't pass an argument'.",
-      "verify": "Did trigram matching find the right entity despite the paraphrase? Would a reasonable user consider this the right hit?"
+      "intent": "Fuzzy retrieval \u2014 the wording does not match the issue title. Note the Decision for this thread was retracted by the landing gate (PR 5735 never merged), so retrieval succeeding while traversal returns nothing is the expected split.",
+      "verify": "Did trigram matching find the right entity despite the paraphrase? The absent Decision is correct, not a retrieval failure."
     },
     {
       "id": "H8",
@@ -94,7 +95,7 @@
       "mode": "impact",
       "query": "3.1.2",
       "depth": 2,
-      "intent": "Impact from a release — what shipped in it?",
+      "intent": "Impact from a release \u2014 what shipped in it?",
       "verify": "Are the reached issues genuinely the contents of 3.1.2, per flask's actual release notes?"
     },
     {
@@ -104,7 +105,7 @@
       "query": "Config.from_file() missing ENOTDIR in silent error handling",
       "depth": 3,
       "intent": "Forward traversal over the 5-source cluster.",
-      "verify": "Does the blast radius look right, or does thread-merging over-connect unrelated work?"
+      "verify": "Impact still traverses the rejected PRs as ARTIFACTS, which is correct \u2014 they exist and are linked. Only the Decision was withheld. Check the blast radius reads as 'these artifacts are related' and not as 'this shipped'."
     },
     {
       "id": "H10",
@@ -121,7 +122,7 @@
       "mode": "why",
       "query": "package detection fails with namespace package in project layout",
       "depth": 3,
-      "intent": "An issue in a thread with NO Decision — it did not meet the §5.1 rubric.",
+      "intent": "An issue in a thread with NO Decision \u2014 it did not meet the \u00a75.1 rubric.",
       "contract": "Must return no answer. The system must not invent a decision where the rubric declined to assert one.",
       "verify": "Confirm flask genuinely has no recorded decision resolving this, i.e. the refusal is correct rather than a miss."
     },
@@ -132,7 +133,7 @@
       "query": "davidism",
       "depth": 2,
       "intent": "Impact from a person. Authorship edges (`created`) are deliberately excluded from the impact edge set.",
-      "contract": "Must return no answer. 'Everything this person touched' is a Bus Factor / Expert Finder query, explicitly out of scope for v1 (§6).",
+      "contract": "Must return no answer. 'Everything this person touched' is a Bus Factor / Expert Finder query, explicitly out of scope for v1 (\u00a76).",
       "verify": "Confirm the empty answer is the right behaviour rather than a gap worth closing."
     },
     {
@@ -163,7 +164,7 @@
       "depth": 3,
       "as_of": "2025-06-01T00:00:00+00:00",
       "intent": "Point-in-time query BEFORE this decision existed, using the valid_from/valid_to window.",
-      "contract": "Must return fewer paths than F1 — ideally none. Edges whose valid_from postdates the as-of instant must not be traversed.",
+      "contract": "Must return fewer paths than F1 \u2014 ideally none. Edges whose valid_from postdates the as-of instant must not be traversed.",
       "verify": "Confirm the time filter genuinely restricts the answer rather than being ignored."
     },
     {
@@ -173,7 +174,7 @@
       "query": "Looser type annotations for send_file() path_or_file argument",
       "depth": 3,
       "as_of": "2026-12-31T00:00:00+00:00",
-      "intent": "Point-in-time query AFTER everything — control for T1.",
+      "intent": "Point-in-time query AFTER everything \u2014 control for T1.",
       "contract": "Must return the same paths as F2. If T1 shrinks and T2 does not, the time filter is working in both directions.",
       "verify": "Compare against F2; they should match."
     }

--- a/eval/render_report.py
+++ b/eval/render_report.py
@@ -220,6 +220,7 @@ TEMPLATE = """<title>Decision Graph — Evaluation Worksheet</title>
   --inferred:     #A6742E;
   --held:     #2E7D5B;
   --violated: #B04A3E;
+  --halt-soft: #FBEDEA;
   --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --serif: ui-serif, "Iowan Old Style", Georgia, "Times New Roman", serif;
   --mono: ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, monospace;
@@ -240,13 +241,14 @@ TEMPLATE = """<title>Decision Graph — Evaluation Worksheet</title>
     --inferred:     #D2A055;
     --held:     #5DB98C;
     --violated: #D97A6C;
+    --halt-soft: #2A1C1A;
   }}
 }}
 :root[data-theme="dark"] {{
   --ground:#101317; --surface:#171B21; --sunk:#1D222A; --ink:#E4E8ED;
   --muted:#98A2AE; --faint:#6B7683; --rule:#272E37; --accent:#58B5A8;
   --accent-soft:#16302E; --explicit:#7FA3C2; --corroborated:#5DB98C;
-  --inferred:#D2A055; --held:#5DB98C; --violated:#D97A6C;
+  --inferred:#D2A055; --held:#5DB98C; --violated:#D97A6C; --halt-soft:#2A1C1A;
 }}
 
 * {{ box-sizing: border-box; }}
@@ -281,6 +283,8 @@ code, .mono {{ font-family: var(--mono); font-size: .86em; }}
 }}
 .note p {{ margin: 0; font-size: .93rem; }}
 .note strong {{ color: var(--accent); }}
+.note.fixed {{ background: var(--sunk); border-left-color: var(--held); }}
+.note.fixed strong {{ color: var(--held); }}
 
 .stats {{ display: flex; flex-wrap: wrap; gap: 1px; background: var(--rule);
   border: 1px solid var(--rule); margin: 2rem 0 .75rem; }}
@@ -402,6 +406,18 @@ button:hover {{ opacity: .9; }}
     <h1>Evaluation worksheet</h1>
     <p class="sub">Decision Graph against <code>pallets/flask</code> — PRD v3.1 §9.
     18 queries: 2 flagship plus 16 harder cases. Generated {generated}.</p>
+
+    <div class="note fixed">
+      <p><strong>Regenerated after a defect found in adjudication.</strong>
+      A spot-check of issue 5912 against GitHub found it <em>closed as not planned</em>
+      with no linked pull requests. The extraction was correct — all five sources really
+      do contain <code>fixes #5912</code> — but the §5.1 rubric never checked whether the
+      work <em>landed</em>, and a closing keyword survives rejection intact.
+      <strong>12 of 20 Decisions rested on pull requests that were never merged.</strong>
+      Validation now requires a merged pull request; 7 Decisions were retracted and 13
+      remain, every one with a merged implementer. Issues #16 and #17.
+      Query H1 is now the regression guard for that defect.</p>
+    </div>
 
     <div class="note">
       <p><strong>Nothing here is graded.</strong> §9 requires answers checked against the

--- a/eval/report.html
+++ b/eval/report.html
@@ -15,6 +15,7 @@
   --inferred:     #A6742E;
   --held:     #2E7D5B;
   --violated: #B04A3E;
+  --halt-soft: #FBEDEA;
   --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
   --serif: ui-serif, "Iowan Old Style", Georgia, "Times New Roman", serif;
   --mono: ui-monospace, "Cascadia Mono", "SF Mono", Menlo, Consolas, monospace;
@@ -35,13 +36,14 @@
     --inferred:     #D2A055;
     --held:     #5DB98C;
     --violated: #D97A6C;
+    --halt-soft: #2A1C1A;
   }
 }
 :root[data-theme="dark"] {
   --ground:#101317; --surface:#171B21; --sunk:#1D222A; --ink:#E4E8ED;
   --muted:#98A2AE; --faint:#6B7683; --rule:#272E37; --accent:#58B5A8;
   --accent-soft:#16302E; --explicit:#7FA3C2; --corroborated:#5DB98C;
-  --inferred:#D2A055; --held:#5DB98C; --violated:#D97A6C;
+  --inferred:#D2A055; --held:#5DB98C; --violated:#D97A6C; --halt-soft:#2A1C1A;
 }
 
 * { box-sizing: border-box; }
@@ -76,6 +78,8 @@ code, .mono { font-family: var(--mono); font-size: .86em; }
 }
 .note p { margin: 0; font-size: .93rem; }
 .note strong { color: var(--accent); }
+.note.fixed { background: var(--sunk); border-left-color: var(--held); }
+.note.fixed strong { color: var(--held); }
 
 .stats { display: flex; flex-wrap: wrap; gap: 1px; background: var(--rule);
   border: 1px solid var(--rule); margin: 2rem 0 .75rem; }
@@ -196,7 +200,19 @@ button:hover { opacity: .9; }
   <div class="lede">
     <h1>Evaluation worksheet</h1>
     <p class="sub">Decision Graph against <code>pallets/flask</code> — PRD v3.1 §9.
-    18 queries: 2 flagship plus 16 harder cases. Generated 2026-08-12 19:52.</p>
+    18 queries: 2 flagship plus 16 harder cases. Generated 2026-08-12 20:21.</p>
+
+    <div class="note fixed">
+      <p><strong>Regenerated after a defect found in adjudication.</strong>
+      A spot-check of issue 5912 against GitHub found it <em>closed as not planned</em>
+      with no linked pull requests. The extraction was correct — all five sources really
+      do contain <code>fixes #5912</code> — but the §5.1 rubric never checked whether the
+      work <em>landed</em>, and a closing keyword survives rejection intact.
+      <strong>12 of 20 Decisions rested on pull requests that were never merged.</strong>
+      Validation now requires a merged pull request; 7 Decisions were retracted and 13
+      remain, every one with a merged implementer. Issues #16 and #17.
+      Query H1 is now the regression guard for that defect.</p>
+    </div>
 
     <div class="note">
       <p><strong>Nothing here is graded.</strong> §9 requires answers checked against the
@@ -210,12 +226,12 @@ button:hover { opacity: .9; }
 
   <div class="stats">
     <div class="stat"><span class="n">18</span><span class="l">queries</span></div>
-    <div class="stat"><span class="n">12</span><span class="l">answered</span></div>
-    <div class="stat"><span class="n">6</span><span class="l">returned nothing</span></div>
-    <div class="stat good"><span class="n">4/4</span><span class="l">contracts held</span></div>
+    <div class="stat"><span class="n">10</span><span class="l">answered</span></div>
+    <div class="stat"><span class="n">8</span><span class="l">returned nothing</span></div>
+    <div class="stat good"><span class="n">5/5</span><span class="l">contracts held</span></div>
   </div>
 
-  <div class="tiers"><span class="tb tier-explicit" style="flex:41"><span>explicit 41</span></span><span class="tb tier-corroborated" style="flex:30"><span>corroborated 30</span></span></div>
+  <div class="tiers"><span class="tb tier-explicit" style="flex:37"><span>explicit 37</span></span><span class="tb tier-corroborated" style="flex:30"><span>corroborated 30</span></span></div>
   <p class="caption">Evidence tier across every path returned. No path used the inferred
   fallback — the graph holds no inferred edges, so that branch is exercised only by the
   seeded fixture in the test suite.</p>
@@ -525,9 +541,9 @@ button:hover { opacity: .9; }
         <span class="etype">closes</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">body_closing_keyword</span>
-        
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
       </div>
-      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       <div class="step">
         <span class="conn">←</span>
         <span class="etype">implemented_by</span>
@@ -647,7 +663,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_closes_cluster</span>
         <span class="ref">thread:30:pr-5777</span>
       </div>
-      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       </div>
     </li>
     <li class="path">
@@ -799,9 +815,9 @@ button:hover { opacity: .9; }
         <span class="etype">closes</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">body_closing_keyword</span>
-        
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
       </div>
-      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       <div class="step">
         <span class="conn">←</span>
         <span class="etype">implemented_by</span>
@@ -838,18 +854,23 @@ button:hover { opacity: .9; }
     <header class="q-head">
       <div class="q-id">H1</div>
       <div class="q-meta">
-        <span class="cat">Causal reconstruction</span>
+        <span class="cat">Correct refusal</span>
         <span class="meta-chip mode-why">why</span>
         <span class="meta-chip">depth 3</span>
         
-        <span class="meta-chip ans">answered</span>
+        <span class="meta-chip noans">no answer</span>
       </div>
     </header>
 
     <p class="query"><span class="q-label">Query</span> <code>Config.from_file() missing ENOTDIR in silent error handling</code></p>
-    <p class="intent">Hardest clustering case: this issue was closed by FIVE distinct sources (3 PRs + 2 commits), all merged into one thread.</p>
+    <p class="intent">The defect case. Issue 5912 was closed as NOT PLANNED and its three closing PRs were all rejected unmerged, yet every one contains &#x27;fixes #5912&#x27;. Before the landing gate the system asserted a Decision here.</p>
 
     
+        <div class="contract held">
+          <span class="contract-label">Engine contract</span>
+          <span class="contract-state">HELD</span>
+          <p>Must return no answer. Nothing in this thread ever merged, so no Decision may be asserted. This is the regression guard for issues #16/#17.</p>
+        </div>
 
     <section class="block">
       <h4>Retrieval candidates</h4>
@@ -862,12 +883,12 @@ button:hover { opacity: .9; }
               <td class="mono">fuzzy</td>
               <td class="num">1.00</td>
             </tr><tr>
-              <td class="mono">decision:932</td>
-              <td>Config.from_file() missing ENOTDIR in silent error handling</td>
-              <td class="mono">exact</td>
-              <td class="num">1.00</td>
-            </tr><tr>
               <td class="mono">pull_request:704</td>
+              <td>Fix Config.from_file silent error handling to include ENOTDIR</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.72</td>
+            </tr><tr>
+              <td class="mono">commit:706</td>
               <td>Fix Config.from_file silent error handling to include ENOTDIR</td>
               <td class="mono">fuzzy</td>
               <td class="num">0.72</td>
@@ -876,29 +897,11 @@ button:hover { opacity: .9; }
     </section>
 
     <section class="block">
-      <h4>Traversal <span class="count">1 path</span></h4>
-      <ul class="paths">
-    <li class="path">
-      <div class="path-head">
-        <span class="path-n">path 1</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="depth">1 hop</span>
-      </div>
-      <div class="trace">
-        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
-      <div class="step">
-        <span class="conn">←</span>
-        <span class="etype">motivated_by</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5913</span>
-      </div>
-      <div class="node">decision:932 — Config.from_file() missing ENOTDIR in silent error handling</div>
-      </div>
-    </li></ul>
+      <h4>Traversal <span class="count">0 paths</span></h4>
+      <ul class="paths"><li class="empty">No path returned. <span class="mono">no path found, explicit or inferred</span></li></ul>
     </section>
 
-    <div class="verify"><span class="verify-label">Check against flask</span><p>Should all five sources belong to one decision? Did flask really resolve this across multiple PRs, or are some unrelated?</p></div>
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Confirm flask really did decline this work, i.e. the refusal is correct. The artifacts themselves remain queryable — only the Decision is withheld.</p></div>
 
     <footer class="verdict" data-q="H1">
       <span class="v-label">Verdict</span>
@@ -1248,12 +1251,12 @@ button:hover { opacity: .9; }
         <span class="meta-chip mode-why">why</span>
         <span class="meta-chip">depth 3</span>
         
-        <span class="meta-chip ans">answered</span>
+        <span class="meta-chip noans">no answer</span>
       </div>
     </header>
 
     <p class="query"><span class="q-label">Query</span> <code>template_filter decorator broken</code></p>
-    <p class="intent">Fuzzy retrieval — the query wording does not match the issue title, which is &#x27;The `template_filter` decorator doesn&#x27;t work if you don&#x27;t pass an argument&#x27;.</p>
+    <p class="intent">Fuzzy retrieval — the wording does not match the issue title. Note the Decision for this thread was retracted by the landing gate (PR 5735 never merged), so retrieval succeeding while traversal returns nothing is the expected split.</p>
 
     
 
@@ -1268,43 +1271,25 @@ button:hover { opacity: .9; }
               <td class="mono">fuzzy</td>
               <td class="num">0.36</td>
             </tr><tr>
-              <td class="mono">decision:919</td>
-              <td>The `template_filter` decorator doesn&#x27;t work if you don&#x27;t pass an argument</td>
-              <td class="mono">fuzzy</td>
-              <td class="num">0.36</td>
-            </tr><tr>
               <td class="mono">commit:94</td>
               <td>rewrite docs, clean up typing for template decorators</td>
               <td class="mono">fuzzy</td>
               <td class="num">0.32</td>
+            </tr><tr>
+              <td class="mono">commit:92</td>
+              <td>use template_filter without parens</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.31</td>
             </tr></tbody>
       </table>
     </section>
 
     <section class="block">
-      <h4>Traversal <span class="count">1 path</span></h4>
-      <ul class="paths">
-    <li class="path">
-      <div class="path-head">
-        <span class="path-n">path 1</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="depth">1 hop</span>
-      </div>
-      <div class="trace">
-        <div class="node node-start">issue:80 — The `template_filter` decorator doesn&#x27;t work if you don&#x27;t pass an argument</div>
-      <div class="step">
-        <span class="conn">←</span>
-        <span class="etype">motivated_by</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5735</span>
-      </div>
-      <div class="node">decision:919 — The `template_filter` decorator doesn&#x27;t work if you don&#x27;t pass an argument</div>
-      </div>
-    </li></ul>
+      <h4>Traversal <span class="count">0 paths</span></h4>
+      <ul class="paths"><li class="empty">No path returned. <span class="mono">no path found, explicit or inferred</span></li></ul>
     </section>
 
-    <div class="verify"><span class="verify-label">Check against flask</span><p>Did trigram matching find the right entity despite the paraphrase? Would a reasonable user consider this the right hit?</p></div>
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Did trigram matching find the right entity despite the paraphrase? The absent Decision is correct, not a retrieval failure.</p></div>
 
     <footer class="verdict" data-q="H7">
       <span class="v-label">Verdict</span>
@@ -1508,18 +1493,18 @@ button:hover { opacity: .9; }
         <span class="conn">←</span>
         <span class="etype">deployed_by</span>
         <span class="tier tier-explicit">explicit</span>
-        <span class="extractor">synthesis_release_note</span>
-        <span class="ref">release:3.1.2 via #5776</span>
+        <span class="extractor">release_notes_reference</span>
+        <span class="ref">3.1.2</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
       <div class="step">
-        <span class="conn">→</span>
-        <span class="etype">implemented_by</span>
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
         <span class="tier tier-corroborated">corroborated</span>
-        <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5777</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
       </div>
-      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       </div>
     </li>
     <li class="path">
@@ -1534,16 +1519,16 @@ button:hover { opacity: .9; }
         <span class="conn">←</span>
         <span class="etype">deployed_by</span>
         <span class="tier tier-explicit">explicit</span>
-        <span class="extractor">release_notes_reference</span>
-        <span class="ref">3.1.2</span>
+        <span class="extractor">synthesis_release_note</span>
+        <span class="ref">release:3.1.2 via #5776</span>
       </div>
-      <div class="node">issue:51 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
       <div class="step">
-        <span class="conn">←</span>
-        <span class="etype">closes</span>
+        <span class="conn">→</span>
+        <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
-        <span class="extractor">body_closing_keyword</span>
-        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref">thread:30:pr-5777</span>
       </div>
       <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       </div>
@@ -1694,12 +1679,12 @@ button:hover { opacity: .9; }
               <td class="mono">fuzzy</td>
               <td class="num">1.00</td>
             </tr><tr>
-              <td class="mono">decision:932</td>
-              <td>Config.from_file() missing ENOTDIR in silent error handling</td>
-              <td class="mono">exact</td>
-              <td class="num">1.00</td>
-            </tr><tr>
               <td class="mono">pull_request:704</td>
+              <td>Fix Config.from_file silent error handling to include ENOTDIR</td>
+              <td class="mono">fuzzy</td>
+              <td class="num">0.72</td>
+            </tr><tr>
+              <td class="mono">commit:706</td>
               <td>Fix Config.from_file silent error handling to include ENOTDIR</td>
               <td class="mono">fuzzy</td>
               <td class="num">0.72</td>
@@ -1708,7 +1693,7 @@ button:hover { opacity: .9; }
     </section>
 
     <section class="block">
-      <h4>Traversal <span class="count">12 paths</span></h4>
+      <h4>Traversal <span class="count">10 paths</span></h4>
       <ul class="paths">
     <li class="path">
       <div class="path-head">
@@ -1802,7 +1787,7 @@ button:hover { opacity: .9; }
     </li>
         <li class="more">
           <details>
-            <summary>7 further paths</summary>
+            <summary>5 further paths</summary>
             <ul class="paths">
     <li class="path">
       <div class="path-head">
@@ -1933,72 +1918,12 @@ button:hover { opacity: .9; }
       </div>
       <div class="node">pull_request:704 — Fix Config.from_file silent error handling to include ENOTDIR</div>
       </div>
-    </li>
-    <li class="path">
-      <div class="path-head">
-        <span class="path-n">path 11</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="depth">2 hops</span>
-      </div>
-      <div class="trace">
-        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
-      <div class="step">
-        <span class="conn">←</span>
-        <span class="etype">closes</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="extractor">body_closing_keyword</span>
-        
-      </div>
-      <div class="node">pull_request:572 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
-      <div class="step">
-        <span class="conn">←</span>
-        <span class="etype">implemented_by</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5913</span>
-      </div>
-      <div class="node">decision:932 — Config.from_file() missing ENOTDIR in silent error handling</div>
-      </div>
-    </li>
-    <li class="path">
-      <div class="path-head">
-        <span class="path-n">path 12</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="depth">3 hops</span>
-      </div>
-      <div class="trace">
-        <div class="node node-start">issue:576 — Config.from_file() missing ENOTDIR in silent error handling</div>
-      <div class="step">
-        <span class="conn">←</span>
-        <span class="etype">closes</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="extractor">body_closing_keyword</span>
-        
-      </div>
-      <div class="node">commit:574 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
-      <div class="step">
-        <span class="conn">←</span>
-        <span class="etype">implements</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="extractor">pr_commit_list</span>
-        <span class="ref">c8ecf241e3605c48ac84ab863c206f1072888668</span>
-      </div>
-      <div class="node">pull_request:572 — Fix Config.from_file() silent mode not handling ENOTDIR</div>
-      <div class="step">
-        <span class="conn">←</span>
-        <span class="etype">implemented_by</span>
-        <span class="tier tier-explicit">explicit</span>
-        <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5913</span>
-      </div>
-      <div class="node">decision:932 — Config.from_file() missing ENOTDIR in silent error handling</div>
-      </div>
     </li></ul>
           </details>
         </li></ul>
     </section>
 
-    <div class="verify"><span class="verify-label">Check against flask</span><p>Does the blast radius look right, or does thread-merging over-connect unrelated work?</p></div>
+    <div class="verify"><span class="verify-label">Check against flask</span><p>Impact still traverses the rejected PRs as ARTIFACTS, which is correct — they exist and are linked. Only the Decision was withheld. Check the blast radius reads as &#x27;these artifacts are related&#x27; and not as &#x27;this shipped&#x27;.</p></div>
 
     <footer class="verdict" data-q="H9">
       <span class="v-label">Verdict</span>
@@ -2153,9 +2078,9 @@ button:hover { opacity: .9; }
         <span class="etype">closes</span>
         <span class="tier tier-explicit">explicit</span>
         <span class="extractor">body_closing_keyword</span>
-        
+        <span class="ref">https://github.com/pallets/flask/pull/5900</span>
       </div>
-      <div class="node">pull_request:439 — clarify async view incompatibility with gevent monkey patching</div>
+      <div class="node">pull_request:487 — document using gevent for async</div>
       <div class="step">
         <span class="conn">←</span>
         <span class="etype">implemented_by</span>
@@ -2649,9 +2574,9 @@ button:hover { opacity: .9; }
         <span class="etype">closes</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">body_closing_keyword</span>
-        
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
       </div>
-      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       <div class="step">
         <span class="conn">←</span>
         <span class="etype">implemented_by</span>
@@ -2771,7 +2696,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_closes_cluster</span>
         <span class="ref">thread:30:pr-5777</span>
       </div>
-      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       </div>
     </li>
     <li class="path">
@@ -2923,9 +2848,9 @@ button:hover { opacity: .9; }
         <span class="etype">closes</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">body_closing_keyword</span>
-        
+        <span class="ref">https://github.com/pallets/flask/pull/5777</span>
       </div>
-      <div class="node">pull_request:41 — Loosen send_file type annotation to include typing.IO[bytes]</div>
+      <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       <div class="step">
         <span class="conn">←</span>
         <span class="etype">implemented_by</span>

--- a/eval/results.json
+++ b/eval/results.json
@@ -3,16 +3,17 @@
     "target_repo": "pallets/flask",
     "window": "12 months",
     "spec": "PRD v3.1 \u00a79 \u2014 2 flagship queries + 13-18 additional covering harder, less curated cases",
-    "adjudication": "Correctness is decided by a human against flask's actual history. The runner records what the system returned and never grades it. Where a 'contract' field appears, that is a mechanically checkable property of the engine (e.g. 'must return no answer'), not a claim about flask."
+    "adjudication": "Correctness is decided by a human against flask's actual history. The runner records what the system returned and never grades it. Where a 'contract' field appears, that is a mechanically checkable property of the engine (e.g. 'must return no answer'), not a claim about flask.",
+    "revision": "Regenerated after issues #16/#17. The landing gate retracted 7 Decisions that rested on unmerged work; 13 remain, all with a merged implementer."
   },
-  "generated_at": "2026-08-12T19:52:18.687698+05:30",
+  "generated_at": "2026-08-12T20:21:38.196970+05:30",
   "summary": {
     "total": 18,
-    "answered": 12,
-    "returned_no_answer": 6,
-    "contracts_checked": 4,
-    "contracts_held": 4,
-    "used_inferred_fallback": 4,
+    "answered": 10,
+    "returned_no_answer": 8,
+    "contracts_checked": 5,
+    "contracts_held": 5,
+    "used_inferred_fallback": 6,
     "adjudicated": 0
   },
   "results": [
@@ -272,9 +273,9 @@
               "tier": "corroborated",
               "tag": "explicit",
               "extractor": "body_closing_keyword",
-              "source_ref": null,
+              "source_ref": "https://github.com/pallets/flask/pull/5777",
               "direction": "reverse",
-              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
             },
             {
               "edge_type": "implemented_by",
@@ -392,7 +393,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5777",
               "direction": "forward",
-              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
             }
           ]
         },
@@ -542,9 +543,9 @@
               "tier": "corroborated",
               "tag": "explicit",
               "extractor": "body_closing_keyword",
-              "source_ref": null,
+              "source_ref": "https://github.com/pallets/flask/pull/5777",
               "direction": "reverse",
-              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
             },
             {
               "edge_type": "implemented_by",
@@ -576,12 +577,12 @@
     },
     {
       "id": "H1",
-      "category": "causal",
+      "category": "negative",
       "mode": "why",
       "query": "Config.from_file() missing ENOTDIR in silent error handling",
-      "intent": "Hardest clustering case: this issue was closed by FIVE distinct sources (3 PRs + 2 commits), all merged into one thread.",
-      "verify": "Should all five sources belong to one decision? Did flask really resolve this across multiple PRs, or are some unrelated?",
-      "contract": null,
+      "intent": "The defect case. Issue 5912 was closed as NOT PLANNED and its three closing PRs were all rejected unmerged, yet every one contains 'fixes #5912'. Before the landing gate the system asserted a Decision here.",
+      "verify": "Confirm flask really did decline this work, i.e. the refusal is correct. The artifacts themselves remain queryable \u2014 only the Decision is withheld.",
+      "contract": "Must return no answer. Nothing in this thread ever merged, so no Decision may be asserted. This is the regression guard for issues #16/#17.",
       "as_of": null,
       "depth": 3,
       "candidates": [
@@ -594,46 +595,29 @@
           "score": 1.0
         },
         {
-          "node_id": 932,
-          "node_type": "decision",
-          "external_id": "thread:30:pr-5913",
-          "title": "Config.from_file() missing ENOTDIR in silent error handling",
-          "match": "exact",
-          "score": 1.0
-        },
-        {
           "node_id": 704,
           "node_type": "pull_request",
           "external_id": "5955",
           "title": "Fix Config.from_file silent error handling to include ENOTDIR",
           "match": "fuzzy",
           "score": 0.719
-        }
-      ],
-      "paths": [
+        },
         {
-          "tier": "explicit",
-          "depth": 1,
-          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
-          "steps": [
-            {
-              "edge_type": "motivated_by",
-              "tier": "explicit",
-              "tag": "explicit",
-              "extractor": "synthesis_closes_cluster",
-              "source_ref": "thread:30:pr-5913",
-              "direction": "reverse",
-              "to_node": "decision:932 \u2014 Config.from_file() missing ENOTDIR in silent error handling"
-            }
-          ]
+          "node_id": 706,
+          "node_type": "commit",
+          "external_id": "6422bf669e29db4dccebb17becf1f22f1a1634bf",
+          "title": "Fix Config.from_file silent error handling to include ENOTDIR",
+          "match": "fuzzy",
+          "score": 0.719
         }
       ],
-      "used_inferred_fallback": false,
-      "explanation": "1 explicit path(s) found; inferred edges not consulted",
-      "answered": true,
+      "paths": [],
+      "used_inferred_fallback": true,
+      "explanation": "no path found, explicit or inferred",
+      "answered": false,
       "verdict": null,
       "notes": null,
-      "contract_check": null
+      "contract_check": "HELD"
     },
     {
       "id": "H2",
@@ -896,8 +880,8 @@
       "category": "retrieval",
       "mode": "why",
       "query": "template_filter decorator broken",
-      "intent": "Fuzzy retrieval \u2014 the query wording does not match the issue title, which is 'The `template_filter` decorator doesn't work if you don't pass an argument'.",
-      "verify": "Did trigram matching find the right entity despite the paraphrase? Would a reasonable user consider this the right hit?",
+      "intent": "Fuzzy retrieval \u2014 the wording does not match the issue title. Note the Decision for this thread was retracted by the landing gate (PR 5735 never merged), so retrieval succeeding while traversal returns nothing is the expected split.",
+      "verify": "Did trigram matching find the right entity despite the paraphrase? The absent Decision is correct, not a retrieval failure.",
       "contract": null,
       "as_of": null,
       "depth": 3,
@@ -911,43 +895,26 @@
           "score": 0.361
         },
         {
-          "node_id": 919,
-          "node_type": "decision",
-          "external_id": "thread:30:pr-5735",
-          "title": "The `template_filter` decorator doesn't work if you don't pass an argument",
-          "match": "fuzzy",
-          "score": 0.361
-        },
-        {
           "node_id": 94,
           "node_type": "commit",
           "external_id": "edebd3704437f19b5b137eaffe97130fe817d144",
           "title": "rewrite docs, clean up typing for template decorators",
           "match": "fuzzy",
           "score": 0.317
-        }
-      ],
-      "paths": [
+        },
         {
-          "tier": "explicit",
-          "depth": 1,
-          "start": "issue:80 \u2014 The `template_filter` decorator doesn't work if you don't pass an argument",
-          "steps": [
-            {
-              "edge_type": "motivated_by",
-              "tier": "explicit",
-              "tag": "explicit",
-              "extractor": "synthesis_closes_cluster",
-              "source_ref": "thread:30:pr-5735",
-              "direction": "reverse",
-              "to_node": "decision:919 \u2014 The `template_filter` decorator doesn't work if you don't pass an argument"
-            }
-          ]
+          "node_id": 92,
+          "node_type": "commit",
+          "external_id": "daf1510a4bda652ac2cfca03ec5567b03ddf8bf1",
+          "title": "use template_filter without parens",
+          "match": "fuzzy",
+          "score": 0.308
         }
       ],
-      "used_inferred_fallback": false,
-      "explanation": "1 explicit path(s) found; inferred edges not consulted",
-      "answered": true,
+      "paths": [],
+      "used_inferred_fallback": true,
+      "explanation": "no path found, explicit or inferred",
+      "answered": false,
       "verdict": null,
       "notes": null,
       "contract_check": null
@@ -1119,31 +1086,6 @@
               "edge_type": "deployed_by",
               "tier": "explicit",
               "tag": "explicit",
-              "extractor": "synthesis_release_note",
-              "source_ref": "release:3.1.2 via #5776",
-              "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
-            },
-            {
-              "edge_type": "implemented_by",
-              "tier": "corroborated",
-              "tag": "explicit",
-              "extractor": "synthesis_closes_cluster",
-              "source_ref": "thread:30:pr-5777",
-              "direction": "forward",
-              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
-            }
-          ]
-        },
-        {
-          "tier": "corroborated",
-          "depth": 2,
-          "start": "release:961 \u2014 3.1.2",
-          "steps": [
-            {
-              "edge_type": "deployed_by",
-              "tier": "explicit",
-              "tag": "explicit",
               "extractor": "release_notes_reference",
               "source_ref": "3.1.2",
               "direction": "reverse",
@@ -1156,6 +1098,31 @@
               "extractor": "body_closing_keyword",
               "source_ref": "https://github.com/pallets/flask/pull/5777",
               "direction": "reverse",
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
+            }
+          ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 2,
+          "start": "release:961 \u2014 3.1.2",
+          "steps": [
+            {
+              "edge_type": "deployed_by",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "synthesis_release_note",
+              "source_ref": "release:3.1.2 via #5776",
+              "direction": "reverse",
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+            },
+            {
+              "edge_type": "implemented_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5777",
+              "direction": "forward",
               "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
             }
           ]
@@ -1274,7 +1241,7 @@
       "mode": "impact",
       "query": "Config.from_file() missing ENOTDIR in silent error handling",
       "intent": "Forward traversal over the 5-source cluster.",
-      "verify": "Does the blast radius look right, or does thread-merging over-connect unrelated work?",
+      "verify": "Impact still traverses the rejected PRs as ARTIFACTS, which is correct \u2014 they exist and are linked. Only the Decision was withheld. Check the blast radius reads as 'these artifacts are related' and not as 'this shipped'.",
       "contract": null,
       "as_of": null,
       "depth": 3,
@@ -1288,17 +1255,17 @@
           "score": 1.0
         },
         {
-          "node_id": 932,
-          "node_type": "decision",
-          "external_id": "thread:30:pr-5913",
-          "title": "Config.from_file() missing ENOTDIR in silent error handling",
-          "match": "exact",
-          "score": 1.0
-        },
-        {
           "node_id": 704,
           "node_type": "pull_request",
           "external_id": "5955",
+          "title": "Fix Config.from_file silent error handling to include ENOTDIR",
+          "match": "fuzzy",
+          "score": 0.719
+        },
+        {
+          "node_id": 706,
+          "node_type": "commit",
+          "external_id": "6422bf669e29db4dccebb17becf1f22f1a1634bf",
           "title": "Fix Config.from_file silent error handling to include ENOTDIR",
           "match": "fuzzy",
           "score": 0.719
@@ -1509,69 +1476,10 @@
               "to_node": "pull_request:704 \u2014 Fix Config.from_file silent error handling to include ENOTDIR"
             }
           ]
-        },
-        {
-          "tier": "explicit",
-          "depth": 2,
-          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
-          "steps": [
-            {
-              "edge_type": "closes",
-              "tier": "explicit",
-              "tag": "explicit",
-              "extractor": "body_closing_keyword",
-              "source_ref": null,
-              "direction": "reverse",
-              "to_node": "pull_request:572 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
-            },
-            {
-              "edge_type": "implemented_by",
-              "tier": "explicit",
-              "tag": "explicit",
-              "extractor": "synthesis_closes_cluster",
-              "source_ref": "thread:30:pr-5913",
-              "direction": "reverse",
-              "to_node": "decision:932 \u2014 Config.from_file() missing ENOTDIR in silent error handling"
-            }
-          ]
-        },
-        {
-          "tier": "explicit",
-          "depth": 3,
-          "start": "issue:576 \u2014 Config.from_file() missing ENOTDIR in silent error handling",
-          "steps": [
-            {
-              "edge_type": "closes",
-              "tier": "explicit",
-              "tag": "explicit",
-              "extractor": "body_closing_keyword",
-              "source_ref": null,
-              "direction": "reverse",
-              "to_node": "commit:574 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
-            },
-            {
-              "edge_type": "implements",
-              "tier": "explicit",
-              "tag": "explicit",
-              "extractor": "pr_commit_list",
-              "source_ref": "c8ecf241e3605c48ac84ab863c206f1072888668",
-              "direction": "reverse",
-              "to_node": "pull_request:572 \u2014 Fix Config.from_file() silent mode not handling ENOTDIR"
-            },
-            {
-              "edge_type": "implemented_by",
-              "tier": "explicit",
-              "tag": "explicit",
-              "extractor": "synthesis_closes_cluster",
-              "source_ref": "thread:30:pr-5913",
-              "direction": "reverse",
-              "to_node": "decision:932 \u2014 Config.from_file() missing ENOTDIR in silent error handling"
-            }
-          ]
         }
       ],
       "used_inferred_fallback": false,
-      "explanation": "12 explicit path(s) found; inferred edges not consulted",
+      "explanation": "10 explicit path(s) found; inferred edges not consulted",
       "answered": true,
       "verdict": null,
       "notes": null,
@@ -1706,9 +1614,9 @@
               "tier": "explicit",
               "tag": "explicit",
               "extractor": "body_closing_keyword",
-              "source_ref": null,
+              "source_ref": "https://github.com/pallets/flask/pull/5900",
               "direction": "reverse",
-              "to_node": "pull_request:439 \u2014 clarify async view incompatibility with gevent monkey patching"
+              "to_node": "pull_request:487 \u2014 document using gevent for async"
             },
             {
               "edge_type": "implemented_by",
@@ -2062,9 +1970,9 @@
               "tier": "corroborated",
               "tag": "explicit",
               "extractor": "body_closing_keyword",
-              "source_ref": null,
+              "source_ref": "https://github.com/pallets/flask/pull/5777",
               "direction": "reverse",
-              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
             },
             {
               "edge_type": "implemented_by",
@@ -2182,7 +2090,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5777",
               "direction": "forward",
-              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
             }
           ]
         },
@@ -2332,9 +2240,9 @@
               "tier": "corroborated",
               "tag": "explicit",
               "extractor": "body_closing_keyword",
-              "source_ref": null,
+              "source_ref": "https://github.com/pallets/flask/pull/5777",
               "direction": "reverse",
-              "to_node": "pull_request:41 \u2014 Loosen send_file type annotation to include typing.IO[bytes]"
+              "to_node": "pull_request:64 \u2014 use IO[bytes] instead of BinaryIO for wider compatibility"
             },
             {
               "edge_type": "implemented_by",

--- a/src/decision_graph/extractors.py
+++ b/src/decision_graph/extractors.py
@@ -152,6 +152,11 @@ def extract_issue_or_pr(ctx: Context, payload: dict[str, Any]) -> int:
     )
 
     if is_pr:
+        # Merge state is nested under the `pull_request` sub-object on this endpoint,
+        # NOT at the top level. Reading payload["merged_at"] silently yields None, which
+        # is how 27 real merges were discarded for the whole of Phase 1-3 (issue #16).
+        # merged_at is what distinguishes work that landed from work that was refused,
+        # and the §5.1 rubric depends on it.
         db.upsert_detail(
             ctx.conn,
             "pull_request",
@@ -160,8 +165,12 @@ def extract_issue_or_pr(ctx: Context, payload: dict[str, Any]) -> int:
             state=payload.get("state") or "unknown",
             body=body,
             closed_at=parse_ts(payload.get("closed_at")),
+            merged_at=parse_ts((payload.get("pull_request") or {}).get("merged_at")),
         )
     else:
+        # state_reason separates an issue that was resolved (`completed`) from one the
+        # maintainers declined (`not_planned`). Without it, a refusal is indistinguishable
+        # from a fix.
         db.upsert_detail(
             ctx.conn,
             "issue",
@@ -170,6 +179,7 @@ def extract_issue_or_pr(ctx: Context, payload: dict[str, Any]) -> int:
             state=payload.get("state") or "unknown",
             body=body,
             closed_at=parse_ts(payload.get("closed_at")),
+            state_reason=payload.get("state_reason"),
         )
 
     # created: author -> artifact

--- a/src/decision_graph/run.py
+++ b/src/decision_graph/run.py
@@ -71,6 +71,10 @@ def ingest(
 
         if synthesize:
             log.info("--- decision synthesis ---")
+            # Retract first: a rule change or invalidated evidence must be able to
+            # WITHDRAW a Decision, not merely fail to create new ones (issue #17).
+            synthesis.retract_unsupported(conn)
+            conn.commit()
             outcome = synthesis.synthesize(conn, repo_node_id)
             conn.commit()
             # Runs after promotion so a Decision created this run can be upgraded in the

--- a/src/decision_graph/synthesis.py
+++ b/src/decision_graph/synthesis.py
@@ -59,7 +59,13 @@ WHERE e.edge_type = 'closes'
   AND src.thread_key IS NOT NULL
   AND src.thread_key = dst.thread_key
 ORDER BY src.thread_key,
-         (src.node_type = 'pull_request') DESC,  -- a PR is a better implementer than a bare commit
+         -- A MERGED pull request is the implementer. Ordering by node id first (as this
+         -- did originally) picked whichever artifact happened to be written earliest,
+         -- which named an unmerged PR in 5 threads that contained a merged one --
+         -- including flagship F2, where PR 5794 (never merged) was credited over PR 5777
+         -- (merged 2025-08-18). Attribution has to follow what landed, not insertion order.
+         (pr.merged_at IS NOT NULL) DESC,
+         (src.node_type = 'pull_request') DESC,  -- then a PR over a bare commit
          dst.id,
          src.id
 """
@@ -75,6 +81,23 @@ class SynthesisResult:
     def __post_init__(self) -> None:
         if self.refusals is None:
             self.refusals = []
+
+
+def retract_unsupported(conn: psycopg.Connection) -> tuple[int, list[str]]:
+    """Withdraw Decisions that no longer satisfy the rubric (issue #17).
+
+    Must run BEFORE synthesis. The deferred guard only re-validates rows something
+    touches, so a Decision asserted under an older, looser rule survives indefinitely
+    unless it is explicitly revisited. A claim the graph no longer supports has to go.
+    """
+    row = conn.execute("SELECT * FROM retract_unsupported_decisions()").fetchone()
+    count = int(row["retracted"]) if row else 0
+    threads = list(row["thread_keys"]) if row and row["thread_keys"] else []
+    if count:
+        log.warning("retracted %s Decision(s) no longer supported by evidence", count)
+        for t in threads:
+            log.warning("  retracted %s", t)
+    return count, threads
 
 
 def synthesize(conn: psycopg.Connection, repo_node_id: int) -> SynthesisResult:
@@ -226,6 +249,36 @@ def _promote(conn: psycopg.Connection, repo_node_id: int, row: dict) -> bool:
         extractor="synthesis_closes_cluster",
         source_ref=thread_key,
         observed_at=row["decided_at"],
+    )
+
+    # Withdraw rubric edges this Decision used to claim but no longer selects.
+    #
+    # Upserting the correct edge is not enough: a DIFFERENT destination is a different
+    # row, so the old edge simply survives alongside the new one. When the implementer
+    # tie-break changed to prefer merged PRs, every re-pointed Decision ended up
+    # asserting two implementers at once -- F2 credited both PR 5794 (never merged) and
+    # PR 5777 (merged). Idempotent for an unchanged selection is not the same as
+    # idempotent for a changed one.
+    #
+    # Superseded edges are time-versioned rather than deleted, so the graph keeps a
+    # record of what it used to claim. valid_from < now() excludes edges created in this
+    # same transaction, which cannot be closed (the 0001 CHECK requires valid_to >
+    # valid_from, and now() is frozen per transaction).
+    conn.execute(
+        """
+        UPDATE edge
+        SET valid_to = now()
+        WHERE src_node_id = %(decision)s
+          AND edge_type IN ('motivated_by', 'implemented_by')
+          AND valid_to IS NULL
+          AND valid_from < now()
+          AND dst_node_id NOT IN (%(motivator)s, %(implementer)s)
+        """,
+        {
+            "decision": decision_node_id,
+            "motivator": row["motivator_id"],
+            "implementer": row["implementer_id"],
+        },
     )
 
     return existing is None


### PR DESCRIPTION
Closes #16, closes #17. Found when a reviewer checked issue 5912 against GitHub and saw *Closed as not planned* with no linked PRs.

The extraction was correct — all five sources genuinely contain `fixes #5912`. The **decision** was wrong: the maintainers refused this work and the system asserted the opposite.

## Three defects, one root cause: nothing modelled whether work landed

**#16 — `merged_at` never populated.** `extract_issue_or_pr` read `payload["merged_at"]`, but the `/issues` endpoint nests merge state under `payload["pull_request"]["merged_at"]`. The column has existed since migration 0001 and always held NULL, discarding 27 real merges. Nothing read it, so nothing failed. `issue.state_reason` was never modelled at all. Both backfilled from the `raw` JSONB already stored — no API calls, bounded window untouched.

**#17 — the rubric never checked landing.** Validation was satisfied by a `closes` edge, but a closing keyword is typed by a contributor *before* the outcome is known and survives rejection intact.

**Implementer attribution** — the tie-break ordered by node id, crediting whichever artifact was written first.

## The gate applies to Implementation too, not only Validation

Clause 2 is an OR. Tightening Validation alone would have been **inert** — every rejected cluster still qualified through Implementation, since all 20 satisfied both.

Gating both is faithful to the PRD rather than an extension of it. §5.1's own worked example reads: *"a **merged**, reviewed PR with no linked issue describes that something happened and that it landed, but not why."* The rubric's picture of Implementation was always a merged PR; the code never checked.

## Result

| | before | after |
|---|---|---|
| Decisions | 20 | **13** |
| with a merged implementer | 8 | **13 / 13** |
| motivated by a declined issue | 4 | **0** |
| failing the rubric audit | 0 | 0 |

7 retracted. Flagship F2 now credits PR 5777 (merged 2025-08-18) instead of PR 5794 (never merged).

## Corroboration needed no recomputation — and the reason is interesting

All 6 corroborated threads contain a merged PR. **PUBLISHED is the one category that does not survive rejection:**

| category | threads | landed |
|---|---|---|
| PUBLISHED | 3 | **3/3** |
| DECLARED without PUBLISHED | 17 | 10/17 |

A maintainer citing an issue in a release note is written *after* the outcome, by someone with authority over it. The other three categories are contributor-authored before the outcome is known. So the tier was sound; what was wrong was implementer attribution *inside* those threads.

I need to correct something I said earlier: "two corroborated explicit Decisions rest on unmerged PRs" was wrong. The threads landed — synthesis just named the wrong PR within them.

## Retraction, and a bug found while building it

The deferred guard only re-validates rows something touches, so Decisions asserted under the old rule would have survived indefinitely. `retract_unsupported_decisions()` withdraws them — same principle as `apply_corroboration()` being reversible.

Building it surfaced a further bug: promotion was idempotent for an *unchanged* selection but not a *changed* one. Re-pointing the implementer left the old `implemented_by` edge in place, so F2 briefly asserted **two** implementers at once. Superseded rubric edges are now time-versioned rather than deleted, keeping a record of what the graph used to claim.

## Tests

6 new landing checks. Three rubric fixtures broke — stale, not regressions: they asserted acceptance from clusters with no merge. I updated them so each still isolates the clause it names, rather than just satisfying the gate; without that fix T3 would have passed for the wrong reason ("rejected because nothing merged" instead of "rejected because there is no Implementation").

**30 SQL checks and 20 Python tests green.**

## Evaluation regenerated

10 answered, 8 returned nothing, **5/5 contracts held**. H1 is promoted from a showcase clustering result to the **regression guard** for this defect.

## PRD

Adds a Phase 5+ roadmap note on modelling rejected decisions as a first-class outcome. Not a rubric tweak — the *why* of a refusal lives in closing comments and review discussion, which extraction-first does not read yet. Adding a `rejected` status without that would reintroduce the exact failure §5.1 exists to prevent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pCAUDALD1g8DBsf8j8PuK