### PR TITLE
Add an interactive menu as the default front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,24 @@ Answers are written to `.env` and read by every later command, so **you never ex
 environment variable again**. Re-run `dg init` any time; add `--reconfigure` to change the
 token or repo.
 
-### The five commands
+### Just run it
+
+Run `dg` with no command and it opens an interactive menu — a banner, a live status line
+(is the database up? is the graph empty?), and a numbered list you pick from. Nothing to
+memorise; it asks for what a command would need. On a pipe or in a script it prints help
+instead, so it never blocks waiting for input.
+
+```powershell
+.\dg.ps1
+```
+
+### The commands
+
+Every menu choice maps to one of these, so you can skip the menu once you know them.
 
 | command | what it does |
 |---|---|
+| `dg` *(no command)* | open the interactive menu |
 | `dg init` | first-time setup, and safe to repeat |
 | `dg doctor` | checks Docker, `.env`, token, rate limit, database, schema, data — and says how to fix each failure |
 | `dg ingest --repo owner/name` | pulls the last 12 months into the graph |
@@ -353,10 +367,10 @@ psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  5 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 60 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 68 checks
 ```
 
-All SQL suites run in a transaction and roll back. The Python suite runs 45 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 53 tests
 standalone. Setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 and 5 for the trace annotation. Docker adds 3 more that compile the whole package on the

--- a/README.md
+++ b/README.md
@@ -353,15 +353,19 @@ psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  5 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 57 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 60 checks
 ```
 
-All SQL suites run in a transaction and roll back. The Python suite runs 42 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 45 tests
 standalone. Setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 and 5 for the trace annotation. Docker adds 3 more that compile the whole package on the
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
+
+Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell
+5.1 decodes a BOM-less script using the system ANSI codepage, where an em-dash's last byte
+becomes a closing quote and silently truncates the string it sits in.
 
 These run on the host and still need Python. They are for working *on* the tool; using it
 needs only Docker.

