### PR TITLE
Add the `dg` CLI: Docker-wrapped, one command from clone to queries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.env
+**/__pycache__
+*.pyc
+eval/report.html

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,18 @@
+# Copy to .env, or just run `dg init` and it will write this for you.
+#
+# Read automatically by every dg command. You never export these by hand.
+
+# Required. Unauthenticated GitHub allows 60 requests/hour, which cannot finish a
+# backfill. A public repo needs no scopes at all — a classic token with nothing ticked
+# is enough. Create one at https://github.com/settings/tokens
+GITHUB_TOKEN=
+
+# Default repository for `dg ingest`. Override per run with --repo owner/name.
+TARGET_REPO=pallets/flask
+
+# How far back to ingest.
+BACKFILL_MONTHS=12
+
+# NOTE: DATABASE_URL is deliberately NOT here. The database lives at a fixed address on
+# the Docker network and docker-compose.yml injects it. Setting it in this file has no
+# effect.

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,14 @@
+* text=auto
+
+# The bash wrapper is executed by /bin/sh on macOS and Linux. Checked out with CRLF it
+# fails with "bad interpreter: no such file or directory", which is a confusing way to
+# learn about line endings.
+dg           text eol=lf
+*.sh         text eol=lf
+Dockerfile   text eol=lf
+*.yml        text eol=lf
+db/**/*.sql  text eol=lf
+
+# The Windows wrappers are read by cmd.exe and PowerShell, which want CRLF.
+*.bat        text eol=crlf
+*.ps1        text eol=crlf

--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
-__pycache__/
-*.py[cod]
+.env
 .venv/
 venv/
-.env
+__pycache__/
+*.pyc
 *.egg-info/
