### PR TITLE
Make the shell wrappers pure ASCII

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,15 +353,19 @@ psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  5 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 57 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 60 checks
 ```
 
-All SQL suites run in a transaction and roll back. The Python suite runs 42 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 45 tests
 standalone. Setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 and 5 for the trace annotation. Docker adds 3 more that compile the whole package on the
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
+
+Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell
+5.1 decodes a BOM-less script using the system ANSI codepage, where an em-dash's last byte
+becomes a closing quote and silently truncates the string it sits in.
 
 These run on the host and still need Python. They are for working *on* the tool; using it
 needs only Docker.

--- a/dg
+++ b/dg
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# dg — macOS / Linux wrapper.
+# dg - macOS / Linux wrapper.
 #
 # Does only what must happen on the host: confirm Docker is running, build the image the
 # first time, and hand the arguments to the container. Every other decision lives in
@@ -29,7 +29,7 @@ docker info >/dev/null 2>&1 || fail \
 
 docker compose version >/dev/null 2>&1 || fail \
     "This Docker has no 'compose' subcommand." \
-    "Update Docker Desktop — Compose v2 is required."
+    "Update Docker Desktop - Compose v2 is required."
 
 # Build once. Docker caches layers, so rebuilding after a Dockerfile change is quick, but
 # doing it on every command would add seconds to every query.

--- a/dg.ps1
+++ b/dg.ps1
@@ -1,4 +1,4 @@
-# dg — PowerShell wrapper.
+# dg - PowerShell wrapper.
 #
 # Does only what must happen on the host: confirm Docker is running, build the image the
 # first time, and hand the arguments to the container. Every other decision lives in
@@ -29,7 +29,7 @@ if ($LASTEXITCODE -ne 0) {
 
 docker compose version 2>&1 | Out-Null
 if ($LASTEXITCODE -ne 0) {
-    Fail "This Docker has no 'compose' subcommand." "Update Docker Desktop — Compose v2 is required."
+    Fail "This Docker has no 'compose' subcommand." "Update Docker Desktop - Compose v2 is required."
 }
 
 # Build once. Docker caches layers, so a rebuild after a Dockerfile change is quick, but

--- a/tests/test_wrapper_encoding.py
+++ b/tests/test_wrapper_encoding.py
@@ -1,0 +1,75 @@
+"""The shell wrappers must be pure ASCII.
+
+`dg.ps1` shipped with an em-dash inside a double-quoted string. The file is UTF-8 without
+a BOM, and Windows PowerShell 5.1 decodes BOM-less scripts using the system ANSI codepage
+-- 1252 on a default Windows install. There, the three UTF-8 bytes of an em-dash decode as
+`a~EUR"`, and that final byte is U+201D RIGHT DOUBLE QUOTATION MARK, which PowerShell
+accepts as a string terminator. The string ended early, quote balance broke, and the
+parser reported `The string is missing the terminator: "` ten lines further down.
+
+A BOM would also fix it. ASCII is the stronger rule: these three files bootstrap the tool
+before anything else exists, they are read by whatever codepage the host happens to use,
+and nothing they say needs a character outside ASCII to say it. A BOM has to survive git
+attributes, editors and copy-paste; ASCII cannot be un-fixed.
+
+This is checked rather than remembered because the character is invisible in every editor
+that renders it correctly, which is all of them.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Every file executed by a host shell before the container exists.
+WRAPPERS = ("dg.ps1", "dg.bat", "dg")
+
+# The exact byte sequence that shipped: U+2014 inside a double-quoted PowerShell string.
+EM_DASH_SAMPLE = b'Fail "Update Docker Desktop \xe2\x80\x94 Compose v2 is required."\r\n'
+
+
+def non_ascii_positions(data: bytes) -> list[tuple[int, int, int]]:
+    """(line, column, byte) for every byte outside ASCII. Byte-wise, not decoded, because
+    the whole failure is that the host decodes these bytes differently than we intend."""
+    found = []
+    line = column = 1
+    for byte in data:
+        if byte > 0x7F:
+            found.append((line, column, byte))
+        if byte == 0x0A:
+            line += 1
+            column = 1
+        else:
+            column += 1
+    return found
+
+
+class WrapperEncodingTest(unittest.TestCase):
+    def test_wrappers_exist(self) -> None:
+        for name in WRAPPERS:
+            self.assertTrue((ROOT / name).is_file(), f"{name} is missing")
+
+    def test_wrappers_are_pure_ascii(self) -> None:
+        for name in WRAPPERS:
+            with self.subTest(wrapper=name):
+                offenders = non_ascii_positions((ROOT / name).read_bytes())
+                detail = ", ".join(
+                    f"line {ln} col {col}: 0x{b:02X}" for ln, col, b in offenders[:5]
+                )
+                self.assertEqual(
+                    offenders,
+                    [],
+                    f"{name} contains non-ASCII bytes ({detail}). Windows PowerShell 5.1 "
+                    f"decodes BOM-less scripts as the ANSI codepage, where these become "
+                    f"different characters -- an em-dash becomes a closing quote.",
+                )
+
+    def test_the_check_is_not_vacuous(self) -> None:
+        # If this ever passes, the check above has stopped checking.
+        self.assertNotEqual(
+            non_ascii_positions(EM_DASH_SAMPLE),
+            [],
+            "the ASCII check accepted the exact byte sequence that broke dg.ps1",
+        )


### PR DESCRIPTION
Closes #33.

`dg.ps1` could not be parsed by Windows PowerShell 5.1 — the one shell it exists to serve. An em-dash inside a double-quoted string, in a BOM-less UTF-8 file, decodes under codepage 1252 with a trailing U+201D that PowerShell treats as a closing quote.

## Changes

- `dg.ps1`, `dg` — em-dash replaced with an ASCII hyphen. `dg.bat` was already clean.
- `tests/test_wrapper_encoding.py` — byte-wise scan of all three wrappers, reporting line and column. The character is invisible in every editor that renders it correctly, so this has to be mechanical.
- `README.md` — test counts 57 → 60, 42 → 45 standalone, plus a note on why the guard exists.

## Verification

Not "it looks right":

- The fixed file parses under the real thing — `[Parser]::ParseFile` on PowerShell **5.1.26100.9168**, codepage **1252**: `PARSE OK - 212 tokens`.
- The failure reproduces from a two-line BOM-less script whose only unusual feature is an em-dash in a quoted string: `REPRODUCED: The string is missing the terminator: ".`
- `.\dg.ps1 doctor` now runs end to end — builds the image, waits on the db healthcheck, and reports every check.
- Run against the pre-fix blob, the new test flags `line 32 col 76`, which is the offending byte.
- Full suite: 60 tests, 12 skipped without `DATABASE_URL`.

## Why ASCII rather than a BOM

A BOM fixes this too. ASCII is the stronger rule: these three files bootstrap the tool before anything else exists, they are decoded by whatever codepage the host happens to use, and nothing they say needs a character outside ASCII to say it. A BOM must survive git attributes, editors and copy-paste; ASCII cannot be un-fixed.

## Note on the test

It carries a `test_the_check_is_not_vacuous` case, like #32. The Python floor guard's first version passed on the file it was written to reject, so a guard that has not been shown to fail is not yet a guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fD9iYs7DXFK8etpgp3DdH