--- a/README.md
+++ b/README.md
@@ -353,13 +353,15 @@ psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  5 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 54 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 57 checks
 ```
 
 All SQL suites run in a transaction and roll back. The Python suite runs 42 tests
-standalone; setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
+standalone. Setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
-and 5 for the trace annotation.
+and 5 for the trace annotation. Docker adds 3 more that compile the whole package on the
+oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
+one and otherwise nothing ever exercises the declared floor.
 
 These run on the host and still need Python. They are for working *on* the tool; using it
 needs only Docker.

--- a/dg
+++ b/dg
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# dg — macOS / Linux wrapper.
+# dg - macOS / Linux wrapper.
 #
 # Does only what must happen on the host: confirm Docker is running, build the image the
 # first time, and hand the arguments to the container. Every other decision lives in
@@ -29,7 +29,7 @@ docker info >/dev/null 2>&1 || fail \
 
 docker compose version >/dev/null 2>&1 || fail \
     "This Docker has no 'compose' subcommand." \
-    "Update Docker Desktop — Compose v2 is required."
+    "Update Docker Desktop - Compose v2 is required."
 
 # Build once. Docker caches layers, so rebuilding after a Dockerfile change is quick, but
 # doing it on every command would add seconds to every query.

--- a/dg.ps1
+++ b/dg.ps1
@@ -1,4 +1,4 @@
-# dg — PowerShell wrapper.
+# dg - PowerShell wrapper.
 #
 # Does only what must happen on the host: confirm Docker is running, build the image the
 # first time, and hand the arguments to the container. Every other decision lives in
@@ -29,7 +29,7 @@ if ($LASTEXITCODE -ne 0) {
 
 docker compose version 2>&1 | Out-Null
 if ($LASTEXITCODE -ne 0) {
-    Fail "This Docker has no 'compose' subcommand." "Update Docker Desktop — Compose v2 is required."
+    Fail "This Docker has no 'compose' subcommand." "Update Docker Desktop - Compose v2 is required."
 }
 
 # Build once. Docker caches layers, so a rebuild after a Dockerfile change is quick, but

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -354,6 +354,12 @@ def cmd_init(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+def cmd_menu(args: argparse.Namespace) -> int:
+    from . import menu
+
+    return menu.run(args)
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     heading("Environment")
     states: list[str] = []
@@ -626,6 +632,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     i.set_defaults(fn=cmd_init)
 
+    m = sub.add_parser("menu", help="interactive launcher (also shown when you run dg with no command)")
+    m.set_defaults(fn=cmd_menu)
+
     d = sub.add_parser("doctor", help="check everything is healthy and say how to fix it")
     d.set_defaults(fn=cmd_doctor)
 
@@ -657,6 +666,13 @@ def main(argv: list[str] | None = None) -> int:
     args, extra = parser.parse_known_args(argv)
 
     if not getattr(args, "command", None):
+        # A bare `dg` on a real terminal opens the interactive menu -- the front door for
+        # someone who does not yet know the commands. Piped or scripted, there is no one to
+        # answer its prompts, so fall back to help rather than block reading stdin.
+        if sys.stdin.isatty() and sys.stdout.isatty():
+            from . import menu
+
+            return menu.run(args)
         parser.print_help()
         return 0
 

--- a/src/decision_graph/menu.py
+++ b/src/decision_graph/menu.py
@@ -1,0 +1,245 @@
+"""The interactive launcher -- what `dg` shows when you run it with no command.
+
+This is a front door, not a second implementation. Every action it offers dispatches to
+the same `cmd_*` function the flag-driven CLI calls, so `dg query "..." --mode why` and
+picking "Ask why" from the menu run identical code. The menu only gathers the arguments a
+newcomer would not know to type, then hands off.
+
+It draws once, reads one choice, runs it, and loops. The status block at the top is read
+live from the database on every redraw, so it doubles as a lightweight `doctor` -- you see
+whether the graph is empty before you pick, not after.
+
+Shown only on a real terminal. Piped or scripted, `dg` with no command prints help instead,
+so nothing here can block a non-interactive caller waiting on input that will never come.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from .cli import (
+    _connect,
+    bold,
+    cmd_doctor,
+    cmd_ingest,
+    cmd_query,
+    cmd_status,
+    cyan,
+    dim,
+    explain_db_error,
+    green,
+    red,
+    yellow,
+)
+
+# Rendered once with pyfiglet's "small" font and pasted, because the container image has no
+# figlet and this must not gain a dependency just to print a header. Pure ASCII; the font
+# uses backticks and backslashes, so each line is a raw string.
+BANNER = [
+    r"    _        _    _                                _",
+    r" __| |___ __(_)__(_)___ _ _ ___ __ _ _ _ __ _ _ __| |_",
+    r"/ _` / -_) _| (_-< / _ \ ' \___/ _` | '_/ _` | '_ \ ' \ ",
+    r"\__,_\___\__|_/__/_\___/_||_|  \__, |_| \__,_| .__/_||_|",
+    r"                               |___/         |_|",
+]
+
+
+class Action:
+    """One menu row: a key, a label, a one-line hint, and what running it does."""
+
+    def __init__(self, key: str, label: str, hint: str, run) -> None:
+        self.key = key
+        self.label = label
+        self.hint = hint
+        self.run = run
+
+
+def _clear() -> None:
+    # Home the cursor and clear below it, rather than a full reset -- this keeps scrollback
+    # intact so nothing an action printed is lost when the menu redraws over it.
+    if os.environ.get("NO_COLOR") is None:
+        print("\033[H\033[J", end="")
+
+
+def _greeting() -> str:
+    # The hour comes from the database clock via now(), not the host: datetime.now() is
+    # banned across this codebase for order-independence, and the same honesty applies here
+    # -- read the wall clock from a source we control.
+    try:
+        conn = _connect()
+        hour = conn.execute("SELECT extract(hour FROM now()) AS h").fetchone()["h"]
+        conn.close()
+    except Exception:
+        return "Hello"
+    h = int(hour)
+    if h < 12:
+        return "Good morning"
+    if h < 18:
+        return "Good afternoon"
+    return "Good evening"
+
+
+def _status_block() -> None:
+    """A live preflight: repo, database, schema, and how full the graph is.
+
+    Deliberately tolerant. A brand-new user reaches this before `init` has ever run, so
+    every probe that can fail is caught and rendered as a next step, not a traceback.
+    """
+    repo = os.environ.get("TARGET_REPO", "")
+    token = os.environ.get("GITHUB_TOKEN", "")
+
+    target = bold(repo) if repo else yellow("not set")
+    print(f"  target repo   {target}")
+    if not token:
+        print(f"    {yellow('!')} no GITHUB_TOKEN -- run {bold('setup')} (menu i) before ingesting")
+
+    try:
+        conn = _connect()
+    except Exception as exc:
+        why, _ = explain_db_error(exc)
+        print(f"    {red('x')} database unreachable -- {dim(why)}")
+        return
+
+    from . import migrate
+
+    try:
+        pending = migrate.pending(conn)
+    except Exception:
+        pending = None
+
+    if pending:
+        print(f"    {yellow('!')} {len(pending)} migration(s) pending -- run {bold('setup')} (menu i)")
+    elif pending == []:
+        print(f"    {green('/')} database reachable, schema up to date")
+    else:
+        print(f"    {yellow('!')} no schema yet -- run {bold('setup')} (menu i)")
+
+    try:
+        nodes = conn.execute("SELECT count(*) AS n FROM node").fetchone()["n"]
+        decisions = conn.execute("SELECT count(*) AS n FROM decision").fetchone()["n"]
+    except Exception:
+        nodes = decisions = 0
+
+    if nodes:
+        print(
+            f"    {green('/')} graph: {bold(f'{nodes:,}')} artifacts, "
+            f"{bold(str(decisions))} decisions"
+        )
+    else:
+        hint = f" --repo {repo}" if repo else ""
+        print(f"    {yellow('!')} graph is empty -- run an {bold('ingest')} (menu 1){dim(hint)}")
+
+    conn.close()
+
+
+def _ask(prompt: str, default: str = "") -> str:
+    suffix = f" [{default}]" if default else ""
+    try:
+        raw = input(f"  {prompt}{dim(suffix)}: ").strip()
+    except EOFError:
+        return default
+    return raw or default
+
+
+# --- the actions, each a thin gatherer in front of a real cmd_* -------------------------
+
+
+def _run_init(_ns: argparse.Namespace) -> None:
+    from .cli import cmd_init
+
+    cmd_init(argparse.Namespace(reconfigure=False))
+
+
+def _run_ingest(_ns: argparse.Namespace) -> None:
+    repo = os.environ.get("TARGET_REPO", "")
+    chosen = _ask("repository to ingest (owner/name)", repo)
+    if not chosen:
+        print(yellow("  nothing to ingest -- no repository given"))
+        return
+    cmd_ingest(argparse.Namespace(repo=chosen), [])
+
+
+def _run_query(mode: str):
+    def go(_ns: argparse.Namespace) -> None:
+        subject = "changed" if mode == "why" else "you want to trace"
+        text = _ask(f"what {subject}? (a title, #number, or commit sha)")
+        if not text:
+            print(yellow("  nothing to look up"))
+            return
+        extra = ["--mode", mode]
+        if mode == "impact":
+            extra += ["--depth", _ask("depth", "2")]
+        cmd_query(argparse.Namespace(text=text), extra)
+
+    return go
+
+
+ACTIONS = [
+    Action("1", "Ingest a repository", "pull the last 12 months into the graph", _run_ingest),
+    Action("2", "Ask why", "why did a change happen?", _run_query("why")),
+    Action("3", "Trace impact", "what does a change affect, downstream?", _run_query("impact")),
+    Action("4", "Repository status", "counts, cursors, decisions", lambda ns: cmd_status(ns)),
+    Action("5", "Health check", "what works, and how to fix what does not", lambda ns: cmd_doctor(ns)),
+    Action("i", "Setup / reconfigure", "token, target repo, migrations (safe to re-run)", _run_init),
+]
+
+
+def _draw() -> None:
+    _clear()
+    print()
+    for line in BANNER:
+        print(cyan(line))
+    print()
+    print(f"  {dim('organizational intelligence engine')}")
+    print(f"  {dim('why did this change happen -- reconstructed from a repository history')}")
+    print()
+    print(
+        "  " + dim("ask why? ") + "(2)   "
+        + dim("what breaks? ") + "(3)   "
+        + dim("what is inside? ") + "(4)"
+    )
+    print()
+    print(f"  {_greeting()}.")
+    print()
+    _status_block()
+    print()
+    for a in ACTIONS:
+        print(f"  {bold(a.key)}  {a.label:<22}{dim(a.hint)}")
+    print(f"  {bold('q')}  {'Quit':<22}")
+    print()
+
+
+def run(ns: argparse.Namespace) -> int:
+    """The read-run-redraw loop. Returns an exit code when the user quits."""
+    by_key = {a.key: a for a in ACTIONS}
+    while True:
+        _draw()
+        try:
+            choice = input(f"  {cyan('>')} ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+
+        if choice in ("q", "quit", "exit"):
+            print(dim("  bye"))
+            return 0
+
+        action = by_key.get(choice)
+        if not action:
+            continue
+
+        print()
+        try:
+            action.run(ns)
+        except KeyboardInterrupt:
+            print(yellow("\n  cancelled"))
+        except Exception as exc:  # a failed action must not kill the menu
+            print(red(f"  error: {exc}"))
+
+        # Hold the action's output on screen until the user is ready; otherwise the redraw
+        # wipes it instantly.
+        try:
+            input(dim("\n  press Enter to return to the menu "))
+        except (EOFError, KeyboardInterrupt):
+            return 0

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,75 @@
+"""The interactive menu, exercised without a database or a terminal.
+
+These are unit checks over the parts that do not touch Postgres: the banner stays ASCII
+(the wrappers taught us what a stray non-ASCII byte costs), the action table is well-formed,
+and the loop actually exits on `q` and on end-of-input rather than spinning. The DB-backed
+status block and the real query dispatch are covered live, not here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from decision_graph import menu
+
+
+class BannerTest(unittest.TestCase):
+    def test_banner_is_pure_ascii(self) -> None:
+        for i, line in enumerate(menu.BANNER):
+            offenders = [(c, ord(c)) for c in line if ord(c) > 0x7F]
+            self.assertEqual(offenders, [], f"banner line {i} has non-ASCII: {offenders}")
+
+
+class ActionTableTest(unittest.TestCase):
+    def test_keys_are_unique(self) -> None:
+        keys = [a.key for a in menu.ACTIONS]
+        self.assertEqual(len(keys), len(set(keys)), f"duplicate menu keys: {keys}")
+
+    def test_every_action_is_callable(self) -> None:
+        for a in menu.ACTIONS:
+            self.assertTrue(callable(a.run), f"action {a.key} is not runnable")
+
+    def test_query_actions_are_present(self) -> None:
+        # The two questions the tool answers must both have a door.
+        labels = {a.label for a in menu.ACTIONS}
+        self.assertIn("Ask why", labels)
+        self.assertIn("Trace impact", labels)
+
+
+class LoopTest(unittest.TestCase):
+    def _run_with_input(self, lines: list[str]) -> int:
+        # Draw is stubbed so the loop never touches the database; input is scripted.
+        with mock.patch.object(menu, "_draw", lambda: None), mock.patch(
+            "builtins.input", side_effect=lines
+        ), redirect_stdout(io.StringIO()):
+            return menu.run(argparse.Namespace())
+
+    def test_q_quits(self) -> None:
+        self.assertEqual(self._run_with_input(["q"]), 0)
+
+    def test_eof_quits(self) -> None:
+        # A closed stdin must end the loop, not raise -- otherwise a piped invocation spins.
+        with mock.patch.object(menu, "_draw", lambda: None), mock.patch(
+            "builtins.input", side_effect=EOFError
+        ), redirect_stdout(io.StringIO()):
+            self.assertEqual(menu.run(argparse.Namespace()), 0)
+
+    def test_unknown_choice_redraws_without_running_anything(self) -> None:
+        # "zzz" matches no action, then "q" exits. It must not dispatch or crash.
+        self.assertEqual(self._run_with_input(["zzz", "q"]), 0)
+
+    def test_a_failing_action_does_not_kill_the_loop(self) -> None:
+        boom = menu.Action("9", "Boom", "raises", lambda ns: (_ for _ in ()).throw(RuntimeError("boom")))
+        with mock.patch.object(menu, "ACTIONS", [boom]), mock.patch.object(
+            menu, "_draw", lambda: None
+        ), mock.patch("builtins.input", side_effect=["9", "", "q"]), redirect_stdout(io.StringIO()):
+            # rebuild the key map inside run() picks up the patched ACTIONS
+            self.assertEqual(menu.run(argparse.Namespace()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_python_floor.py
+++ b/tests/test_python_floor.py
@@ -1,0 +1,107 @@
+"""Every source file must compile on the oldest Python the package claims to support.
+
+`dg status` shipped with a nested f-string reusing the same quote character inside its
+expression — legal only under PEP 701, so Python 3.12 and later. `pyproject.toml` declares
+`requires-python = ">=3.11"`, but the Dockerfile pins `python:3.13-slim`, so every
+containerised command parsed it happily. The declared floor and the exercised floor were
+different numbers, and the only way to find out was to run the package outside the
+container on 3.11.
+
+**`ast.parse(..., feature_version=(3, 11))` does not catch this.** That was the first
+attempt at this guard, and it passed on the broken file: `feature_version` gates a short
+list of grammar features and does not restore the pre-3.12 f-string tokenizer. A check that
+cannot fail is worse than no check, because it reports success — so this runs a genuine
+interpreter at the declared floor instead, and `test_the_check_is_not_vacuous` proves the
+mechanism still rejects the exact syntax that shipped.
+
+Requires Docker; skipped without it, since the containerised `dg` already needs Docker and
+the host is not assumed to have a 3.11 interpreter lying around.
+"""
+
+from __future__ import annotations
+
+import re
+import shutil
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# The shape that shipped: an f-string nested in another f-string's expression, reusing the
+# same quote character.
+PEP701_ONLY = """value = f"{bold(r['name'])}  {dim(f'{r['nodes']:,} artifacts')}"\n"""
+
+
+def declared_floor() -> tuple[int, int]:
+    """The minimum Python version from pyproject.toml's requires-python.
+
+    Read rather than hardcoded: raising `requires-python` later would otherwise leave this
+    guard quietly checking a version nobody supports any more.
+    """
+    text = (ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    match = re.search(r'requires-python\s*=\s*"[^"]*?(\d+)\.(\d+)', text)
+    if not match:
+        raise AssertionError("could not read requires-python from pyproject.toml")
+    return int(match.group(1)), int(match.group(2))
+
+
+def _docker_available() -> bool:
+    if not shutil.which("docker"):
+        return False
+    return subprocess.run(
+        ["docker", "info"], capture_output=True, timeout=60
+    ).returncode == 0
+
+
+def compile_under_floor(directory: Path, targets: list[str]) -> subprocess.CompletedProcess:
+    major, minor = declared_floor()
+    return subprocess.run(
+        [
+            "docker", "run", "--rm",
+            "-v", f"{directory}:/w",
+            "-w", "/w",
+            f"python:{major}.{minor}-slim",
+            "python", "-m", "compileall", "-q", *targets,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=600,
+    )
+
+
+@unittest.skipUnless(_docker_available(), "Docker not available")
+class PythonFloorTest(unittest.TestCase):
+    def test_pyproject_declares_a_floor(self) -> None:
+        major, minor = declared_floor()
+        self.assertEqual(major, 3)
+        self.assertGreaterEqual(minor, 8)
+
+    def test_package_compiles_at_the_declared_floor(self) -> None:
+        result = compile_under_floor(ROOT, ["src", "tests", "eval"])
+        floor = declared_floor()
+        self.assertEqual(
+            result.returncode,
+            0,
+            f"source does not compile on Python {floor[0]}.{floor[1]}, which "
+            f"pyproject.toml claims to support:\n{result.stdout}{result.stderr}",
+        )
+
+    def test_the_check_is_not_vacuous(self) -> None:
+        # If this ever passes, the guard above has stopped guarding — which is exactly how
+        # the first version of this test failed silently.
+        with tempfile.TemporaryDirectory() as tmp:
+            bad = Path(tmp) / "pep701_sample.py"
+            bad.write_text(PEP701_ONLY, encoding="utf-8")
+            result = compile_under_floor(Path(tmp), ["pep701_sample.py"])
+        self.assertNotEqual(
+            result.returncode,
+            0,
+            "the floor check accepted syntax that is invalid at the declared floor",
+        )
+        self.assertIn("SyntaxError", result.stdout + result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wrapper_encoding.py
+++ b/tests/test_wrapper_encoding.py
@@ -1,0 +1,75 @@
+"""The shell wrappers must be pure ASCII.
+
+`dg.ps1` shipped with an em-dash inside a double-quoted string. The file is UTF-8 without
+a BOM, and Windows PowerShell 5.1 decodes BOM-less scripts using the system ANSI codepage
+-- 1252 on a default Windows install. There, the three UTF-8 bytes of an em-dash decode as
+`a~EUR"`, and that final byte is U+201D RIGHT DOUBLE QUOTATION MARK, which PowerShell
+accepts as a string terminator. The string ended early, quote balance broke, and the
+parser reported `The string is missing the terminator: "` ten lines further down.
+
+A BOM would also fix it. ASCII is the stronger rule: these three files bootstrap the tool
+before anything else exists, they are read by whatever codepage the host happens to use,
+and nothing they say needs a character outside ASCII to say it. A BOM has to survive git
+attributes, editors and copy-paste; ASCII cannot be un-fixed.
+
+This is checked rather than remembered because the character is invisible in every editor
+that renders it correctly, which is all of them.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+
+# Every file executed by a host shell before the container exists.
+WRAPPERS = ("dg.ps1", "dg.bat", "dg")
+
+# The exact byte sequence that shipped: U+2014 inside a double-quoted PowerShell string.
+EM_DASH_SAMPLE = b'Fail "Update Docker Desktop \xe2\x80\x94 Compose v2 is required."\r\n'
+
+
+def non_ascii_positions(data: bytes) -> list[tuple[int, int, int]]:
+    """(line, column, byte) for every byte outside ASCII. Byte-wise, not decoded, because
+    the whole failure is that the host decodes these bytes differently than we intend."""
+    found = []
+    line = column = 1
+    for byte in data:
+        if byte > 0x7F:
+            found.append((line, column, byte))
+        if byte == 0x0A:
+            line += 1
+            column = 1
+        else:
+            column += 1
+    return found
+
+
+class WrapperEncodingTest(unittest.TestCase):
+    def test_wrappers_exist(self) -> None:
+        for name in WRAPPERS:
+            self.assertTrue((ROOT / name).is_file(), f"{name} is missing")
+
+    def test_wrappers_are_pure_ascii(self) -> None:
+        for name in WRAPPERS:
+            with self.subTest(wrapper=name):
+                offenders = non_ascii_positions((ROOT / name).read_bytes())
+                detail = ", ".join(
+                    f"line {ln} col {col}: 0x{b:02X}" for ln, col, b in offenders[:5]
+                )
+                self.assertEqual(
+                    offenders,
+                    [],
+                    f"{name} contains non-ASCII bytes ({detail}). Windows PowerShell 5.1 "
+                    f"decodes BOM-less scripts as the ANSI codepage, where these become "
+                    f"different characters -- an em-dash becomes a closing quote.",
+                )
+
+    def test_the_check_is_not_vacuous(self) -> None:
+        # If this ever passes, the check above has stopped checking.
+        self.assertNotEqual(
+            non_ascii_positions(EM_DASH_SAMPLE),
+            [],
+            "the ASCII check accepted the exact byte sequence that broke dg.ps1",
+        )


### PR DESCRIPTION
Closes #35. **Stacked on #34** — based on `fix/ascii-only-wrappers`, because the menu is pointless while `dg.ps1` itself won't parse. Merge #34 first and GitHub retargets this to `main` automatically.

## What changed

Running `dg` with no command used to print an argparse help dump. Now, on a terminal, it opens a guided launcher:

```
    _        _    _                                _
 __| |___ __(_)__(_)___ _ _ ___ __ _ _ _ __ _ _ __| |_
/ _` / -_) _| (_-< / _ \ ' \___/ _` | '_/ _` | '_ \ ' \
\__,_\___\__|_/__/_\___/_||_|  \__, |_| \__,_| .__/_||_|
                               |___/         |_|

  organizational intelligence engine
  why did this change happen -- reconstructed from a repository history

  ask why? (2)   what breaks? (3)   what is inside? (4)

  Good afternoon.

  target repo   pallets/flask
    / database reachable, schema up to date
    / graph: 958 artifacts, 13 decisions

  1  Ingest a repository   pull the last 12 months into the graph
  2  Ask why               why did a change happen?
  3  Trace impact          what does a change affect, downstream?
  4  Repository status     counts, cursors, decisions
  5  Health check          what works, and how to fix what does not
  i  Setup / reconfigure   token, target repo, migrations (safe to re-run)
  q  Quit

  >
```

## Design

- **A front door, not a second implementation.** Every menu action dispatches to the existing `cmd_*` function. Menu and flags run identical code; the menu only gathers the argument a newcomer wouldn't know to type.
- **Live status block.** Read from the database on every redraw, so you see whether the graph is empty *before* you pick. Doubles as a lightweight doctor; every failing probe renders as a next step, not a traceback, because a new user reaches this before `init`.
- **Never blocks a script.** Shown only when stdin and stdout are both TTYs. Piped or scripted, a bare `dg` still prints help. Verified: `echo "" | dg` prints usage.
- **No new dependency, pure ASCII.** Banner pre-rendered and pasted; the image has no figlet, and #33 established what a stray non-ASCII byte costs in a bootstrap path.

## Verification

- Live through Docker against the real graph: the health-check action, and an "Ask why" query on *"change default redirect code to 303"* returning its real motivated_by / implemented_by trace.
- `echo "" | dg` → help, no hang.
- `dg --help` lists `menu`.
- Suite: 68 tests (was 60), 12 skipped without `DATABASE_URL`. New `tests/test_menu.py` covers banner ASCII, the action table, and loop exit on `q` / EOF / unknown choice / a failing action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fD9iYs7DXFK8etpgp3DdH