### PR TITLE
Add an interactive menu as the default front door

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,10 +39,24 @@ Answers are written to `.env` and read by every later command, so **you never ex
 environment variable again**. Re-run `dg init` any time; add `--reconfigure` to change the
 token or repo.
 
-### The five commands
+### Just run it
+
+Run `dg` with no command and it opens an interactive menu — a banner, a live status line
+(is the database up? is the graph empty?), and a numbered list you pick from. Nothing to
+memorise; it asks for what a command would need. On a pipe or in a script it prints help
+instead, so it never blocks waiting for input.
+
+```powershell
+.\dg.ps1
+```
+
+### The commands
+
+Every menu choice maps to one of these, so you can skip the menu once you know them.
 
 | command | what it does |
 |---|---|
+| `dg` *(no command)* | open the interactive menu |
 | `dg init` | first-time setup, and safe to repeat |
 | `dg doctor` | checks Docker, `.env`, token, rate limit, database, schema, data — and says how to fix each failure |
 | `dg ingest --repo owner/name` | pulls the last 12 months into the graph |
@@ -353,10 +367,10 @@ psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  5 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 60 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 68 checks
 ```
 
-All SQL suites run in a transaction and roll back. The Python suite runs 45 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 53 tests
 standalone. Setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 and 5 for the trace annotation. Docker adds 3 more that compile the whole package on the

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -354,6 +354,12 @@ def cmd_init(args: argparse.Namespace) -> int:
 # ---------------------------------------------------------------------------
 
 
+def cmd_menu(args: argparse.Namespace) -> int:
+    from . import menu
+
+    return menu.run(args)
+
+
 def cmd_doctor(args: argparse.Namespace) -> int:
     heading("Environment")
     states: list[str] = []
@@ -626,6 +632,9 @@ def build_parser() -> argparse.ArgumentParser:
     )
     i.set_defaults(fn=cmd_init)
 
+    m = sub.add_parser("menu", help="interactive launcher (also shown when you run dg with no command)")
+    m.set_defaults(fn=cmd_menu)
+
     d = sub.add_parser("doctor", help="check everything is healthy and say how to fix it")
     d.set_defaults(fn=cmd_doctor)
 
@@ -657,6 +666,13 @@ def main(argv: list[str] | None = None) -> int:
     args, extra = parser.parse_known_args(argv)
 
     if not getattr(args, "command", None):
+        # A bare `dg` on a real terminal opens the interactive menu -- the front door for
+        # someone who does not yet know the commands. Piped or scripted, there is no one to
+        # answer its prompts, so fall back to help rather than block reading stdin.
+        if sys.stdin.isatty() and sys.stdout.isatty():
+            from . import menu
+
+            return menu.run(args)
         parser.print_help()
         return 0
 

--- a/src/decision_graph/menu.py
+++ b/src/decision_graph/menu.py
@@ -1,0 +1,245 @@
+"""The interactive launcher -- what `dg` shows when you run it with no command.
+
+This is a front door, not a second implementation. Every action it offers dispatches to
+the same `cmd_*` function the flag-driven CLI calls, so `dg query "..." --mode why` and
+picking "Ask why" from the menu run identical code. The menu only gathers the arguments a
+newcomer would not know to type, then hands off.
+
+It draws once, reads one choice, runs it, and loops. The status block at the top is read
+live from the database on every redraw, so it doubles as a lightweight `doctor` -- you see
+whether the graph is empty before you pick, not after.
+
+Shown only on a real terminal. Piped or scripted, `dg` with no command prints help instead,
+so nothing here can block a non-interactive caller waiting on input that will never come.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+
+from .cli import (
+    _connect,
+    bold,
+    cmd_doctor,
+    cmd_ingest,
+    cmd_query,
+    cmd_status,
+    cyan,
+    dim,
+    explain_db_error,
+    green,
+    red,
+    yellow,
+)
+
+# Rendered once with pyfiglet's "small" font and pasted, because the container image has no
+# figlet and this must not gain a dependency just to print a header. Pure ASCII; the font
+# uses backticks and backslashes, so each line is a raw string.
+BANNER = [
+    r"    _        _    _                                _",
+    r" __| |___ __(_)__(_)___ _ _ ___ __ _ _ _ __ _ _ __| |_",
+    r"/ _` / -_) _| (_-< / _ \ ' \___/ _` | '_/ _` | '_ \ ' \ ",
+    r"\__,_\___\__|_/__/_\___/_||_|  \__, |_| \__,_| .__/_||_|",
+    r"                               |___/         |_|",
+]
+
+
+class Action:
+    """One menu row: a key, a label, a one-line hint, and what running it does."""
+
+    def __init__(self, key: str, label: str, hint: str, run) -> None:
+        self.key = key
+        self.label = label
+        self.hint = hint
+        self.run = run
+
+
+def _clear() -> None:
+    # Home the cursor and clear below it, rather than a full reset -- this keeps scrollback
+    # intact so nothing an action printed is lost when the menu redraws over it.
+    if os.environ.get("NO_COLOR") is None:
+        print("\033[H\033[J", end="")
+
+
+def _greeting() -> str:
+    # The hour comes from the database clock via now(), not the host: datetime.now() is
+    # banned across this codebase for order-independence, and the same honesty applies here
+    # -- read the wall clock from a source we control.
+    try:
+        conn = _connect()
+        hour = conn.execute("SELECT extract(hour FROM now()) AS h").fetchone()["h"]
+        conn.close()
+    except Exception:
+        return "Hello"
+    h = int(hour)
+    if h < 12:
+        return "Good morning"
+    if h < 18:
+        return "Good afternoon"
+    return "Good evening"
+
+
+def _status_block() -> None:
+    """A live preflight: repo, database, schema, and how full the graph is.
+
+    Deliberately tolerant. A brand-new user reaches this before `init` has ever run, so
+    every probe that can fail is caught and rendered as a next step, not a traceback.
+    """
+    repo = os.environ.get("TARGET_REPO", "")
+    token = os.environ.get("GITHUB_TOKEN", "")
+
+    target = bold(repo) if repo else yellow("not set")
+    print(f"  target repo   {target}")
+    if not token:
+        print(f"    {yellow('!')} no GITHUB_TOKEN -- run {bold('setup')} (menu i) before ingesting")
+
+    try:
+        conn = _connect()
+    except Exception as exc:
+        why, _ = explain_db_error(exc)
+        print(f"    {red('x')} database unreachable -- {dim(why)}")
+        return
+
+    from . import migrate
+
+    try:
+        pending = migrate.pending(conn)
+    except Exception:
+        pending = None
+
+    if pending:
+        print(f"    {yellow('!')} {len(pending)} migration(s) pending -- run {bold('setup')} (menu i)")
+    elif pending == []:
+        print(f"    {green('/')} database reachable, schema up to date")
+    else:
+        print(f"    {yellow('!')} no schema yet -- run {bold('setup')} (menu i)")
+
+    try:
+        nodes = conn.execute("SELECT count(*) AS n FROM node").fetchone()["n"]
+        decisions = conn.execute("SELECT count(*) AS n FROM decision").fetchone()["n"]
+    except Exception:
+        nodes = decisions = 0
+
+    if nodes:
+        print(
+            f"    {green('/')} graph: {bold(f'{nodes:,}')} artifacts, "
+            f"{bold(str(decisions))} decisions"
+        )
+    else:
+        hint = f" --repo {repo}" if repo else ""
+        print(f"    {yellow('!')} graph is empty -- run an {bold('ingest')} (menu 1){dim(hint)}")
+
+    conn.close()
+
+
+def _ask(prompt: str, default: str = "") -> str:
+    suffix = f" [{default}]" if default else ""
+    try:
+        raw = input(f"  {prompt}{dim(suffix)}: ").strip()
+    except EOFError:
+        return default
+    return raw or default
+
+
+# --- the actions, each a thin gatherer in front of a real cmd_* -------------------------
+
+
+def _run_init(_ns: argparse.Namespace) -> None:
+    from .cli import cmd_init
+
+    cmd_init(argparse.Namespace(reconfigure=False))
+
+
+def _run_ingest(_ns: argparse.Namespace) -> None:
+    repo = os.environ.get("TARGET_REPO", "")
+    chosen = _ask("repository to ingest (owner/name)", repo)
+    if not chosen:
+        print(yellow("  nothing to ingest -- no repository given"))
+        return
+    cmd_ingest(argparse.Namespace(repo=chosen), [])
+
+
+def _run_query(mode: str):
+    def go(_ns: argparse.Namespace) -> None:
+        subject = "changed" if mode == "why" else "you want to trace"
+        text = _ask(f"what {subject}? (a title, #number, or commit sha)")
+        if not text:
+            print(yellow("  nothing to look up"))
+            return
+        extra = ["--mode", mode]
+        if mode == "impact":
+            extra += ["--depth", _ask("depth", "2")]
+        cmd_query(argparse.Namespace(text=text), extra)
+
+    return go
+
+
+ACTIONS = [
+    Action("1", "Ingest a repository", "pull the last 12 months into the graph", _run_ingest),
+    Action("2", "Ask why", "why did a change happen?", _run_query("why")),
+    Action("3", "Trace impact", "what does a change affect, downstream?", _run_query("impact")),
+    Action("4", "Repository status", "counts, cursors, decisions", lambda ns: cmd_status(ns)),
+    Action("5", "Health check", "what works, and how to fix what does not", lambda ns: cmd_doctor(ns)),
+    Action("i", "Setup / reconfigure", "token, target repo, migrations (safe to re-run)", _run_init),
+]
+
+
+def _draw() -> None:
+    _clear()
+    print()
+    for line in BANNER:
+        print(cyan(line))
+    print()
+    print(f"  {dim('organizational intelligence engine')}")
+    print(f"  {dim('why did this change happen -- reconstructed from a repository history')}")
+    print()
+    print(
+        "  " + dim("ask why? ") + "(2)   "
+        + dim("what breaks? ") + "(3)   "
+        + dim("what is inside? ") + "(4)"
+    )
+    print()
+    print(f"  {_greeting()}.")
+    print()
+    _status_block()
+    print()
+    for a in ACTIONS:
+        print(f"  {bold(a.key)}  {a.label:<22}{dim(a.hint)}")
+    print(f"  {bold('q')}  {'Quit':<22}")
+    print()
+
+
+def run(ns: argparse.Namespace) -> int:
+    """The read-run-redraw loop. Returns an exit code when the user quits."""
+    by_key = {a.key: a for a in ACTIONS}
+    while True:
+        _draw()
+        try:
+            choice = input(f"  {cyan('>')} ").strip().lower()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            return 0
+
+        if choice in ("q", "quit", "exit"):
+            print(dim("  bye"))
+            return 0
+
+        action = by_key.get(choice)
+        if not action:
+            continue
+
+        print()
+        try:
+            action.run(ns)
+        except KeyboardInterrupt:
+            print(yellow("\n  cancelled"))
+        except Exception as exc:  # a failed action must not kill the menu
+            print(red(f"  error: {exc}"))
+
+        # Hold the action's output on screen until the user is ready; otherwise the redraw
+        # wipes it instantly.
+        try:
+            input(dim("\n  press Enter to return to the menu "))
+        except (EOFError, KeyboardInterrupt):
+            return 0

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -1,0 +1,75 @@
+"""The interactive menu, exercised without a database or a terminal.
+
+These are unit checks over the parts that do not touch Postgres: the banner stays ASCII
+(the wrappers taught us what a stray non-ASCII byte costs), the action table is well-formed,
+and the loop actually exits on `q` and on end-of-input rather than spinning. The DB-backed
+status block and the real query dispatch are covered live, not here.
+"""
+
+from __future__ import annotations
+
+import argparse
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest import mock
+
+from decision_graph import menu
+
+
+class BannerTest(unittest.TestCase):
+    def test_banner_is_pure_ascii(self) -> None:
+        for i, line in enumerate(menu.BANNER):
+            offenders = [(c, ord(c)) for c in line if ord(c) > 0x7F]
+            self.assertEqual(offenders, [], f"banner line {i} has non-ASCII: {offenders}")
+
+
+class ActionTableTest(unittest.TestCase):
+    def test_keys_are_unique(self) -> None:
+        keys = [a.key for a in menu.ACTIONS]
+        self.assertEqual(len(keys), len(set(keys)), f"duplicate menu keys: {keys}")
+
+    def test_every_action_is_callable(self) -> None:
+        for a in menu.ACTIONS:
+            self.assertTrue(callable(a.run), f"action {a.key} is not runnable")
+
+    def test_query_actions_are_present(self) -> None:
+        # The two questions the tool answers must both have a door.
+        labels = {a.label for a in menu.ACTIONS}
+        self.assertIn("Ask why", labels)
+        self.assertIn("Trace impact", labels)
+
+
+class LoopTest(unittest.TestCase):
+    def _run_with_input(self, lines: list[str]) -> int:
+        # Draw is stubbed so the loop never touches the database; input is scripted.
+        with mock.patch.object(menu, "_draw", lambda: None), mock.patch(
+            "builtins.input", side_effect=lines
+        ), redirect_stdout(io.StringIO()):
+            return menu.run(argparse.Namespace())
+
+    def test_q_quits(self) -> None:
+        self.assertEqual(self._run_with_input(["q"]), 0)
+
+    def test_eof_quits(self) -> None:
+        # A closed stdin must end the loop, not raise -- otherwise a piped invocation spins.
+        with mock.patch.object(menu, "_draw", lambda: None), mock.patch(
+            "builtins.input", side_effect=EOFError
+        ), redirect_stdout(io.StringIO()):
+            self.assertEqual(menu.run(argparse.Namespace()), 0)
+
+    def test_unknown_choice_redraws_without_running_anything(self) -> None:
+        # "zzz" matches no action, then "q" exits. It must not dispatch or crash.
+        self.assertEqual(self._run_with_input(["zzz", "q"]), 0)
+
+    def test_a_failing_action_does_not_kill_the_loop(self) -> None:
+        boom = menu.Action("9", "Boom", "raises", lambda ns: (_ for _ in ()).throw(RuntimeError("boom")))
+        with mock.patch.object(menu, "ACTIONS", [boom]), mock.patch.object(
+            menu, "_draw", lambda: None
+        ), mock.patch("builtins.input", side_effect=["9", "", "q"]), redirect_stdout(io.StringIO()):
+            # rebuild the key map inside run() picks up the patched ACTIONS
+            self.assertEqual(menu.run(argparse.Namespace()), 0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #35. (Supersedes #36, which auto-closed when its stacked base branch `fix/ascii-only-wrappers` was deleted on merge of #34. Rebased onto `main`; same commit, now a clean single-commit diff.)

## What changed

Running `dg` with no command used to print an argparse help dump. Now, on a terminal, it opens a guided launcher:

```
    _        _    _                                _
 __| |___ __(_)__(_)___ _ _ ___ __ _ _ _ __ _ _ __| |_
/ _` / -_) _| (_-< / _ \ ' \___/ _` | '_/ _` | '_ \ ' \
\__,_\___\__|_/__/_\___/_||_|  \__, |_| \__,_| .__/_||_|
                               |___/         |_|

  organizational intelligence engine
  why did this change happen -- reconstructed from a repository history

  ask why? (2)   what breaks? (3)   what is inside? (4)

  Good afternoon.

  target repo   pallets/flask
    / database reachable, schema up to date
    / graph: 958 artifacts, 13 decisions

  1  Ingest a repository   pull the last 12 months into the graph
  2  Ask why               why did a change happen?
  3  Trace impact          what does a change affect, downstream?
  4  Repository status     counts, cursors, decisions
  5  Health check          what works, and how to fix what does not
  i  Setup / reconfigure   token, target repo, migrations (safe to re-run)
  q  Quit

  >
```

Pick a number, it asks only for what that command needs, runs it, holds the output, and redraws.

## Design

- **A front door, not a second implementation.** Every menu action dispatches to the existing `cmd_*` function; menu and flags run identical code.
- **Live status block**, read from the database on every redraw — you see whether the graph is empty before you pick. Doubles as a lightweight doctor; every failing probe renders as a next step, because a new user reaches this before `init`.
- **Never blocks a script.** Shown only when stdin and stdout are both TTYs; piped or scripted, bare `dg` still prints help. Verified `echo "" | dg` → usage, no hang.
- **No new dependency, pure ASCII.** Banner pre-rendered and pasted; the image has no figlet, and #33 established what a stray non-ASCII byte costs in a bootstrap path.

## Verification

- Live through Docker against the real graph: the health-check action, and an "Ask why" query returning its real motivated_by / implemented_by trace.
- `dg --help` lists `menu`; `echo "" | dg` prints help.
- Suite: 68 tests (was 60), 12 skipped without `DATABASE_URL`. New `tests/test_menu.py` covers banner ASCII, the action table, and loop exit on `q` / EOF / unknown choice / a failing action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017fD9iYs7DXFK8etpgp3DdH