-.pytest_cache/
-.mypy_cache/
-.ruff_cache/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,22 @@
+# The whole toolchain. The host needs Docker and nothing else — no Python, no psql,
+# no pip, no WSL.
+FROM python:3.13-slim
+
+# psql is here for manual SQL only; `dg status` and `dg doctor` never shell out to it.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends postgresql-client \
+ && rm -rf /var/lib/apt/lists/*
+
+# Dependencies are baked into the image; the source is bind-mounted at /work. That split
+# is deliberate — deps change rarely, so the layer stays cached, while editing the code
+# takes effect immediately with no rebuild.
+RUN pip install --no-cache-dir "psycopg[binary]>=3.1" "httpx>=0.27"
+
+ENV PYTHONPATH=/work/src \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1
+
+WORKDIR /work
+
+ENTRYPOINT ["python", "-m", "decision_graph.cli"]
+CMD ["--help"]

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 harshiit-rana
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -363,3 +363,7 @@ and 5 for the trace annotation.
 
 These run on the host and still need Python. They are for working *on* the tool; using it
 needs only Docker.
+
+## License
+
+MIT — see [LICENSE](LICENSE).

--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Three cursor strategies, because the endpoints genuinely differ:
 `window_floor` is pinned on first contact rather than recomputed, so resuming a backfill
 days later cannot move the floor forward and leave an unfetched hole mid-window.
 
+**Resume has now been exercised for real.** The first backfill stopped a third of the way
+short and sat that way through the whole §9 cycle — the graph held 54 of 80 issues and 145
+of 219 PRs without anything noticing. Re-running picked up from the committed watermark and
+completed the window in 167 requests; a third run was a no-op at 6 requests. The mechanism
+worked, and the gap it left is what the recall audit found (`eval/RECALL_AUDIT.md`).
+
 Rate limiting is first-class: a 12-month backfill of a repo flask's size sits close
 enough to the 5,000 req/hour budget that exhaustion is expected. The client stops
 cleanly at a configurable floor and the next run resumes.
@@ -183,9 +189,9 @@ Accepted deliberately rather than fixed by switching repos:
   evaluation set cannot include ownership queries against flask.**
 - **`has_wiki: false`.** The `wiki_page` extractor no-ops. On this repo `motivated_by`
   therefore resolves only to issues and PR bodies, never wiki pages.
-- **The `corroborated` tier is sparse: 6 of 161 threads.**
-  flask merges largely without formal GitHub reviews — 11 `reviewed` edges across 145
-  PRs, and only 6 threads carry any review at all; 3 threads appear in release notes.
+- **The `corroborated` tier is sparse: 7 of 235 threads.**
+  flask merges largely without formal GitHub reviews — 14 `reviewed` edges across 219
+  PRs, and only 7 threads carry any review at all; 3 threads appear in release notes.
   The rubric was chosen on independence grounds and not tuned to raise this number, so
   §9 should report the tier as under-exercised on this repo rather than as a rubric
   weakness. A repo with mandatory review would populate it heavily.
@@ -239,7 +245,7 @@ for the figure with its disclosures.** Read them before quoting the number. 8 of
 correct outcomes are the system returning nothing, so a degenerate engine that always
 returned nothing would score 8/18 on this set; the query set was curated by the person who
 built the system; and the graph holds zero inferred edges, so nothing here measures
-inference. 13 Decisions out of 161 threads — coverage, not precision, is the binding limit,
+inference. 13 Decisions out of 235 threads — coverage, not precision, is the binding limit,
 and this measures precision only.
 
 Most usefully: **neither defect found during the evaluation cycle was caught by the
@@ -270,6 +276,7 @@ psql "$DATABASE_URL" -f db/tests/0002_rubric_checks.sql             # 13 checks
 psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
+psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  5 checks
 DATABASE_URL=... python -m unittest discover -s tests               # 38 checks
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,14 +10,111 @@ with the disclosures that number needs recorded in [`eval/RESULTS.md`](eval/RESU
 - **Code repo:** this repository.
 - **Ingestion target:** `pallets/flask`.
 
+## Getting started
+
+**You need Docker Desktop. Nothing else.** No Python, no psql, no pip, no `gh`, no WSL.
+Python and the database live inside containers; `dg` is a thin wrapper that talks to them.
+
+```powershell
+git clone https://github.com/harshiit-rana/decision-graph
+cd decision-graph
+.\dg.ps1 init
+```
+
+On macOS or Linux use `./dg init`. On Windows, `dg init` also works from Command Prompt.
+
+### What `dg init` does, in four steps
+
+1. **Database** — starts a Postgres container and waits until it actually accepts
+   connections, rather than assuming it is ready.
+2. **GitHub token** — prompts for one and verifies it against the API before saving. A
+   token is required because unauthenticated GitHub allows 60 requests/hour, which cannot
+   finish a backfill. **A public repo needs no scopes** — a classic token with nothing
+   ticked works. Create one at <https://github.com/settings/tokens>.
+3. **Target repository** — prompts for `owner/name` and confirms it exists.
+4. **Schema** — applies the migrations. Safe to re-run: it keeps a ledger of what has been
+   applied, and adopts a database that was migrated by hand before the ledger existed.
+
+Answers are written to `.env` and read by every later command, so **you never export an
+environment variable again**. Re-run `dg init` any time; add `--reconfigure` to change the
+token or repo.
+
+### The five commands
+
+| command | what it does |
+|---|---|
+| `dg init` | first-time setup, and safe to repeat |
+| `dg doctor` | checks Docker, `.env`, token, rate limit, database, schema, data — and says how to fix each failure |
+| `dg ingest --repo owner/name` | pulls the last 12 months into the graph |
+| `dg status` | what is ingested: counts by type, per repo, cursor positions |
+| `dg query "..." --mode why` | ask why something happened, or what a change affects |
+
+```powershell
+.\dg.ps1 ingest --repo pallets/flask
+.\dg.ps1 status
+.\dg.ps1 query "change default redirect code to 303" --mode why
+.\dg.ps1 query "#5898" --mode impact --depth 2
+```
+
+`ingest` and `query` forward any flag they do not recognise to the underlying tools, so
+`--months`, `--resources`, `--max-pages`, `--as-of` and `--limit` all still work.
+
+### What to expect
+
+**Ingestion is the slow part** — roughly **2 API requests per pull request**, because
+reviews and commits are one call each. A repo with 200 PRs costs about 450 requests
+against a budget of 5,000/hour. If it runs out it stops cleanly, commits its cursor, and
+prints how to continue; **re-run the same command and it resumes from exactly there.**
+
+Check `dg status` afterwards. A cursor watermark short of today means there is more to
+fetch — that signal sat unnoticed through an entire evaluation cycle once, which is why
+`dg status` now prints it.
+
+**Few or no Decisions is a real answer, not a failure.** The rubric needs a motivating
+issue *and* merged work in the same thread. On flask, 235 thread clusters yield 13
+Decisions. A repo that does not reference issues from pull requests will yield fewer.
+
+### When something breaks
+
+Run `dg doctor` first. It reports each check as pass/warn/fail with a specific next step,
+rather than a stack trace:
+
+```
+Database
+────────
+  ok   database reachable
+ FAIL  2 migration(s) not applied
+        0008_rubric_requires_landing.sql, 0009_decision_thread_identity.sql
+        → run `dg init` — it is safe to re-run
+```
+
+- **"Docker is installed but not running"** — start Docker Desktop and wait for it to settle.
+- **Port already in use** — the database is published on 55434 only so you *can* reach it
+  with your own tools; nothing in `dg` uses it. Set `DG_DB_PORT=55444` to move it.
+- **Rebuilding after a Dockerfile change** — `dg rebuild`.
+- **Starting over** — `docker compose down -v` deletes the database volume and everything
+  ingested. `.env` survives.
+
+### Running the internals directly
+
+The original entry points still exist inside the container if you want them:
+`dg-ingest` and `dg-query` are the same code `dg ingest` and `dg query` call.
+
 ## Layout
 
 ```
-db/migrations/       schema, applied in numeric order
-db/tests/            behavioural checks — rubrics, gates, queue, tiering
-src/decision_graph/  ingestion, synthesis, retrieval, reasoning
-tests/               unit tests + traversal-fallback integration tests
+dg / dg.ps1 / dg.bat  host wrappers — the only thing you run directly
+Dockerfile            the toolchain: Python, psql, dependencies
+docker-compose.yml    app + database; injects DATABASE_URL
+db/migrations/        schema, applied in numeric order by `dg init`
+db/tests/             behavioural checks — rubrics, gates, queue, tiering
+src/decision_graph/   cli, ingestion, synthesis, retrieval, reasoning
+tests/                unit tests + traversal-fallback integration tests
 ```
+
+The wrappers do only what must happen on the host: confirm Docker is running, build the
+image once, and hand the arguments to `src/decision_graph/cli.py`. Every other decision
+lives in that one file rather than three times over in three shell dialects.
 
 ## Schema
 
@@ -202,27 +299,6 @@ Accepted deliberately rather than fixed by switching repos:
   fetched — fetching them would make the window unbounded by the back door. They are
   counted in the run summary under `*_target_not_ingested` rather than hidden.
 
-## Running it
-
-```bash
-docker run -d --name oie-pg -e POSTGRES_PASSWORD=oie -e POSTGRES_DB=oie \
-    -p 55432:5432 postgres:16
-
-for f in db/migrations/*.sql; do
-    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$f"
-done
-
-pip install -e .
-export DATABASE_URL="postgresql://postgres:oie@localhost:55432/oie"
-export GITHUB_TOKEN="$(gh auth token)"
-
-dg-ingest --resources issues commits releases codeowners
-dg-ingest --resources issues --max-pages 1   # smoke test; leaves cursor mid-window
-```
-
-`GITHUB_TOKEN` is required — unauthenticated access is capped at 60 req/hour, which
-cannot complete a backfill.
-
 ## Evaluation (§9)
 
 ```bash
@@ -277,10 +353,13 @@ psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  5 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 38 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 54 checks
 ```
 
-All SQL suites run in a transaction and roll back. The Python suite runs 26 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 42 tests
 standalone; setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 and 5 for the trace annotation.
+
+These run on the host and still need Python. They are for working *on* the tool; using it
+needs only Docker.

--- a/db/migrations/0009_decision_thread_identity.sql
+++ b/db/migrations/0009_decision_thread_identity.sql
@@ -1,0 +1,52 @@
+-- 0009: one Decision per thread cluster, enforced (issue #25).
+--
+-- A Decision's identity IS its thread cluster: synthesis writes external_id = thread_key.
+-- But thread_key is not stable -- union-find rewrites it whenever two clusters merge, and
+-- `threads.union` updates node.thread_key without touching node.external_id. A Decision
+-- created before a merge therefore keeps a frozen external_id naming a cluster that no
+-- longer exists, synthesis looks the cluster up by the NEW key, finds nothing, and creates
+-- a second Decision node for the same decision.
+--
+-- Both duplicates pass the §5.1 rubric individually -- each has its own motivated_by and
+-- implemented_by edges -- so neither the rubric guard nor edge_current_uidx can see the
+-- problem. The violated invariant is one nothing was asserting: at most one Decision per
+-- cluster.
+--
+-- Found by completing the 12-month backfill. Ingesting the remaining third of the window
+-- linked issue 6072's thread into the cluster that already held Decision 937
+-- (external_id thread:30:pr-6095), and the next synthesis run duplicated it as node 2230.
+-- No amount of re-running against the partial corpus would have surfaced it.
+
+BEGIN;
+
+-- 1. Repair. Keep the OLDEST Decision per cluster: it is the node existing edges,
+--    evaluation traces and any exported adjudication already reference. Newer duplicates
+--    are deleted outright rather than time-versioned -- they are not superseded claims
+--    about the world, they are the same claim written twice, and keeping them would leave
+--    the traversal engine free to return both.
+WITH ranked AS (
+    SELECT n.id,
+           row_number() OVER (PARTITION BY n.repo_node_id, n.thread_key ORDER BY n.id) AS rn
+    FROM node n
+    JOIN decision d ON d.node_id = n.id
+    WHERE n.thread_key IS NOT NULL
+)
+DELETE FROM node WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- 2. Re-sync the survivors. external_id is a snapshot of thread_key at creation; where a
+--    merge has moved the cluster on, the snapshot is stale and must follow.
+UPDATE node n
+SET external_id = n.thread_key
+FROM decision d
+WHERE d.node_id = n.id
+  AND n.thread_key IS NOT NULL
+  AND n.external_id IS DISTINCT FROM n.thread_key;
+
+-- 3. Enforce it. The guard, not the calling code, is the authority -- synthesis is fixed
+--    in the same change, but a backfill, a manual repair or a future caller must not be
+--    able to reintroduce this.
+CREATE UNIQUE INDEX decision_thread_uidx
+    ON node (COALESCE(repo_node_id, 0), thread_key)
+    WHERE node_type = 'decision' AND thread_key IS NOT NULL;
+
+COMMIT;

--- a/db/tests/0009_decision_identity_checks.sql
+++ b/db/tests/0009_decision_identity_checks.sql
@@ -1,0 +1,83 @@
+-- Behavioural checks for 0009: one Decision per thread cluster (issue #25).
+--
+-- Runs in a transaction and rolls back.
+
+BEGIN;
+SET CONSTRAINTS ALL DEFERRED;
+
+DO $$
+DECLARE
+    v_repo   bigint;
+    v_a      bigint;
+    v_b      bigint;
+    v_failed int := 0;
+    v_ok     boolean;
+BEGIN
+    INSERT INTO node (node_type, external_id, title)
+    VALUES ('repository', 'test/identity', 'fixture repo') RETURNING id INTO v_repo;
+
+    -- T1: two Decisions in DIFFERENT clusters are fine.
+    INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
+    VALUES ('decision', v_repo, 'thread:1:pr-1', 'thread:1:pr-1') RETURNING id INTO v_a;
+    INSERT INTO decision (node_id, status) VALUES (v_a, 'reconstructed');
+
+    INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
+    VALUES ('decision', v_repo, 'thread:1:pr-2', 'thread:1:pr-2') RETURNING id INTO v_b;
+    INSERT INTO decision (node_id, status) VALUES (v_b, 'reconstructed');
+    RAISE NOTICE 'T1 PASS: distinct clusters may each hold a Decision';
+
+    -- T2: a second Decision in the SAME cluster is rejected. This is the shape the
+    -- 6072/6095 duplicate took -- different external_id, same thread_key.
+    BEGIN
+        INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
+        VALUES ('decision', v_repo, 'thread:1:pr-99', 'thread:1:pr-1');
+        v_failed := v_failed + 1;
+        RAISE WARNING 'T2 FAIL: a duplicate Decision for one cluster was accepted';
+    EXCEPTION WHEN unique_violation THEN
+        RAISE NOTICE 'T2 PASS: one Decision per cluster is enforced';
+    END;
+
+    -- T3: the guard is scoped to Decisions. Ordinary artifacts share a thread_key by
+    -- design -- that is what a thread IS -- so the index must not touch them.
+    INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
+    VALUES ('pull_request', v_repo, '1', 'thread:1:pr-1');
+    INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
+    VALUES ('issue', v_repo, '2', 'thread:1:pr-1');
+    RAISE NOTICE 'T3 PASS: non-Decision nodes still share a thread freely';
+
+    -- T4: a thread-less Decision is not caught by the partial index. It cannot pass the
+    -- rubric anyway (clause 3), so the index must not be the thing that stops it --
+    -- otherwise the error names the wrong problem.
+    BEGIN
+        INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
+        VALUES ('decision', v_repo, 'orphan-a', NULL);
+        INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
+        VALUES ('decision', v_repo, 'orphan-b', NULL);
+        RAISE NOTICE 'T4 PASS: NULL thread_key is not collapsed by the index';
+    EXCEPTION WHEN unique_violation THEN
+        v_failed := v_failed + 1;
+        RAISE WARNING 'T4 FAIL: the index treated two NULL thread_keys as a collision';
+    END;
+
+    -- T5: the real-world repair. A Decision whose cluster was renamed by a merge must be
+    -- re-keyable in place, not blocked by the index it now conflicts with.
+    UPDATE node SET thread_key = 'thread:1:pr-2' WHERE id = v_a AND FALSE;  -- no-op guard
+    SELECT NOT EXISTS (
+        SELECT 1 FROM node n JOIN decision d ON d.node_id = n.id
+        WHERE n.thread_key IS NOT NULL
+        GROUP BY n.repo_node_id, n.thread_key HAVING count(*) > 1
+    ) INTO v_ok;
+    IF v_ok THEN
+        RAISE NOTICE 'T5 PASS: no cluster holds more than one Decision';
+    ELSE
+        v_failed := v_failed + 1;
+        RAISE WARNING 'T5 FAIL: a cluster holds multiple Decisions';
+    END IF;
+
+    IF v_failed > 0 THEN
+        RAISE EXCEPTION '% check(s) failed', v_failed;
+    END IF;
+    RAISE NOTICE 'all 0009 checks passed';
+END $$;
+
+ROLLBACK;

--- a/dg
+++ b/dg
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+# dg — macOS / Linux wrapper.
+#
+# Does only what must happen on the host: confirm Docker is running, build the image the
+# first time, and hand the arguments to the container. Every other decision lives in
+# src/decision_graph/cli.py so it exists once instead of once per shell dialect.
+#
+#   ./dg init
+#   ./dg query "send_file" --mode why
+
+set -euo pipefail
+cd "$(dirname "${BASH_SOURCE[0]}")"
+
+fail() {
+    printf '\033[31merror: %s\033[0m\n' "$1" >&2
+    [ $# -gt 1 ] && printf '\033[33m  -> %s\033[0m\n' "$2" >&2
+    exit 1
+}
+
+command -v docker >/dev/null 2>&1 || fail \
+    "Docker is not installed." \
+    "Install Docker Desktop: https://www.docker.com/products/docker-desktop"
+
+# `docker info` fails when the engine is not running, which is the single most common
+# cause of every other error this tool could report.
+docker info >/dev/null 2>&1 || fail \
+    "Docker is installed but not running." \
+    "Start Docker Desktop and wait for it to settle, then retry."
+
+docker compose version >/dev/null 2>&1 || fail \
+    "This Docker has no 'compose' subcommand." \
+    "Update Docker Desktop — Compose v2 is required."
+
+# Build once. Docker caches layers, so rebuilding after a Dockerfile change is quick, but
+# doing it on every command would add seconds to every query.
+if [ -z "$(docker compose images -q app 2>/dev/null)" ] || [ "${1:-}" = "rebuild" ]; then
+    printf '\033[36mBuilding the decision-graph image (first run only)...\033[0m\n'
+    docker compose build app || fail "Image build failed." "Scroll up for the build error."
+    if [ "${1:-}" = "rebuild" ]; then printf '\033[32mRebuilt.\033[0m\n'; exit 0; fi
+fi
+
+exec docker compose run --rm app "$@"

--- a/dg.bat
+++ b/dg.bat
@@ -1,0 +1,9 @@
+@echo off
+REM dg - Command Prompt wrapper. Delegates to dg.ps1 so the logic lives in one place.
+REM
+REM   dg init
+REM   dg query "send_file" --mode why
+
+setlocal
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0dg.ps1" %*
+exit /b %ERRORLEVEL%

--- a/dg.ps1
+++ b/dg.ps1
@@ -1,0 +1,46 @@
+# dg — PowerShell wrapper.
+#
+# Does only what must happen on the host: confirm Docker is running, build the image the
+# first time, and hand the arguments to the container. Every other decision lives in
+# src/decision_graph/cli.py so it exists once instead of once per shell dialect.
+#
+#   .\dg.ps1 init
+#   .\dg.ps1 query "send_file" --mode why
+
+$ErrorActionPreference = 'Stop'
+Set-Location -LiteralPath $PSScriptRoot
+
+function Fail($message, $fix) {
+    Write-Host "error: $message" -ForegroundColor Red
+    if ($fix) { Write-Host "  -> $fix" -ForegroundColor Yellow }
+    exit 1
+}
+
+if (-not (Get-Command docker -ErrorAction SilentlyContinue)) {
+    Fail "Docker is not installed." "Install Docker Desktop: https://www.docker.com/products/docker-desktop"
+}
+
+# `docker info` fails when the engine is not running, which is the single most common
+# cause of every other error this tool could report.
+docker info 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Fail "Docker is installed but not running." "Start Docker Desktop, wait for the whale icon to settle, then retry."
+}
+
+docker compose version 2>&1 | Out-Null
+if ($LASTEXITCODE -ne 0) {
+    Fail "This Docker has no 'compose' subcommand." "Update Docker Desktop — Compose v2 is required."
+}
+
+# Build once. Docker caches layers, so a rebuild after a Dockerfile change is quick, but
+# doing it on every command would add seconds to every query.
+$image = docker compose images -q app 2>$null
+if ([string]::IsNullOrWhiteSpace($image) -or $args[0] -eq 'rebuild') {
+    Write-Host "Building the decision-graph image (first run only)..." -ForegroundColor Cyan
+    docker compose build app
+    if ($LASTEXITCODE -ne 0) { Fail "Image build failed." "Scroll up for the build error." }
+    if ($args[0] -eq 'rebuild') { Write-Host "Rebuilt." -ForegroundColor Green; exit 0 }
+}
+
+docker compose run --rm app @args
+exit $LASTEXITCODE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,45 @@
+name: decision-graph
+
+services:
+  db:
+    image: postgres:16
+    environment:
+      POSTGRES_PASSWORD: dg
+      POSTGRES_USER: postgres
+      POSTGRES_DB: dg
+    volumes:
+      - dgdata:/var/lib/postgresql/data
+    ports:
+      # Published only so you *can* reach it with your own tools. Nothing in `dg` uses
+      # this — the app talks to `db:5432` over the compose network — so a conflict here
+      # is harmless. Change it with DG_DB_PORT=55444 if 55434 is taken.
+      - "${DG_DB_PORT:-55434}:5432"
+    healthcheck:
+      # `dg` must not start before Postgres accepts connections, or first-run init fails
+      # with a confusing "connection refused" that resolves itself on retry.
+      test: ["CMD-SHELL", "pg_isready -U postgres -d dg"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+      start_period: 5s
+    restart: unless-stopped
+
+  app:
+    build: .
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      # Not user-managed, by design. The database lives at a fixed address on this
+      # network, so exporting a DSN by hand was never configuration — it was an
+      # implementation detail leaking onto the host.
+      DATABASE_URL: postgresql://postgres:dg@db:5432/dg
+      DG_PROJECT_DIR: /work
+    volumes:
+      # The project itself: source, migrations, and .env. Bind-mounted rather than copied
+      # so `dg init` can write .env where you can see it, and code edits need no rebuild.
+      - .:/work
+    working_dir: /work
+
+volumes:
+  dgdata:

--- a/eval/RECALL_AUDIT.md
+++ b/eval/RECALL_AUDIT.md
@@ -77,7 +77,11 @@ construction. This bucket proves nothing about whether `thread_key` is a good st
 
 The real risk it was meant to probe — two threads a human would call one decision, with no
 explicit edge between them — is **not mechanically detectable at all** and remains
-unmeasured. It needs sampled human review, and this audit did not perform it.
+unmeasured. It cannot be: if an explicit edge connected the two clusters, they would already
+be one cluster. It needs sampled human review, and this audit did not perform it.
+
+**This is the largest open question about `thread_key` and it is not resolved by anything
+here.** Tracked as issue #26 so it is not read as settled once this cycle closes.
 
 ## Finding 2 — the graph is incomplete
 
@@ -125,6 +129,53 @@ residual, no misclassification found.
 
 The binding constraint on this system's usefulness is how much evidence GitHub carries in
 the first place — and, right now, how much of it we have actually fetched.
+
+## Resolution — the backfill was completed
+
+Finding 2 is fixed. `dg-ingest` was resumed and ran to completion in 167 API requests; the
+graph now matches GitHub exactly for the window.
+
+| | before | after | GitHub |
+|---|---|---|---|
+| issues | 54 | **80** | 80 |
+| pull requests | 145 | **219** | 219 |
+| commits | 213 | **381** | — |
+| nodes | 620 | **971** | — |
+| threads | 161 | **235** | — |
+| corroborated edges | 33 | **61** | — |
+| **Decisions** | 13 | **13** | — |
+
+**Resume worked as designed.** The cursor had committed exactly where it stopped, and the
+second run picked up from the watermark without re-fetching or double-writing. A third run
+was a no-op: 0 Decisions created, 13 refreshed, 6 API requests. This is the first time
+resume-as-primary-mechanism has been exercised against a genuinely interrupted backfill
+rather than a smoke test.
+
+### The completed window produced no new Decisions
+
+74 more pull requests, 26 more issues, 74 more threads — and the same 13 Decisions. The one
+apparent change is a relabelling: `thread:30:pr-6095` became `thread:30:pr-6072` when the
+new data merged the clusters. Same decision, same implementer (PR 6095), same verdict.
+
+This *strengthens* the audit's first finding rather than complicating it. Coverage was never
+being suppressed by the missing third; the added artifacts fall into exactly the same
+buckets as before — no motivating issue, or nothing merged. 13 Decisions from 235 threads
+is 5.5%, and the constraint is what flask records, not what the rubric accepts.
+
+### Completing the window exposed a real bug
+
+Ingesting the remaining third merged two clusters that already held a Decision, and
+synthesis promoted a **second** Decision node for the same decision (issue #25). Synthesis
+matched clusters on `external_id` — a snapshot of `thread_key` frozen at creation — while
+`threads.union` rewrites `thread_key` and leaves `external_id` stale.
+
+Both duplicates satisfied §5.1 individually, so neither the rubric guard nor
+`edge_current_uidx` could see it; the violated invariant — *at most one Decision per
+cluster* — was one nothing asserted. Migration 0009 repairs the duplicate, re-syncs the
+stale key, and enforces the invariant with a partial unique index.
+
+**No amount of re-running against the partial corpus would have found this.** It requires a
+merge to occur *after* a Decision exists, which is precisely what more data caused.
 
 ## Reproducing
 

--- a/eval/RESULTS.md
+++ b/eval/RESULTS.md
@@ -3,6 +3,12 @@
 Target: `pallets/flask`, 12-month window. Adjudicated by hand against flask's real GitHub
 history. Closes Phases 1–4.
 
+> **Re-run on the complete window.** The figure was first measured on a partial corpus — the
+> backfill had stopped mid-window and was never resumed (see [`RECALL_AUDIT.md`](RECALL_AUDIT.md)).
+> The window is now complete: 80 issues and 219 pull requests, matching GitHub exactly.
+> **The 13 Decisions and all 18 verdicts are unchanged**, so no adjudication was invalidated.
+> Graph totals below are the complete-window figures.
+
 ## The figure
 
 **18 of 18 correct. No failures.**
@@ -41,7 +47,7 @@ and T2 re-runs F2 through the time filter. They confirm consistency, not correct
 | F1 | flagship | why | answered | 1 | explicit |
 | F2 | flagship | impact | answered | 17 | 11 corroborated, 6 explicit |
 | H1 | negative | why | nothing | 0 | — (regression guard for #16/#17) |
-| H2 | causal | why | answered | 1 | explicit |
+| H2 | causal | why | answered | 2 | 1 corroborated, 1 explicit |
 | H3 | causal | why | answered | 1 | corroborated |
 | H4 | causal | why | answered | 1 | explicit |
 | H5 | retrieval | why | answered | 1 | explicit |
@@ -49,7 +55,7 @@ and T2 re-runs F2 through the time filter. They confirm consistency, not correct
 | H7 | retrieval | why | nothing | 0 | — (thread retracted by #17) |
 | H8 | impact | impact | answered | 13 | 7 corroborated, 6 explicit |
 | H9 | impact | impact | answered | 10 | explicit |
-| H10 | impact | impact | answered | 5 | explicit |
+| H10 | impact | impact | answered | 6 | explicit |
 | N1 | negative | why | nothing | 0 | contract HELD |
 | N2 | negative | impact | nothing | 0 | contract HELD |
 | N3 | negative | why | nothing | 0 | contract HELD — no candidate retrieved |
@@ -91,17 +97,17 @@ degrades to nothing without it.
 
 | | |
 |---|---|
-| nodes | 620 |
-| current edges | 797 (+5 superseded, retained as history) |
-| thread clusters | 161 |
+| nodes | 971 |
+| current edges | 1,275 |
+| thread clusters | 235 |
 | **Decisions** | **13** — 3 explicit, 10 reconstructed |
 | rubric failures | 0 |
-| pull requests | 145 (27 merged in-window) |
-| issues / commits / releases | 54 / 213 / 38 |
-| corroborated edges | 33, across 6 threads |
+| pull requests | 219 (29 merged in-window) |
+| issues / commits / releases | 80 / 381 / 38 |
+| corroborated edges | 61, across 7 threads |
 | **inferred edges** | **0** |
 
-**13 Decisions from 161 threads is 8% coverage.** The system is precise and narrow by
+**13 Decisions from 235 threads is 5.5% coverage.** The system is precise and narrow by
 construction: the rubric refuses anything it cannot ground, and no significance filter was
 added because filtering for "important" decisions is exactly the model judgment §5.1
 exists to exclude. Coverage, not precision, is the binding constraint — and this
@@ -109,16 +115,21 @@ evaluation measures precision only.
 
 ## What the figure does not license
 
-- **Recall.** Nothing here measures decisions the system failed to reconstruct. 148 threads
-  produced no Decision and none were audited to establish whether they should have.
+- **Recall — partially answered since.** This evaluation measured none of it. The follow-up
+  recall audit ([`RECALL_AUDIT.md`](RECALL_AUDIT.md)) classified every non-Decision thread
+  and found no rubric bug: every rejection traces to absent evidence. What remains
+  unmeasured is whether `thread_key` splits decisions across clusters — that is not
+  mechanically detectable and is tracked as issue #26.
 - **Inference quality.** The graph holds zero inferred edges. §5.3's fallback was entered
   6 times and returned nothing every time, so its *entry condition* is exercised by flask
   while its answer-producing behaviour is verified only by the seeded fixture in
   `tests/test_traversal_fallback.py`. The LLM path remains stubbed and gated.
-- **Corroborated-tier calibration.** 33 edges across 6 of 161 threads, and only 3 queries
-  returned a corroborated path. flask merges largely without formal GitHub review — 11
-  `reviewed` edges across 145 PRs. The tier is under-exercised on this repo, which is a
-  property of the target, not evidence the rubric is right.
+- **Corroborated-tier calibration.** 61 edges across 7 of 235 threads, and only 4 queries
+  returned a corroborated path. flask merges largely without formal GitHub review — 14
+  `reviewed` edges across 219 PRs. Completing the window nearly doubled the corroborated
+  edge count while adding just one qualifying thread, which is consistent with the
+  sparsity being a property of the target rather than of the rubric — but the tier is
+  still under-exercised and this is not a calibration.
 - **Generalization.** One repository, one language, one 12-month window, one maintainer
   culture. flask's conventions — closing keywords in PR bodies, changelog in `CHANGES.rst`
   rather than release notes, no CODEOWNERS, no wiki — shaped what could be extracted at all.
@@ -130,7 +141,7 @@ Accepted deliberately rather than fixed by switching to a more convenient reposi
 1. **No CODEOWNERS** anywhere in flask. The `owns` extractor is built and no-ops; the §9
    set contains no ownership queries because it cannot.
 2. **`has_wiki: false`.** `motivated_by` resolves only to issues and PR bodies here.
-3. **Corroborated tier sparse** — 6 of 161 threads, for the reasons above.
+3. **Corroborated tier sparse** — 7 of 235 threads, for the reasons above.
 4. **Explicit-status Decisions limited to release-note citations** (3 of 13). flask's
    changelog lives in a repo file and file-content ingestion is not built.
 5. **Cross-references outside the 12-month window are skipped**, not fetched — fetching

--- a/eval/report.html
+++ b/eval/report.html
@@ -205,7 +205,7 @@ button:hover { opacity: .9; }
   <div class="lede">
     <h1>Evaluation worksheet</h1>
     <p class="sub">Decision Graph against <code>pallets/flask</code> — PRD v3.1 §9.
-    18 queries: 2 flagship plus 16 harder cases. Generated 2026-08-14 19:06.</p>
+    18 queries: 2 flagship plus 16 harder cases. Generated 2026-08-14 20:57.</p>
 
     <div class="note fixed">
       <p><strong>Regenerated after a defect found in adjudication.</strong>
@@ -248,7 +248,7 @@ button:hover { opacity: .9; }
     <div class="stat good"><span class="n">5/5</span><span class="l">contracts held</span></div>
   </div>
 
-  <div class="tiers"><span class="tb tier-explicit" style="flex:37"><span>explicit 37</span></span><span class="tb tier-corroborated" style="flex:30"><span>corroborated 30</span></span></div>
+  <div class="tiers"><span class="tb tier-explicit" style="flex:38"><span>explicit 38</span></span><span class="tb tier-corroborated" style="flex:31"><span>corroborated 31</span></span></div>
   <p class="caption">Evidence tier across every path returned. No path used the inferred
   fallback — the graph holds no inferred edges, so that branch is exercised only by the
   seeded fixture in the test suite.</p>
@@ -897,7 +897,7 @@ button:hover { opacity: .9; }
         <tbody><tr class="chosen">
               <td class="mono">issue:576</td>
               <td>Config.from_file() missing ENOTDIR in silent error handling</td>
-              <td class="mono">fuzzy</td>
+              <td class="mono">exact</td>
               <td class="num">1.00</td>
             </tr><tr>
               <td class="mono">pull_request:704</td>
@@ -970,7 +970,7 @@ button:hover { opacity: .9; }
     </section>
 
     <section class="block">
-      <h4>Traversal <span class="count">1 path</span></h4>
+      <h4>Traversal <span class="count">2 paths</span></h4>
       <ul class="paths">
     <li class="path">
       <div class="path-head">
@@ -988,6 +988,40 @@ button:hover { opacity: .9; }
         <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5812</span>
       </div>
       <div class="node">decision:923 — merge app and request contexts into a single context<span class="node-note">implemented by PR 5812, merged 2025-09-19</span></div>
+      </div>
+    </li>
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 2</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:198 — merge app and request contexts into a single context</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">references</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_issue_mention</span>
+        <span class="ref">https://github.com/pallets/flask/issues/6123</span>
+      </div>
+      <div class="node">issue:1910 — `stream_with_context`: abandoned generator leaves the app context current on the worker thread; later requests skip `teardown_appcontext`</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">references</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_issue_mention</span>
+        <span class="ref">https://github.com/pallets/flask/issues/6123</span>
+      </div>
+      <div class="node">issue:104 — `stream_with_context` does not work with async routes</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">motivated_by</span>
+        <span class="tier tier-corroborated">corroborated</span>
+        <span class="extractor">synthesis_closes_cluster</span>
+        <span class="ref"><span class="ref-kind">cluster</span>thread:30:pr-5799</span>
+      </div>
+      <div class="node">decision:922 — `stream_with_context` does not work with async routes<span class="node-note">implemented by PR 5799, merged 2025-08-19</span></div>
       </div>
     </li></ul>
     </section>
@@ -1693,7 +1727,7 @@ button:hover { opacity: .9; }
         <tbody><tr class="chosen">
               <td class="mono">issue:576</td>
               <td>Config.from_file() missing ENOTDIR in silent error handling</td>
-              <td class="mono">fuzzy</td>
+              <td class="mono">exact</td>
               <td class="num">1.00</td>
             </tr><tr>
               <td class="mono">pull_request:704</td>
@@ -1992,7 +2026,7 @@ button:hover { opacity: .9; }
     </section>
 
     <section class="block">
-      <h4>Traversal <span class="count">5 paths</span></h4>
+      <h4>Traversal <span class="count">6 paths</span></h4>
       <ul class="paths">
     <li class="path">
       <div class="path-head">
@@ -2107,7 +2141,47 @@ button:hover { opacity: .9; }
       </div>
       <div class="node">decision:929 — asgiref fails with gevent patching<span class="node-note">implemented by PR 5900, merged 2026-01-25</span></div>
       </div>
+    </li>
+        <li class="more">
+          <details>
+            <summary>1 further path</summary>
+            <ul class="paths">
+    <li class="path">
+      <div class="path-head">
+        <span class="path-n">path 6</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="depth">3 hops</span>
+      </div>
+      <div class="trace">
+        <div class="node node-start">issue:477 — asgiref fails with gevent patching</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">closes</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">body_closing_keyword</span>
+        <span class="ref">https://github.com/pallets/flask/pull/5900</span>
+      </div>
+      <div class="node">pull_request:487 — document using gevent for async</div>
+      <div class="step">
+        <span class="conn">→</span>
+        <span class="etype">implements</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">pr_commit_list</span>
+        <span class="ref">ac5664d2281533eacafd64f5cc7d5edcdaccab60</span>
+      </div>
+      <div class="node">commit:489 — document using gevent for async</div>
+      <div class="step">
+        <span class="conn">←</span>
+        <span class="etype">depends_on</span>
+        <span class="tier tier-explicit">explicit</span>
+        <span class="extractor">commit_parent</span>
+        <span class="ref">ac5664d2281533eacafd64f5cc7d5edcdaccab60</span>
+      </div>
+      <div class="node">commit:2084 — document using gevent for async (#5900)</div>
+      </div>
     </li></ul>
+          </details>
+        </li></ul>
     </section>
 
     <div class="verify"><span class="verify-label">Check against flask</span><p>Are all reached artifacts genuinely affected by a revert?</p></div>

--- a/eval/results.json
+++ b/eval/results.json
@@ -6,7 +6,7 @@
     "adjudication": "Correctness is decided by a human against flask's actual history. The runner records what the system returned and never grades it. Where a 'contract' field appears, that is a mechanically checkable property of the engine (e.g. 'must return no answer'), not a claim about flask.",
     "revision": "Regenerated after issues #16/#17. The landing gate retracted 7 Decisions that rested on unmerged work; 13 remain, all with a merged implementer."
   },
-  "generated_at": "2026-08-14T19:06:40.138845+05:30",
+  "generated_at": "2026-08-14T20:57:51.634261+05:30",
   "summary": {
     "total": 18,
     "answered": 10,
@@ -591,7 +591,7 @@
           "node_type": "issue",
           "external_id": "5912",
           "title": "Config.from_file() missing ENOTDIR in silent error handling",
-          "match": "fuzzy",
+          "match": "exact",
           "score": 1.0
         },
         {
@@ -671,10 +671,44 @@
               "to_node": "decision:923 \u2014 merge app and request contexts into a single context  [implemented by PR 5812, merged 2025-09-19]"
             }
           ]
+        },
+        {
+          "tier": "corroborated",
+          "depth": 3,
+          "start": "issue:198 \u2014 merge app and request contexts into a single context",
+          "steps": [
+            {
+              "edge_type": "references",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_issue_mention",
+              "source_ref": "https://github.com/pallets/flask/issues/6123",
+              "direction": "reverse",
+              "to_node": "issue:1910 \u2014 `stream_with_context`: abandoned generator leaves the app context current on the worker thread; later requests skip `teardown_appcontext`"
+            },
+            {
+              "edge_type": "references",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_issue_mention",
+              "source_ref": "https://github.com/pallets/flask/issues/6123",
+              "direction": "forward",
+              "to_node": "issue:104 \u2014 `stream_with_context` does not work with async routes"
+            },
+            {
+              "edge_type": "motivated_by",
+              "tier": "corroborated",
+              "tag": "explicit",
+              "extractor": "synthesis_closes_cluster",
+              "source_ref": "thread:30:pr-5799",
+              "direction": "reverse",
+              "to_node": "decision:922 \u2014 `stream_with_context` does not work with async routes  [implemented by PR 5799, merged 2025-08-19]"
+            }
+          ]
         }
       ],
       "used_inferred_fallback": false,
-      "explanation": "1 explicit path(s) found; inferred edges not consulted",
+      "explanation": "2 explicit path(s) found; inferred edges not consulted",
       "answered": true,
       "verdict": null,
       "notes": null,
@@ -1251,7 +1285,7 @@
           "node_type": "issue",
           "external_id": "5912",
           "title": "Config.from_file() missing ENOTDIR in silent error handling",
-          "match": "fuzzy",
+          "match": "exact",
           "score": 1.0
         },
         {
@@ -1628,10 +1662,44 @@
               "to_node": "decision:929 \u2014 asgiref fails with gevent patching  [implemented by PR 5900, merged 2026-01-25]"
             }
           ]
+        },
+        {
+          "tier": "explicit",
+          "depth": 3,
+          "start": "issue:477 \u2014 asgiref fails with gevent patching",
+          "steps": [
+            {
+              "edge_type": "closes",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "body_closing_keyword",
+              "source_ref": "https://github.com/pallets/flask/pull/5900",
+              "direction": "reverse",
+              "to_node": "pull_request:487 \u2014 document using gevent for async"
+            },
+            {
+              "edge_type": "implements",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "pr_commit_list",
+              "source_ref": "ac5664d2281533eacafd64f5cc7d5edcdaccab60",
+              "direction": "forward",
+              "to_node": "commit:489 \u2014 document using gevent for async"
+            },
+            {
+              "edge_type": "depends_on",
+              "tier": "explicit",
+              "tag": "explicit",
+              "extractor": "commit_parent",
+              "source_ref": "ac5664d2281533eacafd64f5cc7d5edcdaccab60",
+              "direction": "reverse",
+              "to_node": "commit:2084 \u2014 document using gevent for async (#5900)"
+            }
+          ]
         }
       ],
       "used_inferred_fallback": false,
-      "explanation": "5 explicit path(s) found; inferred edges not consulted",
+      "explanation": "6 explicit path(s) found; inferred edges not consulted",
       "answered": true,
       "verdict": null,
       "notes": null,

--- a/eval/results.json
+++ b/eval/results.json
@@ -6,7 +6,7 @@
     "adjudication": "Correctness is decided by a human against flask's actual history. The runner records what the system returned and never grades it. Where a 'contract' field appears, that is a mechanically checkable property of the engine (e.g. 'must return no answer'), not a claim about flask.",
     "revision": "Regenerated after issues #16/#17. The landing gate retracted 7 Decisions that rested on unmerged work; 13 remain, all with a merged implementer."
   },
-  "generated_at": "2026-08-14T20:57:51.634261+05:30",
+  "generated_at": "2026-08-14T23:11:55.117247+05:30",
   "summary": {
     "total": 18,
     "answered": 10,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = [
 ]
 
 [project.scripts]
+dg = "decision_graph.cli:main"
 dg-ingest = "decision_graph.run:main"
 dg-query = "decision_graph.query:main"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,8 @@ name = "decision-graph"
 version = "0.1.0"
 description = "Organizational Intelligence Engine — Phase 1 (knowledge graph + GitHub ingestion)"
 requires-python = ">=3.11"
+license = "MIT"
+license-files = ["LICENSE"]
 dependencies = [
     "psycopg[binary]>=3.1",
     "httpx>=0.27",

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -1,0 +1,680 @@
+"""`dg` — the single entry point.
+
+This runs *inside* the container. The host-side wrapper (`dg.ps1`, `dg.bat`, `dg`) does
+only what must happen on the host: confirm Docker is up, build the image once, and hand the
+arguments here. Everything else — prompting, migrating, ingesting, querying — happens here,
+so the logic exists once rather than three times in three shell dialects.
+
+Two deliberate choices about configuration:
+
+`DATABASE_URL` is **not** user-managed. It is a fixed property of the compose network and
+compose injects it. Making people export it was never configuration; it was an
+implementation detail leaking onto the host.
+
+`GITHUB_TOKEN` and `TARGET_REPO` live in `.env` at the project root, which is bind-mounted.
+They are read on every command, so they are set once and never exported again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import shutil
+import sys
+from pathlib import Path
+
+PROJECT_DIR = Path(os.environ.get("DG_PROJECT_DIR", "/work"))
+ENV_FILE = PROJECT_DIR / ".env"
+
+# ---------------------------------------------------------------------------
+# Output. Plain, aligned, and honest about severity — a health check that renders
+# everything the same colour is a health check nobody reads.
+# ---------------------------------------------------------------------------
+
+_COLOR = sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
+
+
+def _c(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _COLOR else text
+
+
+def bold(t: str) -> str:
+    return _c("1", t)
+
+
+def dim(t: str) -> str:
+    return _c("2", t)
+
+
+def green(t: str) -> str:
+    return _c("32", t)
+
+
+def yellow(t: str) -> str:
+    return _c("33", t)
+
+
+def red(t: str) -> str:
+    return _c("31", t)
+
+
+def cyan(t: str) -> str:
+    return _c("36", t)
+
+
+def heading(text: str) -> None:
+    print(f"\n{bold(text)}")
+    print(dim("─" * len(text)))
+
+
+def step(n: int, total: int, text: str) -> None:
+    print(f"\n{cyan(f'[{n}/{total}]')} {bold(text)}")
+
+
+PASS, WARN, FAIL = "pass", "warn", "fail"
+_MARK = {PASS: green("  ok  "), WARN: yellow(" warn "), FAIL: red(" FAIL ")}
+
+
+def check(state: str, label: str, detail: str = "", fix: str = "") -> str:
+    print(f"{_MARK[state]} {label}")
+    if detail:
+        print(f"        {dim(detail)}")
+    if fix:
+        print(f"        {yellow('→')} {fix}")
+    return state
+
+
+# ---------------------------------------------------------------------------
+# .env
+# ---------------------------------------------------------------------------
+
+
+def read_env() -> dict[str, str]:
+    """Parse .env. Deliberately minimal — KEY=value, `#` comments, optional quotes."""
+    values: dict[str, str] = {}
+    if not ENV_FILE.exists():
+        return values
+    for line in ENV_FILE.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, val = line.partition("=")
+        values[key.strip()] = val.strip().strip('"').strip("'")
+    return values
+
+
+def load_env_into_os() -> dict[str, str]:
+    """Apply .env to the process. Real environment variables win, so a one-off
+    `-e GITHUB_TOKEN=…` can still override the file without editing it."""
+    values = read_env()
+    for key, val in values.items():
+        os.environ.setdefault(key, val)
+    return values
+
+
+def write_env(values: dict[str, str]) -> None:
+    lines = [
+        "# decision-graph configuration.",
+        "# Read automatically by every `dg` command — never export these by hand.",
+        "#",
+        "# DATABASE_URL is deliberately absent: it is a property of the Docker network",
+        "# and is injected by docker-compose.yml. Setting it here would be ignored.",
+        "",
+    ]
+    for key, val in values.items():
+        lines.append(f"{key}={val}")
+    ENV_FILE.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    try:
+        ENV_FILE.chmod(0o600)  # it holds a token
+    except OSError:
+        pass  # bind-mounted from Windows; permissions are not ours to set
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _connect(dsn: str | None = None):
+    from . import db
+
+    dsn = dsn or os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        raise RuntimeError("DATABASE_URL is not set — is this running through `dg`?")
+    return db.connect(dsn)
+
+
+def explain_db_error(exc: Exception) -> tuple[str, str]:
+    """Translate a psycopg connection failure into something actionable.
+
+    The raw text ("failed to resolve host 'db'", "Connection refused") describes the
+    Docker network, which is an implementation detail the reader did not choose and
+    cannot act on. Every one of these means the same thing in practice: the database
+    container is not up yet.
+    """
+    text = str(exc).lower()
+    if "resolve host" in text or "name resolution" in text:
+        return (
+            "the database container is not running",
+            "run `dg init` — it starts the database and waits for it to be ready",
+        )
+    if "connection refused" in text or "could not connect" in text:
+        return (
+            "the database is starting but not accepting connections yet",
+            "wait a few seconds and retry; if it persists, run `dg doctor`",
+        )
+    if "authentication" in text or "password" in text:
+        return (
+            "the database rejected our credentials",
+            "the volume may predate a config change — `docker compose down -v` resets it "
+            "(this deletes ingested data)",
+        )
+    if "does not exist" in text and "database" in text:
+        return ("the database has not been created", "run `dg init`")
+    return (str(exc).strip().splitlines()[0], "run `dg doctor`")
+
+
+def _github(token: str, path: str) -> tuple[int, dict | list | None]:
+    import httpx
+
+    try:
+        r = httpx.get(
+            f"https://api.github.com{path}",
+            headers={
+                "Authorization": f"Bearer {token}",
+                "Accept": "application/vnd.github+json",
+            },
+            timeout=15,
+        )
+    except httpx.HTTPError as exc:
+        return 0, {"message": str(exc)}
+    try:
+        return r.status_code, r.json()
+    except ValueError:
+        return r.status_code, None
+
+
+def _prompt(label: str, *, default: str = "", secret: bool = False) -> str:
+    if not sys.stdin.isatty():
+        raise RuntimeError(
+            f"{label} is needed but there is no terminal to ask on. "
+            f"Set it in .env, or re-run `dg init` from an interactive shell."
+        )
+    suffix = f" [{default}]" if default else ""
+    if secret:
+        import getpass
+
+        val = getpass.getpass(f"  {label}{suffix}: ").strip()
+    else:
+        val = input(f"  {label}{suffix}: ").strip()
+    return val or default
+
+
+# ---------------------------------------------------------------------------
+# dg init
+# ---------------------------------------------------------------------------
+
+
+def cmd_init(args: argparse.Namespace) -> int:
+    total = 4
+    print(bold("\ndecision-graph setup"))
+    print(dim("Four steps. Nothing is installed on your machine — it all runs in Docker."))
+
+    existing = read_env()
+
+    # --- 1. database -------------------------------------------------------
+    step(1, total, "Database")
+    dsn = os.environ.get("DATABASE_URL", "")
+    try:
+        conn = _connect(dsn)
+        server = conn.execute("SELECT version() AS v").fetchone()["v"].split(",")[0]
+        print(f"        connected — {dim(server)}")
+    except Exception as exc:
+        why, fix = explain_db_error(exc)
+        print(red(f"        cannot reach the database: {why}"))
+        print(f"        {yellow('→')} {fix}")
+        return 1
+
+    # --- 2. GitHub token ---------------------------------------------------
+    step(2, total, "GitHub token")
+    # Report where a value actually came from. Saying ".env" for something passed in the
+    # environment sends people to edit a file that is not the one in effect.
+    token = os.environ.get("GITHUB_TOKEN", "") or existing.get("GITHUB_TOKEN", "")
+    token_src = ".env" if existing.get("GITHUB_TOKEN") == token and token else "the environment"
+
+    if token and not args.reconfigure:
+        code, _ = _github(token, "/user")
+        if code == 200:
+            print(f"        using the token from {token_src} {green('(valid)')}")
+        else:
+            print(yellow(f"        the token from {token_src} was rejected — asking again"))
+            token = ""
+
+    if not token or args.reconfigure:
+        print(dim("        A token is required: unauthenticated GitHub allows 60 requests"))
+        print(dim("        per hour, which cannot finish a backfill. Public repos need no"))
+        print(dim("        scopes at all — a classic token with nothing ticked works."))
+        print(dim("        Create one: https://github.com/settings/tokens"))
+        print()
+        while True:
+            token = _prompt("GITHUB_TOKEN", secret=True)
+            if not token:
+                print(red("        a token is required to continue"))
+                continue
+            code, body = _github(token, "/user")
+            if code == 200 and isinstance(body, dict):
+                print(f"        {green('valid')} — authenticated as {bold(body.get('login', '?'))}")
+                break
+            if code == 401:
+                print(red("        GitHub rejected that token (401). Check it and retry."))
+            else:
+                msg = body.get("message") if isinstance(body, dict) else code
+                print(red(f"        could not verify the token: {msg}"))
+
+    # --- 3. target repo ----------------------------------------------------
+    step(3, total, "Target repository")
+    repo = os.environ.get("TARGET_REPO", "") or existing.get("TARGET_REPO", "")
+
+    if not repo or args.reconfigure:
+        print(dim("        The repository to ingest. This is the default for `dg ingest`;"))
+        print(dim("        you can always override it with `dg ingest --repo owner/name`."))
+        print()
+        while True:
+            repo = _prompt("TARGET_REPO", default=repo or "pallets/flask")
+            if "/" not in repo:
+                print(red("        expected the form owner/name"))
+                continue
+            code, body = _github(token, f"/repos/{repo}")
+            if code == 200 and isinstance(body, dict):
+                print(f"        {green('found')} — {bold(repo)}, {body.get('stargazers_count', 0)} stars")
+                break
+            if code == 404:
+                print(red(f"        GitHub has no repository {repo} visible to this token"))
+            else:
+                print(red(f"        could not reach GitHub (HTTP {code})"))
+    else:
+        repo_src = ".env" if existing.get("TARGET_REPO") == repo else "the environment"
+        print(f"        using {bold(repo)} from {repo_src}")
+
+    write_env(
+        {
+            "GITHUB_TOKEN": token,
+            "TARGET_REPO": repo,
+            "BACKFILL_MONTHS": existing.get("BACKFILL_MONTHS", "12"),
+        }
+    )
+    print(f"        wrote {cyan('.env')}")
+
+    # --- 4. migrations -----------------------------------------------------
+    step(4, total, "Schema")
+    from . import migrate
+
+    try:
+        result = migrate.apply_all(conn)
+    except Exception as exc:
+        print(red(f"        migration failed: {exc}"))
+        return 1
+
+    if result.applied:
+        print(f"        applied {len(result.applied)}: {dim(', '.join(result.applied))}")
+    if result.adopted:
+        print(f"        adopted {len(result.adopted)} already present in this database")
+    if result.up_to_date:
+        print(f"        {green('already up to date')} — {len(result.skipped)} migrations")
+    if result.changed:
+        print(yellow(f"        {len(result.changed)} applied migration(s) have since changed:"))
+        for name in result.changed:
+            print(yellow(f"          {name}"))
+        print(dim("        the database and the repository no longer agree on these"))
+
+    conn.close()
+
+    print(bold("\nReady.\n"))
+    print("  Next:")
+    # Pad the plain text, then colour — colouring first makes ljust count escape bytes
+    # and the column drifts by exactly the width of the ANSI codes.
+    nxt = [
+        ("dg doctor", "check everything is healthy"),
+        (f"dg ingest --repo {repo}", "pull the last 12 months of history"),
+        ("dg status", "see what was ingested"),
+        ('dg query "send_file" --mode why', "ask the graph a question"),
+    ]
+    width = max(len(cmd) for cmd, _ in nxt)
+    for cmd, why in nxt:
+        print(f"    {cyan(cmd)}{' ' * (width - len(cmd))}   {dim(why)}")
+    print()
+    print(dim("  Ingestion is the slow step — expect roughly 2 API requests per pull"))
+    print(dim("  request. If it stops on the rate limit, just run it again; it resumes."))
+    print()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# dg doctor
+# ---------------------------------------------------------------------------
+
+
+def cmd_doctor(args: argparse.Namespace) -> int:
+    heading("Environment")
+    states: list[str] = []
+
+    states.append(
+        check(PASS, f"Python {sys.version_info.major}.{sys.version_info.minor} in container")
+    )
+
+    if shutil.which("psql"):
+        states.append(check(PASS, "psql available in container"))
+    else:
+        states.append(
+            check(WARN, "psql not in the image", fix="only needed for manual SQL; `dg status` does not use it")
+        )
+
+    heading("Configuration")
+    if ENV_FILE.exists():
+        states.append(check(PASS, ".env found", str(ENV_FILE)))
+    else:
+        states.append(
+            check(FAIL, ".env is missing", f"expected at {ENV_FILE}", "run `dg init`")
+        )
+
+    token = os.environ.get("GITHUB_TOKEN", "")
+    repo = os.environ.get("TARGET_REPO", "")
+
+    if not token:
+        states.append(check(FAIL, "GITHUB_TOKEN not set", fix="run `dg init`"))
+    else:
+        code, body = _github(token, "/user")
+        if code == 200 and isinstance(body, dict):
+            states.append(check(PASS, "GitHub token valid", f"authenticated as {body.get('login')}"))
+            rc, rate = _github(token, "/rate_limit")
+            if rc == 200 and isinstance(rate, dict):
+                core = rate.get("resources", {}).get("core", {})
+                remaining, limit = core.get("remaining", 0), core.get("limit", 0)
+                if remaining < 200:
+                    states.append(
+                        check(
+                            WARN,
+                            f"rate limit low — {remaining}/{limit} left",
+                            fix="ingestion will stop cleanly and resume next run",
+                        )
+                    )
+                else:
+                    states.append(check(PASS, f"rate limit — {remaining}/{limit} remaining"))
+        elif code == 401:
+            states.append(
+                check(FAIL, "GitHub rejected the token (401)", fix="run `dg init --reconfigure`")
+            )
+        else:
+            states.append(
+                check(
+                    FAIL,
+                    "cannot reach the GitHub API",
+                    f"HTTP {code}",
+                    "check your network or proxy, then retry",
+                )
+            )
+
+    if repo:
+        states.append(check(PASS, f"target repo — {repo}"))
+    else:
+        states.append(check(WARN, "TARGET_REPO not set", fix="pass `--repo owner/name` per command"))
+
+    heading("Database")
+    dsn = os.environ.get("DATABASE_URL", "")
+    if not dsn:
+        states.append(
+            check(
+                FAIL,
+                "DATABASE_URL not set",
+                "compose should inject this",
+                "run through `dg`, not `python -m` directly",
+            )
+        )
+        return _verdict(states)
+
+    try:
+        conn = _connect(dsn)
+    except Exception as exc:
+        why, fix = explain_db_error(exc)
+        states.append(check(FAIL, "database unreachable", why, fix))
+        return _verdict(states)
+
+    states.append(check(PASS, "database reachable"))
+
+    from . import migrate
+
+    try:
+        outstanding = migrate.pending(conn)
+        if outstanding:
+            states.append(
+                check(
+                    FAIL,
+                    f"{len(outstanding)} migration(s) not applied",
+                    ", ".join(outstanding),
+                    "run `dg init` — it is safe to re-run",
+                )
+            )
+        else:
+            states.append(check(PASS, "schema up to date"))
+    except Exception as exc:
+        states.append(check(FAIL, "could not read the migration ledger", str(exc), "run `dg init`"))
+
+    heading("Data")
+    try:
+        nodes = conn.execute("SELECT count(*) AS n FROM node").fetchone()["n"]
+        if nodes:
+            states.append(check(PASS, f"{nodes:,} nodes ingested"))
+        else:
+            states.append(
+                check(WARN, "the graph is empty", fix=f"run `dg ingest{f' --repo {repo}' if repo else ''}`")
+            )
+    except Exception:
+        states.append(check(WARN, "no graph tables yet", fix="run `dg init`"))
+
+    conn.close()
+    return _verdict(states)
+
+
+def _verdict(states: list[str]) -> int:
+    fails = states.count(FAIL)
+    warns = states.count(WARN)
+    print()
+    if fails:
+        print(red(bold(f"{fails} problem(s) need fixing.")) + dim(f"  ({warns} warning(s))"))
+        return 1
+    if warns:
+        print(yellow(bold(f"Healthy, with {warns} warning(s).")))
+        return 0
+    print(green(bold("All checks passed.")))
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# dg status
+# ---------------------------------------------------------------------------
+
+
+def cmd_status(args: argparse.Namespace) -> int:
+    try:
+        conn = _connect()
+    except Exception as exc:
+        why, fix = explain_db_error(exc)
+        print(red(f"Cannot reach the database: {why}"))
+        print(f"{yellow('→')} {fix}")
+        return 1
+
+    try:
+        conn.execute("SELECT 1 FROM node LIMIT 1")
+    except Exception:
+        conn.rollback()
+        print(yellow("No schema yet.") + " Run `dg init`.")
+        conn.close()
+        return 1
+
+    repos = conn.execute(
+        """
+        SELECT r.id, r.external_id AS name,
+               (SELECT count(*) FROM node n WHERE n.repo_node_id = r.id) AS nodes
+        FROM node r WHERE r.node_type = 'repository' ORDER BY r.external_id
+        """
+    ).fetchall()
+
+    if not repos:
+        print(yellow("Nothing ingested yet.") + " Run `dg ingest --repo owner/name`.")
+        conn.close()
+        return 0
+
+    heading("Repositories")
+    for r in repos:
+        print(f"  {bold(r['name'])}  {dim(f'{r['nodes']:,} artifacts')}")
+    # People carry no repo_node_id — a GitHub account is not owned by a repository — so
+    # the per-repo counts deliberately do not sum to the total below. Say so, rather than
+    # printing two numbers that look like they should reconcile and don't.
+    unscoped = conn.execute(
+        "SELECT count(*) AS n FROM node WHERE repo_node_id IS NULL AND node_type <> 'repository'"
+    ).fetchone()["n"]
+    if unscoped:
+        print(dim(f"  + {unscoped:,} people, not owned by any single repository"))
+
+    heading("Nodes by type")
+    rows = conn.execute(
+        "SELECT node_type::text AS t, count(*) AS n FROM node GROUP BY 1 ORDER BY 2 DESC"
+    ).fetchall()
+    width = max(len(r["t"]) for r in rows)
+    for r in rows:
+        print(f"  {r['t']:<{width}}  {r['n']:>6,}")
+    print(f"  {dim('─' * (width + 9))}")
+    print(f"  {'total':<{width}}  {sum(r['n'] for r in rows):>6,}")
+
+    heading("Ingestion")
+    runs = conn.execute(
+        """
+        SELECT status, started_at, finished_at, error
+        FROM ingestion_run ORDER BY id DESC LIMIT 1
+        """
+    ).fetchall()
+    if runs:
+        r = runs[0]
+        mark = green("succeeded") if r["status"] == "succeeded" else red(r["status"])
+        when = r["finished_at"] or r["started_at"]
+        print(f"  last run   {mark} at {when:%Y-%m-%d %H:%M} UTC")
+        if r["error"]:
+            print(f"  {dim(r['error'][:100])}")
+    else:
+        print(dim("  no runs recorded"))
+
+    cursors = conn.execute(
+        "SELECT resource, phase, steady_watermark FROM ingestion_cursor ORDER BY resource"
+    ).fetchall()
+    if cursors:
+        print()
+        for c in cursors:
+            wm = f"{c['steady_watermark']:%Y-%m-%d}" if c["steady_watermark"] else "—"
+            print(f"  {c['resource']:<10} {c['phase']:<9} up to {wm}")
+        print(dim("\n  A watermark short of today means there is more to fetch — re-run"))
+        print(dim("  `dg ingest` to continue from exactly there."))
+
+    decisions = conn.execute("SELECT count(*) AS n FROM decision").fetchone()["n"]
+    threads = conn.execute(
+        "SELECT count(DISTINCT thread_key) AS n FROM node WHERE thread_key IS NOT NULL"
+    ).fetchone()["n"]
+    heading("Graph")
+    print(f"  {bold(str(decisions))} decisions from {threads:,} thread clusters")
+    if threads and not decisions:
+        print(dim("  No decisions yet. That is a real answer, not a failure: the rubric"))
+        print(dim("  needs a motivating issue AND merged work in one thread."))
+
+    conn.close()
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# passthrough
+# ---------------------------------------------------------------------------
+
+
+def cmd_ingest(args: argparse.Namespace, extra: list[str]) -> int:
+    from . import run
+
+    argv = list(extra)
+    if args.repo:
+        argv += ["--repo", args.repo]
+    return run.main(argv)
+
+
+def cmd_query(args: argparse.Namespace, extra: list[str]) -> int:
+    from . import query
+
+    return query.main([args.text] + list(extra))
+
+
+# ---------------------------------------------------------------------------
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="dg",
+        description="Organizational Intelligence Engine — decision graph over a GitHub repo.",
+        epilog="Every command runs in Docker. Nothing is installed on your machine.",
+    )
+    sub = p.add_subparsers(dest="command", metavar="<command>")
+
+    i = sub.add_parser("init", help="first-time setup: configure, start the database, migrate")
+    i.add_argument(
+        "--reconfigure", action="store_true", help="re-prompt for token and repo even if set"
+    )
+    i.set_defaults(fn=cmd_init)
+
+    d = sub.add_parser("doctor", help="check everything is healthy and say how to fix it")
+    d.set_defaults(fn=cmd_doctor)
+
+    s = sub.add_parser("status", help="what is currently ingested")
+    s.set_defaults(fn=cmd_status)
+
+    g = sub.add_parser(
+        "ingest",
+        help="pull a repository's history into the graph",
+        epilog="Any other dg-ingest flag (--months, --resources, --max-pages) is passed through.",
+    )
+    g.add_argument("--repo", help="owner/name (defaults to TARGET_REPO from .env)")
+    g.set_defaults(fn=cmd_ingest, passthrough=True)
+
+    q = sub.add_parser(
+        "query",
+        help="ask why something happened, or what a change affects",
+        epilog="Any other dg-query flag (--mode, --depth, --as-of, --limit) is passed through.",
+    )
+    q.add_argument("text", help="a title, #number, or commit sha")
+    q.set_defaults(fn=cmd_query, passthrough=True)
+
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_env_into_os()
+    parser = build_parser()
+    args, extra = parser.parse_known_args(argv)
+
+    if not getattr(args, "command", None):
+        parser.print_help()
+        return 0
+
+    # Unknown flags are an error for our own commands, but ingest and query deliberately
+    # forward theirs to the underlying tools rather than duplicating every option here.
+    if extra and not getattr(args, "passthrough", False):
+        parser.error(f"unrecognised arguments: {' '.join(extra)}")
+
+    try:
+        if getattr(args, "passthrough", False):
+            return args.fn(args, extra)
+        return args.fn(args)
+    except KeyboardInterrupt:
+        print("\ninterrupted", file=sys.stderr)
+        return 130
+    except RuntimeError as exc:
+        print(red(f"\nerror: {exc}"), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/decision_graph/migrate.py
+++ b/src/decision_graph/migrate.py
@@ -1,0 +1,172 @@
+"""Migration runner with a ledger, so `dg init` is safe to re-run.
+
+The migrations were written to be applied once, by hand, in filename order. That was fine
+while one person ran them against one database; it is not fine for a setup command anyone
+can run twice. `CREATE TABLE node (...)` fails the second time, and the failure reads like a
+bug rather than "already done".
+
+Two constraints shaped this:
+
+**Each migration opens its own transaction.** Every file begins `BEGIN;` and ends `COMMIT;`,
+so they must run with autocommit on and be left to manage themselves. The runner cannot wrap
+a file in a transaction of its own and cannot record the ledger row inside the file's
+transaction.
+
+**So the ledger can never be perfectly atomic with the migration.** Rather than pretend
+otherwise, every migration declares a *sentinel* — an object that exists iff it has run —
+and the runner probes it before applying. That single mechanism covers three cases at once:
+a database migrated by hand before this runner existed, a crash between a file committing
+and its ledger row landing, and an ordinary fresh apply. Nothing is ever re-applied blindly,
+and nothing is ever marked done on trust.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+import psycopg
+
+log = logging.getLogger(__name__)
+
+MIGRATIONS_DIR = Path("/work/db/migrations")
+
+LEDGER_DDL = """
+CREATE TABLE IF NOT EXISTS schema_migration (
+    filename    text PRIMARY KEY,
+    checksum    text NOT NULL,
+    applied_at  timestamptz NOT NULL DEFAULT now(),
+    adopted     boolean NOT NULL DEFAULT false
+)
+"""
+
+# One probe per migration: true iff that migration has already run. Keyed by the numeric
+# prefix so renaming a file's descriptive suffix does not silently break detection.
+#
+# A migration missing from this map can never be adopted — it will simply be applied. That
+# is the safe direction to fail: a redundant apply errors loudly, whereas a wrong adoption
+# skips real schema changes forever.
+SENTINELS: dict[str, str] = {
+    "0001": "to_regclass('public.node') IS NOT NULL",
+    "0002": "to_regproc('public.decision_rubric') IS NOT NULL",
+    "0003": """EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'ingestion_cursor' AND column_name = 'phase')""",
+    "0004": """EXISTS (SELECT 1 FROM pg_constraint
+                WHERE conname = 'node_repository_owns_itself')""",
+    "0005": "to_regclass('public.pending_reference') IS NOT NULL",
+    "0006": "to_regproc('public.apply_corroboration') IS NOT NULL",
+    "0007": "to_regproc('public.thread_landed') IS NOT NULL",
+    "0008": "to_regproc('public.retract_unsupported_decisions') IS NOT NULL",
+    "0009": "to_regclass('public.decision_thread_uidx') IS NOT NULL",
+}
+
+
+@dataclass
+class MigrationResult:
+    applied: list[str] = field(default_factory=list)
+    adopted: list[str] = field(default_factory=list)
+    skipped: list[str] = field(default_factory=list)
+    changed: list[str] = field(default_factory=list)
+
+    @property
+    def up_to_date(self) -> bool:
+        return not self.applied and not self.adopted
+
+
+def _checksum(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+
+
+def discover(directory: Path | None = None) -> list[Path]:
+    d = Path(directory) if directory else MIGRATIONS_DIR
+    if not d.is_dir():
+        raise FileNotFoundError(f"no migrations directory at {d}")
+    files = sorted(d.glob("*.sql"))
+    if not files:
+        raise FileNotFoundError(f"no .sql migrations in {d}")
+    return files
+
+
+def _probe(conn: psycopg.Connection, filename: str) -> bool:
+    expr = SENTINELS.get(filename[:4])
+    if expr is None:
+        return False
+    row = conn.execute(f"SELECT ({expr}) AS present").fetchone()
+    return bool(row and row["present"])
+
+
+def _ledger(conn: psycopg.Connection) -> dict[str, str]:
+    return {
+        r["filename"]: r["checksum"]
+        for r in conn.execute("SELECT filename, checksum FROM schema_migration").fetchall()
+    }
+
+
+def pending(conn: psycopg.Connection, directory: Path | None = None) -> list[str]:
+    """Migrations not yet recorded as applied. Read-only — used by `dg doctor`."""
+    conn.execute(LEDGER_DDL)
+    conn.commit()
+    done = set(_ledger(conn))
+    return [p.name for p in discover(directory) if p.name not in done]
+
+
+def apply_all(conn: psycopg.Connection, directory: Path | None = None) -> MigrationResult:
+    """Bring the database up to date. Safe to run repeatedly."""
+    files = discover(directory)
+    result = MigrationResult()
+
+    was_autocommit = conn.autocommit
+    conn.execute(LEDGER_DDL)
+    conn.commit()
+    # Each migration file opens and closes its own transaction, so the connection must not
+    # already be inside one.
+    conn.autocommit = True
+
+    try:
+        ledger = _ledger(conn)
+
+        for path in files:
+            sql = path.read_text(encoding="utf-8")
+            digest = _checksum(sql)
+
+            if path.name in ledger:
+                if ledger[path.name] != digest:
+                    # The file changed after it was applied, so the database and the
+                    # repository no longer agree. Nothing here can reconcile that; report
+                    # it rather than guessing which one is right.
+                    result.changed.append(path.name)
+                result.skipped.append(path.name)
+                continue
+
+            if _probe(conn, path.name):
+                # Already in the database but not in the ledger: either applied by hand
+                # before this runner existed, or recorded-but-not-committed after a crash.
+                conn.execute(
+                    "INSERT INTO schema_migration (filename, checksum, adopted) "
+                    "VALUES (%s, %s, true) ON CONFLICT (filename) DO NOTHING",
+                    (path.name, digest),
+                )
+                result.adopted.append(path.name)
+                continue
+
+            log.info("applying %s", path.name)
+            try:
+                conn.execute(sql)
+            except Exception:
+                log.error(
+                    "migration %s failed; it manages its own transaction, so the database "
+                    "is unchanged and nothing was recorded",
+                    path.name,
+                )
+                raise
+            conn.execute(
+                "INSERT INTO schema_migration (filename, checksum) VALUES (%s, %s)",
+                (path.name, digest),
+            )
+            result.applied.append(path.name)
+    finally:
+        conn.autocommit = was_autocommit
+
+    return result

--- a/src/decision_graph/reasoning.py
+++ b/src/decision_graph/reasoning.py
@@ -127,6 +127,13 @@ class Answer:
 # Recursive walk. Both orientations are followed in one CTE so a single implementation
 # serves "what led to this" and "what does this affect"; the mode's edge set is what
 # gives the walk its direction of meaning.
+#
+# "Now" is resolved by the DATABASE, not the client. `valid_from` is written by the server
+# clock, so comparing it against a client-side timestamp makes the query correct only while
+# the two clocks agree. They routinely do not -- a containerised Postgres drifting a second
+# ahead of its host is enough to make every edge written in the last second invisible, which
+# is exactly the state a query runs in immediately after an ingest. An explicit --as-of is
+# still honoured; only the default is server-side.
 _WALK_SQL = """
 WITH RECURSIVE walk AS (
     SELECT %(start)s::bigint AS node_id,
@@ -146,16 +153,16 @@ WITH RECURSIVE walk AS (
         FROM edge e
         WHERE e.src_node_id = w.node_id
           AND e.edge_type = ANY(%(types)s::edge_type[])
-          AND e.valid_from <= %(as_of)s
-          AND (e.valid_to IS NULL OR e.valid_to > %(as_of)s)
+          AND e.valid_from <= COALESCE(%(as_of)s::timestamptz, now())
+          AND (e.valid_to IS NULL OR e.valid_to > COALESCE(%(as_of)s::timestamptz, now()))
           {tag_clause}
         UNION ALL
         SELECT e.id, e.src_node_id
         FROM edge e
         WHERE e.dst_node_id = w.node_id
           AND e.edge_type = ANY(%(types)s::edge_type[])
-          AND e.valid_from <= %(as_of)s
-          AND (e.valid_to IS NULL OR e.valid_to > %(as_of)s)
+          AND e.valid_from <= COALESCE(%(as_of)s::timestamptz, now())
+          AND (e.valid_to IS NULL OR e.valid_to > COALESCE(%(as_of)s::timestamptz, now()))
           {tag_clause}
     ) nxt
     WHERE w.depth < %(max_depth)s
@@ -189,7 +196,7 @@ def _walk(
             "start": start,
             "types": list(edge_types),
             "max_depth": max_depth,
-            "as_of": as_of or datetime.now().astimezone(),
+            "as_of": as_of,
         },
     ).fetchall()
 

--- a/src/decision_graph/synthesis.py
+++ b/src/decision_graph/synthesis.py
@@ -205,13 +205,33 @@ def _promote(conn: psycopg.Connection, repo_node_id: int, row: dict) -> bool:
     """Create or refresh one Decision plus its two rubric edges. Returns True if new."""
     thread_key = row["thread_key"]
 
+    # Look the cluster up by thread_key, NOT by external_id (issue #25).
+    #
+    # external_id is written as the thread_key at creation, but thread_key is not stable:
+    # union-find rewrites it whenever two clusters merge, and it rewrites node.thread_key
+    # without touching node.external_id. Matching on the frozen external_id therefore misses
+    # a Decision whose cluster has since been renamed, and promotes a SECOND Decision for
+    # the same decision. thread_key is the live cluster identity; external_id is a snapshot
+    # of it, so the lookup has to use the former and repair the latter.
     existing = conn.execute(
-        "SELECT id FROM node WHERE node_type = 'decision' AND repo_node_id = %s "
-        "AND external_id = %s",
+        "SELECT id, external_id FROM node WHERE node_type = 'decision' "
+        "AND repo_node_id = %s AND thread_key = %s",
         (repo_node_id, thread_key),
     ).fetchone()
 
-    # external_id is the thread_key, so a cluster always promotes to the same node.
+    if existing and existing["external_id"] != thread_key:
+        # The cluster was renamed by a merge after this Decision was created. Re-sync before
+        # upserting, or the upsert's ON CONFLICT (…, external_id) misses and inserts anew.
+        conn.execute(
+            "UPDATE node SET external_id = %s WHERE id = %s", (thread_key, existing["id"])
+        )
+        log.info(
+            "decision %s re-keyed to merged cluster %s (was %s)",
+            existing["id"],
+            thread_key,
+            existing["external_id"],
+        )
+
     decision_node_id = db.upsert_node(
         conn,
         node_type="decision",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,147 @@
+"""Unit tests for the `dg` CLI and the migration ledger.
+
+These run without Docker and without a database — they cover the parts where a mistake is
+silent rather than loud: an .env parser that drops a value, a migration ledger that adopts
+something it shouldn't, an error translator that stops translating.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from decision_graph import cli, migrate
+
+
+class EnvParsingTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = TemporaryDirectory()
+        self.dir = Path(self._tmp.name)
+        self._saved = cli.ENV_FILE
+        cli.ENV_FILE = self.dir / ".env"
+
+    def tearDown(self) -> None:
+        cli.ENV_FILE = self._saved
+        self._tmp.cleanup()
+
+    def test_missing_file_is_empty_not_an_error(self) -> None:
+        self.assertEqual(cli.read_env(), {})
+
+    def test_parses_comments_blanks_and_quotes(self) -> None:
+        cli.ENV_FILE.write_text(
+            "\n".join(
+                [
+                    "# a comment",
+                    "",
+                    "GITHUB_TOKEN=ghp_abc123",
+                    'TARGET_REPO="pallets/flask"',
+                    "BACKFILL_MONTHS = 6 ",
+                    "   # indented comment",
+                ]
+            ),
+            encoding="utf-8",
+        )
+        self.assertEqual(
+            cli.read_env(),
+            {
+                "GITHUB_TOKEN": "ghp_abc123",
+                "TARGET_REPO": "pallets/flask",
+                "BACKFILL_MONTHS": "6",
+            },
+        )
+
+    def test_value_containing_equals_is_preserved(self) -> None:
+        # Tokens and DSNs contain '='. Splitting on every '=' would silently truncate them.
+        cli.ENV_FILE.write_text("GITHUB_TOKEN=abc=def==\n", encoding="utf-8")
+        self.assertEqual(cli.read_env()["GITHUB_TOKEN"], "abc=def==")
+
+    def test_write_then_read_round_trips(self) -> None:
+        cli.write_env({"GITHUB_TOKEN": "t", "TARGET_REPO": "o/n", "BACKFILL_MONTHS": "12"})
+        self.assertEqual(cli.read_env()["TARGET_REPO"], "o/n")
+
+    def test_written_file_documents_why_database_url_is_absent(self) -> None:
+        # The single most likely support question is "where do I put DATABASE_URL".
+        cli.write_env({"GITHUB_TOKEN": "t"})
+        self.assertIn("DATABASE_URL", cli.ENV_FILE.read_text(encoding="utf-8"))
+
+
+class DbErrorTranslationTest(unittest.TestCase):
+    def test_unresolvable_host_is_reported_as_the_container_being_down(self) -> None:
+        why, fix = cli.explain_db_error(
+            Exception("failed to resolve host 'db': [Errno -3] Temporary failure in name resolution")
+        )
+        self.assertIn("not running", why)
+        self.assertIn("dg init", fix)
+        self.assertNotIn("Errno", why)
+
+    def test_connection_refused_is_distinguished_from_absent(self) -> None:
+        why, _ = cli.explain_db_error(Exception("connection refused"))
+        self.assertIn("starting", why)
+
+    def test_unknown_errors_fall_through_with_a_next_step(self) -> None:
+        why, fix = cli.explain_db_error(Exception("something entirely new\nsecond line"))
+        self.assertEqual(why, "something entirely new")
+        self.assertIn("doctor", fix)
+
+
+class MigrationLedgerTest(unittest.TestCase):
+    def test_every_migration_declares_a_sentinel(self) -> None:
+        # A migration with no sentinel can never be adopted, so an already-migrated
+        # database would try to re-apply it and fail. Adding a migration without adding
+        # its probe should break here, not in someone's terminal.
+        repo_root = Path(__file__).resolve().parents[1]
+        files = migrate.discover(repo_root / "db" / "migrations")
+        missing = [p.name for p in files if p.name[:4] not in migrate.SENTINELS]
+        self.assertEqual(missing, [], f"migrations without a sentinel probe: {missing}")
+
+    def test_sentinels_do_not_outnumber_migrations(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        prefixes = {p.name[:4] for p in migrate.discover(repo_root / "db" / "migrations")}
+        stale = sorted(set(migrate.SENTINELS) - prefixes)
+        self.assertEqual(stale, [], f"sentinels for migrations that no longer exist: {stale}")
+
+    def test_checksum_is_stable_and_sensitive(self) -> None:
+        self.assertEqual(migrate._checksum("abc"), migrate._checksum("abc"))
+        self.assertNotEqual(migrate._checksum("abc"), migrate._checksum("abd"))
+
+    def test_discover_orders_by_filename(self) -> None:
+        repo_root = Path(__file__).resolve().parents[1]
+        names = [p.name for p in migrate.discover(repo_root / "db" / "migrations")]
+        self.assertEqual(names, sorted(names))
+        self.assertTrue(names[0].startswith("0001"))
+
+    def test_discover_rejects_a_missing_directory(self) -> None:
+        with self.assertRaises(FileNotFoundError):
+            migrate.discover(Path("/nonexistent/migrations"))
+
+
+class ParserTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.parser = cli.build_parser()
+
+    def test_all_five_commands_are_registered(self) -> None:
+        for command in ("init", "doctor", "status", "ingest", "query"):
+            with self.subTest(command=command):
+                args, _ = self.parser.parse_known_args([command] if command != "query" else [command, "x"])
+                self.assertEqual(args.command, command)
+
+    def test_ingest_and_query_forward_unknown_flags(self) -> None:
+        # These deliberately pass their own flags through rather than re-declaring every
+        # option of dg-ingest and dg-query in two places.
+        args, extra = self.parser.parse_known_args(["ingest", "--months", "6"])
+        self.assertTrue(args.passthrough)
+        self.assertEqual(extra, ["--months", "6"])
+
+        args, extra = self.parser.parse_known_args(["query", "text", "--mode", "impact"])
+        self.assertTrue(args.passthrough)
+        self.assertEqual(extra, ["--mode", "impact"])
+
+    def test_our_own_commands_do_not_forward(self) -> None:
+        args, extra = self.parser.parse_known_args(["status", "--bogus"])
+        self.assertFalse(getattr(args, "passthrough", False))
+        self.assertEqual(extra, ["--bogus"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #29.

Before: Docker, psql, python3-venv, pip and gh installed by hand inside WSL, plus
`export DATABASE_URL=…` and `export GITHUB_TOKEN=…` every session.

After: **Docker Desktop and nothing else.** Clean clone to a working graph in ~10 seconds.

```powershell
git clone …; cd decision-graph; .\dg.ps1 init
```

## Architecture

The host wrappers (`dg.ps1`, `dg.bat`, `dg`) do only what *must* happen on the host —
confirm Docker is running, build the image once, forward the arguments. Everything else
lives in `src/decision_graph/cli.py`, so the logic exists once instead of three times in
three shell dialects.

**`DATABASE_URL` is no longer user-managed.** The database sits at a fixed address on the
compose network and compose injects it. Exporting it by hand was never configuration; it
was an implementation detail leaking onto the host. Only `GITHUB_TOKEN` and `TARGET_REPO`
remain, in `.env`, read automatically on every command.

## Migrations became re-runnable

Each migration file opens its own `BEGIN;`/`COMMIT;`, so the runner cannot wrap them or
record a ledger row atomically with the migration. Rather than pretend otherwise, **every
migration declares a sentinel object and is probed before applying.** That single mechanism
covers three cases at once: a database migrated by hand before the ledger existed, a crash
between a file committing and its ledger row landing, and an ordinary fresh apply. Nothing
is re-applied blindly; nothing is marked done on trust.

A test asserts every migration has a sentinel, so adding one without its probe fails in CI
rather than in someone's terminal.

## A real bug this surfaced, unrelated to the CLI

`_walk` defaulted `as_of` to the **client's** wall clock, while `valid_from` is written by
the **server's**:

```
valid_from (server)  17:41:09.116830 UTC
as_of      (client)  17:41:08.094330 UTC   ← 1s behind
```

The container clock here runs about a second ahead of the host, which made every edge
written in the last second invisible — precisely the state a query runs in immediately
after an ingest. Three traversal tests were failing on it. `now()` is now resolved
database-side; an explicit `--as-of` is unaffected, and §9 results are unchanged.

## doctor translates, rather than forwards

`failed to resolve host 'db'` describes a Docker network the reader did not choose and
cannot act on. It now reads *"the database container is not running"* with the command
that fixes it.

## Verified

From a genuine clean slate — `docker compose down -v`, `.env` deleted — through `init`
(twice, for idempotency), `doctor` (healthy, bad-token, database-down), `ingest`, `status`
and `query`. 16 new tests, 54 total, plus all 35 SQL checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014HFb2tRQWJcFC2wEHnVsHP