### PR TITLE
Show the credited implementer in evaluation traces

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,6 @@ dg-ingest --resources issues --max-pages 1   # smoke test; leaves cursor mid-win
 `GITHUB_TOKEN` is required — unauthenticated access is capped at 60 req/hour, which
 cannot complete a backfill.
 
-## Tests
-
 ## Evaluation (§9)
 
 ```bash
@@ -240,15 +238,29 @@ control is the load-bearing one: F1 returns 1 path and drops to 0 when asked as 
 2025-06, while F2 returns 17 both now and as of 2026-12 — so the time filter restricts in
 one direction only, rather than being silently ignored.
 
+**Every Decision in a trace names the artifact it is credited to.** A Why-walk reaching a
+Decision across `motivated_by` stops there and never traverses `implemented_by`, so the
+only PR number on the page used to be the one inside the `thread_key` — and that key names
+the *cluster*, chosen order-independently as PR-preferring-then-lowest-number. Where a
+change took two attempts it names the abandoned one: decision 928 sits in
+`thread:30:pr-5867`, but 5867 was never merged and PR 5899 did the work. 3 of 13 Decisions
+read that way. The graph was right and the report was misleading, which is the worse
+failure of the two — it made a stale label and a stale edge indistinguishable on sight,
+and telling those apart is the whole job during adjudication. Traces now carry the current
+`implemented_by` target and its merge date, every one of them if there is more than one,
+with an unmerged or absent implementer flagged rather than omitted (issue #19).
+
 ## Tests
 
 ```bash
 psql "$DATABASE_URL" -f db/tests/0002_rubric_checks.sql             # 13 checks
 psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 18 checks
+psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 38 checks
 ```
 
-All SQL suites run in a transaction and roll back. The Python suite runs 11 unit tests
-standalone; setting `DATABASE_URL` adds the 7 traversal-fallback integration tests,
-which seed their own fixture because the real graph holds no inferred edges.
+All SQL suites run in a transaction and roll back. The Python suite runs 26 tests
+standalone; setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
+fallback, which seed their own fixture because the real graph holds no inferred edges,
+and 5 for the trace annotation.

--- a/eval/render_report.py
+++ b/eval/render_report.py
@@ -30,22 +30,54 @@ def e(text) -> str:
     return html.escape(str(text if text is not None else ""))
 
 
+# Anything the annotation flags as a broken claim. Styled as a warning rather than as
+# ordinary detail so it cannot be skimmed past.
+WARN_MARKERS = ("NOT MERGED", "no current implementer")
+
+
+def render_node(text, extra_class: str = "") -> str:
+    """Render a node label, splitting off the trailing `[...]` annotation if present.
+
+    Split from the RIGHT and only when the string closes with `]`: real flask titles
+    contain brackets (`typing.IO[bytes]`), and a left split would tear one of those in
+    half. The annotation is always appended last, so the rightmost match is the only
+    candidate that can be one.
+    """
+    label = str(text or "")
+    head, sep, tail = label.rpartition("  [")
+    note = ""
+    if sep and tail.endswith("]"):
+        body = tail[:-1]
+        cls = "node-note warn" if any(m in body for m in WARN_MARKERS) else "node-note"
+        note = f'<span class="{cls}">{e(body)}</span>'
+    else:
+        head = label
+    classes = " ".join(filter(None, ("node", extra_class)))
+    return f'<div class="{classes}">{e(head)}{note}</div>'
+
+
+def render_ref(source_ref) -> str:
+    if not source_ref:
+        return ""
+    # A bare `thread:...` is the union-find cluster id, and the PR number inside it is
+    # whichever attempt sorted first -- not necessarily the one that shipped. Labelling it
+    # stops it reading as an attribution (issue #19).
+    if str(source_ref).startswith("thread:"):
+        return f'<span class="ref"><span class="ref-kind">cluster</span>{e(source_ref)}</span>'
+    return f'<span class="ref">{e(source_ref)}</span>'
+
+
 def render_step(step: dict) -> str:
     arrow = "→" if step["direction"] == "forward" else "←"
-    ref = (
-        f'<span class="ref">{e(step["source_ref"])}</span>'
-        if step.get("source_ref")
-        else ""
-    )
     return f"""
       <div class="step">
         <span class="conn">{arrow}</span>
         <span class="etype">{e(step["edge_type"])}</span>
         <span class="tier tier-{e(step["tier"])}">{e(step["tier"])}</span>
         <span class="extractor">{e(step["extractor"])}</span>
-        {ref}
+        {render_ref(step.get("source_ref"))}
       </div>
-      <div class="node">{e(step["to_node"])}</div>"""
+      {render_node(step["to_node"])}"""
 
 
 def render_path(path: dict, index: int) -> str:
@@ -58,7 +90,7 @@ def render_path(path: dict, index: int) -> str:
         <span class="depth">{path["depth"]} hop{"s" if path["depth"] != 1 else ""}</span>
       </div>
       <div class="trace">
-        <div class="node node-start">{e(path["start"])}</div>{steps}
+        {render_node(path["start"], "node-start")}{steps}
       </div>
     </li>"""
 
@@ -358,12 +390,17 @@ ul.paths {{ list-style: none; margin: 0; padding: 0; display: flex;
   padding: .7rem .85rem; overflow-x: auto; border-radius: 2px; }}
 .node {{ white-space: nowrap; padding: .1rem 0; }}
 .node-start {{ font-weight: 700; }}
+.node-note {{ color: var(--accent); font-weight: 400; margin-left: .5rem; }}
+.node-note::before {{ content: "· "; color: var(--faint); }}
+.node-note.warn {{ color: var(--violated); font-weight: 700; }}
 .step {{ display: flex; gap: .5rem; align-items: center; padding: .12rem 0 .12rem 1.1rem;
   border-left: 1px solid var(--rule); margin-left: .35rem; white-space: nowrap; }}
 .conn {{ color: var(--faint); }}
 .etype {{ color: var(--ink); font-weight: 600; }}
 .extractor {{ color: var(--faint); font-size: .92em; }}
 .ref {{ color: var(--faint); font-size: .88em; opacity: .75; }}
+.ref-kind {{ text-transform: uppercase; letter-spacing: .06em; font-size: .82em;
+  padding: 0 .3rem; margin-right: .35rem; background: var(--rule); border-radius: 2px; }}
 
 .tier {{ font-size: .66rem; text-transform: uppercase; letter-spacing: .05em;
   padding: .08rem .4rem; border-radius: 2px; color: #fff; font-weight: 600;
@@ -417,6 +454,18 @@ button:hover {{ opacity: .9; }}
       Validation now requires a merged pull request; 7 Decisions were retracted and 13
       remain, every one with a merged implementer. Issues #16 and #17.
       Query H1 is now the regression guard for that defect.</p>
+    </div>
+
+    <div class="note">
+      <p><strong>Read the annotation, not the cluster id.</strong>
+      A Decision's <code>thread:…</code> key names its cluster, and that name is chosen
+      order-independently — PR-preferring, then lowest number — so when a change took two
+      attempts the cluster is named after the <em>abandoned</em> one. 3 of 13 Decisions
+      here are. Every Decision node in a trace now carries the pull request the graph
+      actually credits it to and that PR's merge date, so a stale label and a stale edge
+      no longer look alike. <code>NOT MERGED</code> or a missing implementer renders in
+      red; neither should appear. Issue #19 — display only, the keys themselves are
+      unchanged.</p>
     </div>
 
     <div class="note">

--- a/eval/report.html
+++ b/eval/report.html
@@ -153,12 +153,17 @@ ul.paths { list-style: none; margin: 0; padding: 0; display: flex;
   padding: .7rem .85rem; overflow-x: auto; border-radius: 2px; }
 .node { white-space: nowrap; padding: .1rem 0; }
 .node-start { font-weight: 700; }
+.node-note { color: var(--accent); font-weight: 400; margin-left: .5rem; }
+.node-note::before { content: "· "; color: var(--faint); }
+.node-note.warn { color: var(--violated); font-weight: 700; }
 .step { display: flex; gap: .5rem; align-items: center; padding: .12rem 0 .12rem 1.1rem;
   border-left: 1px solid var(--rule); margin-left: .35rem; white-space: nowrap; }
 .conn { color: var(--faint); }
 .etype { color: var(--ink); font-weight: 600; }
 .extractor { color: var(--faint); font-size: .92em; }
 .ref { color: var(--faint); font-size: .88em; opacity: .75; }
+.ref-kind { text-transform: uppercase; letter-spacing: .06em; font-size: .82em;
+  padding: 0 .3rem; margin-right: .35rem; background: var(--rule); border-radius: 2px; }
 
 .tier { font-size: .66rem; text-transform: uppercase; letter-spacing: .05em;
   padding: .08rem .4rem; border-radius: 2px; color: #fff; font-weight: 600;
@@ -200,7 +205,7 @@ button:hover { opacity: .9; }
   <div class="lede">
     <h1>Evaluation worksheet</h1>
     <p class="sub">Decision Graph against <code>pallets/flask</code> — PRD v3.1 §9.
-    18 queries: 2 flagship plus 16 harder cases. Generated 2026-08-12 20:21.</p>
+    18 queries: 2 flagship plus 16 harder cases. Generated 2026-08-14 19:06.</p>
 
     <div class="note fixed">
       <p><strong>Regenerated after a defect found in adjudication.</strong>
@@ -212,6 +217,18 @@ button:hover { opacity: .9; }
       Validation now requires a merged pull request; 7 Decisions were retracted and 13
       remain, every one with a merged implementer. Issues #16 and #17.
       Query H1 is now the regression guard for that defect.</p>
+    </div>
+
+    <div class="note">
+      <p><strong>Read the annotation, not the cluster id.</strong>
+      A Decision's <code>thread:…</code> key names its cluster, and that name is chosen
+      order-independently — PR-preferring, then lowest number — so when a change took two
+      attempts the cluster is named after the <em>abandoned</em> one. 3 of 13 Decisions
+      here are. Every Decision node in a trace now carries the pull request the graph
+      actually credits it to and that PR's merge date, so a stale label and a stale edge
+      no longer look alike. <code>NOT MERGED</code> or a missing implementer renders in
+      red; neither should appear. Issue #19 — display only, the keys themselves are
+      unchanged.</p>
     </div>
 
     <div class="note">
@@ -305,9 +322,9 @@ button:hover { opacity: .9; }
         <span class="etype">motivated_by</span>
         <span class="tier tier-explicit">explicit</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5898</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5898</span>
       </div>
-      <div class="node">decision:930 — change default redirect code to 303</div>
+      <div class="node">decision:930 — change default redirect code to 303<span class="node-note">implemented by PR 5898, merged 2026-01-25</span></div>
       </div>
     </li></ul>
     </section>
@@ -549,9 +566,9 @@ button:hover { opacity: .9; }
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5777</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5777</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       </div>
     </li>
     <li class="path">
@@ -577,7 +594,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5776</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       </div>
     </li>
     <li class="path">
@@ -603,7 +620,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5786</span>
       </div>
-      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests<span class="node-note">implemented by PR 5797, merged 2025-08-18</span></div>
       </div>
     </li>
     <li class="path">
@@ -629,7 +646,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5774</span>
       </div>
-      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes<span class="node-note">implemented by PR 5799, merged 2025-08-19</span></div>
       </div>
     </li>
     <li class="path">
@@ -655,13 +672,13 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5776</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5777</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5777</span>
       </div>
       <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       </div>
@@ -723,13 +740,13 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5786</span>
       </div>
-      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests<span class="node-note">implemented by PR 5797, merged 2025-08-18</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5797</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5797</span>
       </div>
       <div class="node">pull_request:76 — push preserved contexts in correct order</div>
       </div>
@@ -791,13 +808,13 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5774</span>
       </div>
-      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes<span class="node-note">implemented by PR 5799, merged 2025-08-19</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5799</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5799</span>
       </div>
       <div class="node">pull_request:100 — refactor stream_with_context for async views</div>
       </div>
@@ -823,9 +840,9 @@ button:hover { opacity: .9; }
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5777</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5777</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">deployed_by</span>
@@ -968,9 +985,9 @@ button:hover { opacity: .9; }
         <span class="etype">motivated_by</span>
         <span class="tier tier-explicit">explicit</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5812</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5812</span>
       </div>
-      <div class="node">decision:923 — merge app and request contexts into a single context</div>
+      <div class="node">decision:923 — merge app and request contexts into a single context<span class="node-note">implemented by PR 5812, merged 2025-09-19</span></div>
       </div>
     </li></ul>
     </section>
@@ -1042,9 +1059,9 @@ button:hover { opacity: .9; }
         <span class="etype">motivated_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5722</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5722</span>
       </div>
-      <div class="node">decision:918 — Recommend Warning and Safer Defaults for url_for(..., _external=True)</div>
+      <div class="node">decision:918 — Recommend Warning and Safer Defaults for url_for(..., _external=True)<span class="node-note">implemented by PR 5798, merged 2025-08-18</span></div>
       </div>
     </li></ul>
     </section>
@@ -1116,9 +1133,9 @@ button:hover { opacity: .9; }
         <span class="etype">motivated_by</span>
         <span class="tier tier-explicit">explicit</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5867</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5867</span>
       </div>
-      <div class="node">decision:928 — deprecate `should_ignore_error`</div>
+      <div class="node">decision:928 — deprecate `should_ignore_error`<span class="node-note">implemented by PR 5899, merged 2026-01-25</span></div>
       </div>
     </li></ul>
     </section>
@@ -1180,9 +1197,9 @@ button:hover { opacity: .9; }
         <span class="etype">implemented_by</span>
         <span class="tier tier-explicit">explicit</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5898</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5898</span>
       </div>
-      <div class="node">decision:930 — change default redirect code to 303</div>
+      <div class="node">decision:930 — change default redirect code to 303<span class="node-note">implemented by PR 5898, merged 2026-01-25</span></div>
       </div>
     </li></ul>
     </section>
@@ -1412,7 +1429,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5776</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       </div>
     </li>
     <li class="path">
@@ -1430,7 +1447,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5786</span>
       </div>
-      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests<span class="node-note">implemented by PR 5797, merged 2025-08-18</span></div>
       </div>
     </li>
         <li class="more">
@@ -1452,7 +1469,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5774</span>
       </div>
-      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes<span class="node-note">implemented by PR 5799, merged 2025-08-19</span></div>
       </div>
     </li>
     <li class="path">
@@ -1522,13 +1539,13 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5776</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5777</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5777</span>
       </div>
       <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       </div>
@@ -1574,13 +1591,13 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5786</span>
       </div>
-      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests<span class="node-note">implemented by PR 5797, merged 2025-08-18</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5797</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5797</span>
       </div>
       <div class="node">pull_request:76 — push preserved contexts in correct order</div>
       </div>
@@ -1626,13 +1643,13 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5774</span>
       </div>
-      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes<span class="node-note">implemented by PR 5799, merged 2025-08-19</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5799</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5799</span>
       </div>
       <div class="node">pull_request:100 — refactor stream_with_context for async views</div>
       </div>
@@ -2086,9 +2103,9 @@ button:hover { opacity: .9; }
         <span class="etype">implemented_by</span>
         <span class="tier tier-explicit">explicit</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5885</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5885</span>
       </div>
-      <div class="node">decision:929 — asgiref fails with gevent patching</div>
+      <div class="node">decision:929 — asgiref fails with gevent patching<span class="node-note">implemented by PR 5900, merged 2026-01-25</span></div>
       </div>
     </li></ul>
     </section>
@@ -2582,9 +2599,9 @@ button:hover { opacity: .9; }
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5777</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5777</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       </div>
     </li>
     <li class="path">
@@ -2610,7 +2627,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5776</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       </div>
     </li>
     <li class="path">
@@ -2636,7 +2653,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5786</span>
       </div>
-      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests<span class="node-note">implemented by PR 5797, merged 2025-08-18</span></div>
       </div>
     </li>
     <li class="path">
@@ -2662,7 +2679,7 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5774</span>
       </div>
-      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes<span class="node-note">implemented by PR 5799, merged 2025-08-19</span></div>
       </div>
     </li>
     <li class="path">
@@ -2688,13 +2705,13 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5776</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5777</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5777</span>
       </div>
       <div class="node">pull_request:64 — use IO[bytes] instead of BinaryIO for wider compatibility</div>
       </div>
@@ -2756,13 +2773,13 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5786</span>
       </div>
-      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests</div>
+      <div class="node">decision:921 — Session is not updated on redirect target endpoint in tests<span class="node-note">implemented by PR 5797, merged 2025-08-18</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5797</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5797</span>
       </div>
       <div class="node">pull_request:76 — push preserved contexts in correct order</div>
       </div>
@@ -2824,13 +2841,13 @@ button:hover { opacity: .9; }
         <span class="extractor">synthesis_release_note</span>
         <span class="ref">release:3.1.2 via #5774</span>
       </div>
-      <div class="node">decision:922 — `stream_with_context` does not work with async routes</div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes<span class="node-note">implemented by PR 5799, merged 2025-08-19</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5799</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5799</span>
       </div>
       <div class="node">pull_request:100 — refactor stream_with_context for async views</div>
       </div>
@@ -2856,9 +2873,9 @@ button:hover { opacity: .9; }
         <span class="etype">implemented_by</span>
         <span class="tier tier-corroborated">corroborated</span>
         <span class="extractor">synthesis_closes_cluster</span>
-        <span class="ref">thread:30:pr-5777</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5777</span>
       </div>
-      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument</div>
+      <div class="node">decision:920 — Looser type annotations for send_file() path_or_file argument<span class="node-note">implemented by PR 5777, merged 2025-08-18</span></div>
       <div class="step">
         <span class="conn">→</span>
         <span class="etype">deployed_by</span>

--- a/eval/results.json
+++ b/eval/results.json
@@ -6,7 +6,7 @@
     "adjudication": "Correctness is decided by a human against flask's actual history. The runner records what the system returned and never grades it. Where a 'contract' field appears, that is a mechanically checkable property of the engine (e.g. 'must return no answer'), not a claim about flask.",
     "revision": "Regenerated after issues #16/#17. The landing gate retracted 7 Decisions that rested on unmerged work; 13 remain, all with a merged implementer."
   },
-  "generated_at": "2026-08-12T20:21:38.196970+05:30",
+  "generated_at": "2026-08-14T19:06:40.138845+05:30",
   "summary": {
     "total": 18,
     "answered": 10,
@@ -66,7 +66,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5898",
               "direction": "reverse",
-              "to_node": "decision:930 \u2014 change default redirect code to 303"
+              "to_node": "decision:930 \u2014 change default redirect code to 303  [implemented by PR 5898, merged 2026-01-25]"
             }
           ]
         }
@@ -284,7 +284,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5777",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             }
           ]
         },
@@ -309,7 +309,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5776",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             }
           ]
         },
@@ -334,7 +334,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5786",
               "direction": "reverse",
-              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests  [implemented by PR 5797, merged 2025-08-18]"
             }
           ]
         },
@@ -359,7 +359,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5774",
               "direction": "reverse",
-              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes  [implemented by PR 5799, merged 2025-08-19]"
             }
           ]
         },
@@ -384,7 +384,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5776",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             },
             {
               "edge_type": "implemented_by",
@@ -452,7 +452,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5786",
               "direction": "reverse",
-              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests  [implemented by PR 5797, merged 2025-08-18]"
             },
             {
               "edge_type": "implemented_by",
@@ -520,7 +520,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5774",
               "direction": "reverse",
-              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes  [implemented by PR 5799, merged 2025-08-19]"
             },
             {
               "edge_type": "implemented_by",
@@ -554,7 +554,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5777",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             },
             {
               "edge_type": "deployed_by",
@@ -668,7 +668,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5812",
               "direction": "reverse",
-              "to_node": "decision:923 \u2014 merge app and request contexts into a single context"
+              "to_node": "decision:923 \u2014 merge app and request contexts into a single context  [implemented by PR 5812, merged 2025-09-19]"
             }
           ]
         }
@@ -729,7 +729,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5722",
               "direction": "reverse",
-              "to_node": "decision:918 \u2014 Recommend Warning and Safer Defaults for url_for(..., _external=True)"
+              "to_node": "decision:918 \u2014 Recommend Warning and Safer Defaults for url_for(..., _external=True)  [implemented by PR 5798, merged 2025-08-18]"
             }
           ]
         }
@@ -790,7 +790,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5867",
               "direction": "reverse",
-              "to_node": "decision:928 \u2014 deprecate `should_ignore_error`"
+              "to_node": "decision:928 \u2014 deprecate `should_ignore_error`  [implemented by PR 5899, merged 2026-01-25]"
             }
           ]
         }
@@ -835,7 +835,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5898",
               "direction": "reverse",
-              "to_node": "decision:930 \u2014 change default redirect code to 303"
+              "to_node": "decision:930 \u2014 change default redirect code to 303  [implemented by PR 5898, merged 2026-01-25]"
             }
           ]
         }
@@ -1016,7 +1016,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5776",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             }
           ]
         },
@@ -1032,7 +1032,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5786",
               "direction": "reverse",
-              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests  [implemented by PR 5797, merged 2025-08-18]"
             }
           ]
         },
@@ -1048,7 +1048,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5774",
               "direction": "reverse",
-              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes  [implemented by PR 5799, merged 2025-08-19]"
             }
           ]
         },
@@ -1114,7 +1114,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5776",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             },
             {
               "edge_type": "implemented_by",
@@ -1164,7 +1164,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5786",
               "direction": "reverse",
-              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests  [implemented by PR 5797, merged 2025-08-18]"
             },
             {
               "edge_type": "implemented_by",
@@ -1214,7 +1214,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5774",
               "direction": "reverse",
-              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes  [implemented by PR 5799, merged 2025-08-19]"
             },
             {
               "edge_type": "implemented_by",
@@ -1625,7 +1625,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5885",
               "direction": "reverse",
-              "to_node": "decision:929 \u2014 asgiref fails with gevent patching"
+              "to_node": "decision:929 \u2014 asgiref fails with gevent patching  [implemented by PR 5900, merged 2026-01-25]"
             }
           ]
         }
@@ -1981,7 +1981,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5777",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             }
           ]
         },
@@ -2006,7 +2006,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5776",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             }
           ]
         },
@@ -2031,7 +2031,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5786",
               "direction": "reverse",
-              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests  [implemented by PR 5797, merged 2025-08-18]"
             }
           ]
         },
@@ -2056,7 +2056,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5774",
               "direction": "reverse",
-              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes  [implemented by PR 5799, merged 2025-08-19]"
             }
           ]
         },
@@ -2081,7 +2081,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5776",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             },
             {
               "edge_type": "implemented_by",
@@ -2149,7 +2149,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5786",
               "direction": "reverse",
-              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests"
+              "to_node": "decision:921 \u2014 Session is not updated on redirect target endpoint in tests  [implemented by PR 5797, merged 2025-08-18]"
             },
             {
               "edge_type": "implemented_by",
@@ -2217,7 +2217,7 @@
               "extractor": "synthesis_release_note",
               "source_ref": "release:3.1.2 via #5774",
               "direction": "reverse",
-              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes"
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes  [implemented by PR 5799, merged 2025-08-19]"
             },
             {
               "edge_type": "implemented_by",
@@ -2251,7 +2251,7 @@
               "extractor": "synthesis_closes_cluster",
               "source_ref": "thread:30:pr-5777",
               "direction": "reverse",
-              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument"
+              "to_node": "decision:920 \u2014 Looser type annotations for send_file() path_or_file argument  [implemented by PR 5777, merged 2025-08-18]"
             },
             {
               "edge_type": "deployed_by",

--- a/src/decision_graph/evaluation.py
+++ b/src/decision_graph/evaluation.py
@@ -74,10 +74,79 @@ class QueryResult:
     notes: str | None = None
 
 
-def _describe(path: reasoning.Path, node_id: int) -> str:
+# A Decision carries the motivating issue's title and sits under a thread_key naming its
+# cluster. That key is chosen by `threads._rank` — PR-preferring, then lowest number —
+# purely so two ingestion orders produce the same key. It is a stable LABEL, not a claim
+# about which pull request did the work, and when a change took two attempts it names the
+# ABANDONED one: decision 928 sits in `thread:30:pr-5867`, but 5867 was never merged and
+# PR 5899 is the credited implementer.
+#
+# A Why-walk reaching a Decision across `motivated_by` stops there and never traverses
+# `implemented_by`, so the only PR number a reader saw was the wrong one (issue #19).
+# The graph was right; the report was misleading — which is worse than it sounds, because
+# it makes a stale label and a stale edge look identical on the page. Adjudication depends
+# on telling those apart.
+DECISION_FACTS_SQL = """
+SELECT d.node_id,
+       im.node_type   AS implementer_type,
+       im.external_id AS implementer_ref,
+       pr.merged_at
+FROM decision d
+LEFT JOIN edge e  ON e.src_node_id = d.node_id
+                 AND e.edge_type   = 'implemented_by'
+                 AND e.valid_to IS NULL
+LEFT JOIN node im ON im.id = e.dst_node_id
+LEFT JOIN pull_request pr ON pr.node_id = im.id
+WHERE d.node_id = ANY(%s)
+ORDER BY d.node_id, im.external_id
+"""
+
+
+def _format_implementer(row: dict[str, Any]) -> str:
+    kind = row["implementer_type"]
+    ref = row["implementer_ref"]
+    if kind == "commit":
+        return f"commit {ref[:7]}"
+    if kind != "pull_request":
+        return f"{kind} {ref}"
+    # Merge state is spelled out rather than implied. An unmerged implementer should not
+    # be able to sit quietly in a trace — post-#17 it cannot exist, and this is how a
+    # regression would announce itself instead of reading as an ordinary path.
+    when = f"merged {row['merged_at']:%Y-%m-%d}" if row["merged_at"] else "NOT MERGED"
+    return f"PR {ref}, {when}"
+
+
+def decision_annotations(conn, node_ids: list[int]) -> dict[int, str]:
+    """Map Decision node ids to a short statement of what the graph credits them to."""
+    if not node_ids:
+        return {}
+
+    grouped: dict[int, list[dict[str, Any]]] = {}
+    for row in conn.execute(DECISION_FACTS_SQL, (sorted(set(node_ids)),)).fetchall():
+        grouped.setdefault(row["node_id"], []).append(row)
+
+    notes: dict[int, str] = {}
+    for node_id, rows in grouped.items():
+        credited = [r for r in rows if r["implementer_ref"]]
+        if not credited:
+            # Unreachable while the rubric holds. Surfaced rather than skipped: a Decision
+            # asserting nothing is the single most important thing to show an adjudicator.
+            notes[node_id] = "no current implementer"
+            continue
+        # Every current implementer, not the first. A LIMIT 1 here would have concealed
+        # the double-implementer bug that the #17 fix introduced and then repaired.
+        notes[node_id] = "implemented by " + "; ".join(_format_implementer(r) for r in credited)
+    return notes
+
+
+def _describe(
+    path: reasoning.Path, node_id: int, annotations: dict[int, str] | None = None
+) -> str:
     node_type = path.types.get(node_id) or "?"
     title = (path.titles.get(node_id) or "").strip()
-    return f"{node_type}:{node_id}" + (f" — {title}" if title else "")
+    text = f"{node_type}:{node_id}" + (f" — {title}" if title else "")
+    note = (annotations or {}).get(node_id)
+    return f"{text}  [{note}]" if note else text
 
 
 def run_query(conn, spec: dict[str, Any]) -> QueryResult:
@@ -124,6 +193,16 @@ def run_query(conn, spec: dict[str, Any]) -> QueryResult:
     result.used_inferred_fallback = answer.used_inferred_fallback
     result.explanation = answer.explanation
 
+    # Annotated once for the whole answer rather than per step, so a Decision reached by
+    # several paths reads identically in each.
+    decision_ids = [
+        nid
+        for path in answer.paths
+        for nid in path.node_ids
+        if path.types.get(nid) == "decision"
+    ]
+    annotations = decision_annotations(conn, decision_ids)
+
     for path in sorted(answer.paths, key=lambda p: (p.depth, p.target_id)):
         steps = []
         for step, node_id in zip(path.steps, path.node_ids[1:]):
@@ -135,14 +214,14 @@ def run_query(conn, spec: dict[str, Any]) -> QueryResult:
                     extractor=step.extractor,
                     source_ref=step.source_ref,
                     direction="forward" if step.to_node_id == node_id else "reverse",
-                    to_node=_describe(path, node_id),
+                    to_node=_describe(path, node_id, annotations),
                 )
             )
         result.paths.append(
             PathRecord(
                 tier=path.tier,
                 depth=path.depth,
-                start=_describe(path, path.node_ids[0]),
+                start=_describe(path, path.node_ids[0], annotations),
                 steps=steps,
             )
         )

--- a/tests/test_trace_annotation.py
+++ b/tests/test_trace_annotation.py
@@ -1,0 +1,245 @@
+"""Tests for the Decision annotation in evaluation traces (issue #19).
+
+The defect these guard against was not a wrong answer — the graph was correct — but a
+trace that showed the reader the wrong pull request number. A Why-walk reaching a
+Decision across `motivated_by` stops there and never traverses `implemented_by`, so the
+only PR visible was the one embedded in the thread key, and that key names the cluster,
+not the implementer. Where a change took two attempts it names the abandoned one.
+
+So these assert a *reporting* property: whatever the graph currently credits a Decision
+to must appear in the trace, and anything unmerged or missing must appear loudly. A
+report that quietly drops either is the failure being prevented.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import unittest
+from datetime import datetime, timezone
+from pathlib import Path
+
+from decision_graph import evaluation, reasoning
+
+DSN = os.environ.get("DATABASE_URL")
+
+
+def _load_renderer():
+    """eval/ is a script directory, not a package, so load it by path."""
+    path = Path(__file__).resolve().parents[1] / "eval" / "render_report.py"
+    spec = importlib.util.spec_from_file_location("render_report", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class FormatImplementerTest(unittest.TestCase):
+    def test_merged_pull_request_states_its_merge_date(self) -> None:
+        text = evaluation._format_implementer(
+            {
+                "implementer_type": "pull_request",
+                "implementer_ref": "5899",
+                "merged_at": datetime(2026, 1, 25, 3, 53, tzinfo=timezone.utc),
+            }
+        )
+        self.assertEqual(text, "PR 5899, merged 2026-01-25")
+
+    def test_unmerged_pull_request_says_so_explicitly(self) -> None:
+        # Post-#17 this cannot occur. It is spelled out rather than left blank so that a
+        # regression announces itself instead of reading as an ordinary path.
+        text = evaluation._format_implementer(
+            {
+                "implementer_type": "pull_request",
+                "implementer_ref": "5867",
+                "merged_at": None,
+            }
+        )
+        self.assertIn("NOT MERGED", text)
+
+    def test_commit_implementer_is_abbreviated_and_not_called_unmerged(self) -> None:
+        # A commit reachable in the graph is on the default branch by construction, so
+        # borrowing the PR vocabulary of "not merged" would be actively misleading.
+        text = evaluation._format_implementer(
+            {
+                "implementer_type": "commit",
+                "implementer_ref": "c77a5203438fe772d41f6a47303ad3f57a4efe6d",
+                "merged_at": None,
+            }
+        )
+        self.assertEqual(text, "commit c77a520")
+        self.assertNotIn("NOT MERGED", text)
+
+
+class DescribeTest(unittest.TestCase):
+    def _path(self) -> reasoning.Path:
+        return reasoning.Path(
+            node_ids=[928],
+            steps=[],
+            titles={928: "deprecate `should_ignore_error`"},
+            types={928: "decision"},
+        )
+
+    def test_annotation_is_appended_when_present(self) -> None:
+        text = evaluation._describe(
+            self._path(), 928, {928: "implemented by PR 5899, merged 2026-01-25"}
+        )
+        self.assertIn("decision:928", text)
+        self.assertIn("PR 5899", text)
+
+    def test_unannotated_node_is_unchanged(self) -> None:
+        self.assertEqual(
+            evaluation._describe(self._path(), 928),
+            "decision:928 — deprecate `should_ignore_error`",
+        )
+
+
+class RenderTest(unittest.TestCase):
+    """The annotation is only useful if the renderer keeps it distinguishable."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.r = _load_renderer()
+
+    def test_thread_source_ref_is_labelled_as_a_cluster(self) -> None:
+        html = self.r.render_ref("thread:30:pr-5867")
+        self.assertIn("cluster", html)
+        self.assertIn("thread:30:pr-5867", html)
+
+    def test_url_source_ref_is_left_alone(self) -> None:
+        html = self.r.render_ref("https://github.com/pallets/flask/pull/5899")
+        self.assertNotIn("ref-kind", html)
+
+    def test_annotation_is_split_out_of_the_node_label(self) -> None:
+        html = self.r.render_node("decision:928 — x  [implemented by PR 5899, merged 2026-01-25]")
+        self.assertIn("node-note", html)
+        self.assertNotIn("[", html)
+
+    def test_broken_claims_render_as_warnings(self) -> None:
+        for note in ("implemented by PR 5867, NOT MERGED", "no current implementer"):
+            with self.subTest(note=note):
+                html = self.r.render_node(f"decision:1 — x  [{note}]")
+                self.assertIn("node-note warn", html)
+
+    def test_ordinary_annotation_is_not_a_warning(self) -> None:
+        html = self.r.render_node("decision:1 — x  [implemented by PR 5899, merged 2026-01-25]")
+        self.assertNotIn("warn", html)
+
+    def test_bracketed_titles_survive_intact(self) -> None:
+        # flask really ships these. A left-hand split would tear the title in half and
+        # render "bytes]" as if it were an annotation.
+        for title in (
+            "pull_request:41 — Loosen send_file annotation to include typing.IO[bytes]",
+            "commit:9 — [pre-commit.ci lite] apply automatic fixes",
+        ):
+            with self.subTest(title=title):
+                html = self.r.render_node(title)
+                self.assertNotIn("node-note", html)
+
+    def test_bracketed_title_plus_annotation_splits_at_the_annotation(self) -> None:
+        html = self.r.render_node(
+            "pull_request:41 — include typing.IO[bytes]  [implemented by PR 5899, merged 2026-01-25]"
+        )
+        self.assertIn("node-note", html)
+        self.assertIn("typing.IO[bytes]", html)
+        self.assertIn("PR 5899", html)
+
+    def test_node_text_is_escaped(self) -> None:
+        html = self.r.render_node("decision:1 — <script>")
+        self.assertNotIn("<script>", html)
+
+
+@unittest.skipUnless(DSN, "DATABASE_URL not set")
+class DecisionAnnotationsTest(unittest.TestCase):
+    """Each test seeds its own fixture in a transaction and rolls back."""
+
+    def setUp(self) -> None:
+        from decision_graph import db
+
+        self.conn = db.connect(DSN)
+        # The rubric guard is deferred, so a fixture Decision that would not qualify is
+        # never challenged — these tests are about reporting, not about the rubric.
+        self.conn.execute("SET CONSTRAINTS ALL DEFERRED")
+        self._seq = 0
+
+    def tearDown(self) -> None:
+        self.conn.rollback()
+        self.conn.close()
+
+    def _node(self, node_type: str, title: str = "") -> int:
+        self._seq += 1
+        return self.conn.execute(
+            "INSERT INTO node (node_type, external_id, title) VALUES (%s, %s, %s) "
+            "RETURNING id",
+            (node_type, f"anno-{id(self)}-{self._seq}", title),
+        ).fetchone()["id"]
+
+    def _decision(self) -> int:
+        node_id = self._node("decision", "fixture decision")
+        self.conn.execute(
+            "INSERT INTO decision (node_id, status, summary) "
+            "VALUES (%s, 'reconstructed', 'fixture')",
+            (node_id,),
+        )
+        return node_id
+
+    def _pr(self, number: int, merged_at: datetime | None) -> int:
+        node_id = self._node("pull_request", f"PR {number}")
+        self.conn.execute(
+            "INSERT INTO pull_request (node_id, number, state, merged_at) "
+            "VALUES (%s, %s, %s, %s)",
+            (node_id, number, "closed", merged_at),
+        )
+        self.conn.execute("UPDATE node SET external_id = %s WHERE id = %s", (str(number), node_id))
+        return node_id
+
+    def _implemented_by(self, decision: int, target: int, *, valid_to=None) -> None:
+        self.conn.execute(
+            """
+            INSERT INTO edge (src_node_id, dst_node_id, edge_type, tag, evidence_tier,
+                              extractor, valid_from, valid_to)
+            VALUES (%s, %s, 'implemented_by', 'explicit', 'explicit', 'test_fixture',
+                    now() - interval '1 day', %s)
+            """,
+            (decision, target, valid_to),
+        )
+
+    MERGED = datetime(2026, 1, 25, tzinfo=timezone.utc)
+
+    def test_credits_the_current_implementer(self) -> None:
+        d = self._decision()
+        self._implemented_by(d, self._pr(5899, self.MERGED))
+        notes = evaluation.decision_annotations(self.conn, [d])
+        self.assertEqual(notes[d], "implemented by PR 5899, merged 2026-01-25")
+
+    def test_superseded_implementer_is_excluded(self) -> None:
+        # This is the exact shape of decision 928: the abandoned attempt is still in the
+        # graph as history and must not be reported as the credited implementer.
+        d = self._decision()
+        self._implemented_by(d, self._pr(5867, None), valid_to=datetime.now(timezone.utc))
+        self._implemented_by(d, self._pr(5899, self.MERGED))
+        notes = evaluation.decision_annotations(self.conn, [d])
+        self.assertIn("5899", notes[d])
+        self.assertNotIn("5867", notes[d])
+
+    def test_every_current_implementer_is_listed(self) -> None:
+        # No LIMIT 1. The #17 fix briefly left two live implementers on one Decision;
+        # a report showing only the first would have hidden it.
+        d = self._decision()
+        self._implemented_by(d, self._pr(5867, None))
+        self._implemented_by(d, self._pr(5899, self.MERGED))
+        notes = evaluation.decision_annotations(self.conn, [d])
+        self.assertIn("5867", notes[d])
+        self.assertIn("5899", notes[d])
+        self.assertIn("NOT MERGED", notes[d])
+
+    def test_decision_with_no_implementer_is_reported_not_omitted(self) -> None:
+        d = self._decision()
+        notes = evaluation.decision_annotations(self.conn, [d])
+        self.assertEqual(notes[d], "no current implementer")
+
+    def test_empty_input_does_not_query(self) -> None:
+        self.assertEqual(evaluation.decision_annotations(self.conn, []), {})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #19.

## What was wrong

A Why-walk reaching a Decision across `motivated_by` stops there — it never traverses
`implemented_by`. So the only PR number in a trace was the one inside the `thread_key`,
and that key names the **cluster**, picked by `threads._rank` as PR-preferring-then-lowest-number
so that two ingestion orders agree. When a change took two attempts, it names the abandoned one.

| decision | cluster label | credited implementer |
|---|---|---|
| 918 | `thread:30:pr-5722` | PR 5798, merged 2025-08-18 |
| 928 | `thread:30:pr-5867` | PR 5899, merged 2026-01-25 |
| 929 | `thread:30:pr-5885` | PR 5900, merged 2026-01-25 |

Found when H4 was flagged during adjudication as a suspected recurrence of the #16/#17
tie-break defect. It wasn't — edge 878 (→5867, never merged) was correctly superseded by
edge 1192 (→5899, merged). **The graph was right; the report was misleading**, which is the
worse failure: it left a stale *label* and a stale *edge* indistinguishable on the page,
and telling those apart is precisely what adjudication is.

## Scope

Display only. `thread_key` generation is untouched — its order-independence is load-bearing
for rubric clause 3, and the label was never the bug.

- `decision_annotations()` reports **every** current `implemented_by` target with its merge
  date. Deliberately no `LIMIT 1`: that would have concealed the double-implementer bug the
  #17 fix briefly introduced before repairing.
- A missing implementer, or an unmerged one, renders in red rather than being omitted.
  Neither can occur post-#17, so this is how a regression announces itself instead of
  reading as an ordinary path.
- Bare `thread:` source refs badged as cluster ids, so they stop reading as attributions.
- `render_node` splits from the right and only on a closing bracket — flask titles contain
  brackets (`typing.IO[bytes]`, `[pre-commit.ci lite] …`) and a left split tore them in half.
  Caught by a sanity check on the rendered HTML, not by the tests as first written.

## Verification

- 38 Python tests (was 20), 30 SQL checks — all green.
- Worksheet regenerated: 10 answered, 8 nothing, 5/5 contracts — unchanged, as expected for
  a display-only change. All 31 Decision references now annotated, 0 warnings.
- H3 → PR 5798 and H10 → PR 5900, the two queries the mislabeling would have misdirected next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HFb2tRQWJcFC2wEHnVsHP