### PR TITLE
Add dg ask: a natural-language Q&A layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -16,3 +16,6 @@ BACKFILL_MONTHS=12
 # NOTE: DATABASE_URL is deliberately NOT here. The database lives at a fixed address on
 # the Docker network and docker-compose.yml injects it. Setting it in this file has no
 # effect.
+
+# Required for the NLP Explanation Layer using Nvidia NIM.
+NVIDIA_API_KEY=

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
 # Dependencies are baked into the image; the source is bind-mounted at /work. That split
 # is deliberate — deps change rarely, so the layer stays cached, while editing the code
 # takes effect immediately with no rebuild.
-RUN pip install --no-cache-dir "psycopg[binary]>=3.1" "httpx>=0.27"
+RUN pip install --no-cache-dir "psycopg[binary]>=3.1" "httpx>=0.27" "openai>=1.0"
 
 ENV PYTHONPATH=/work/src \
     PYTHONUNBUFFERED=1 \

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -615,6 +615,40 @@ def cmd_query(args: argparse.Namespace, extra: list[str]) -> int:
     return query.main([args.text] + list(extra))
 
 
+def cmd_ask(args: argparse.Namespace, extra: list[str]) -> int:
+    from . import explain, db, retrieval, reasoning
+
+    print(f"Parsing intent for: {args.question!r}")
+    query_str, mode = explain.parse_intent(args.question)
+    print(f"-> Parsed intent: Search for {query_str!r}, Mode: {mode}\n")
+
+    dsn = os.environ.get("DATABASE_URL")
+    if not dsn:
+        print("error: DATABASE_URL is not set", file=sys.stderr)
+        return 2
+
+    conn = db.connect(dsn)
+    candidates = retrieval.find_candidates(conn, query_str, limit=1)
+    if not candidates:
+        print(f"No match found for extracted search term {query_str!r}.", file=sys.stderr)
+        return 1
+
+    c = candidates[0]
+    print(f"Found candidate: node:{c.node_id} {c.node_type} \"{c.title[:56]}\"\n")
+    print("Traversing the graph...")
+    answer = reasoning.reason(conn, c.node_id, reasoning.Mode(mode))
+
+    print("Generating explanation...\n")
+    explanation = explain.summarize_answer(args.question, answer)
+
+    print("-" * 40)
+    print(explanation)
+    print("-" * 40)
+
+    conn.close()
+    return 0
+
+
 # ---------------------------------------------------------------------------
 
 
@@ -656,6 +690,10 @@ def build_parser() -> argparse.ArgumentParser:
     )
     q.add_argument("text", help="a title, #number, or commit sha")
     q.set_defaults(fn=cmd_query, passthrough=True)
+
+    a = sub.add_parser("ask", help="ask a natural language question about the repository")
+    a.add_argument("question", help="e.g. 'Why did we change the default redirect code?'")
+    a.set_defaults(fn=cmd_ask, passthrough=True)
 
     return p
 

--- a/src/decision_graph/explain.py
+++ b/src/decision_graph/explain.py
@@ -1,0 +1,108 @@
+"""NLP Layer for the Organizational Intelligence Engine.
+
+Provides an LLM-based interface to translate natural language questions into
+graph queries, and summarize the resulting paths into human-readable explanations.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+from .reasoning import Answer
+
+# We import OpenAI inside functions so that if the API key is not configured,
+# or the dependency isn't installed for some reason, the rest of the CLI still boots.
+
+MODEL = "meta/llama-3.1-70b-instruct"
+
+def get_client():
+    try:
+        from openai import OpenAI
+    except ImportError:
+        print("error: the 'openai' python package is missing. Rebuild the docker image.", file=sys.stderr)
+        sys.exit(2)
+
+    api_key = os.environ.get("NVIDIA_API_KEY")
+    if not api_key:
+        print("error: NVIDIA_API_KEY is not set in .env", file=sys.stderr)
+        sys.exit(2)
+        
+    return OpenAI(
+        base_url="https://integrate.api.nvidia.com/v1",
+        api_key=api_key
+    )
+
+def parse_intent(question: str) -> tuple[str, str]:
+    """Parse a natural language question into a search query and mode ('why' or 'impact')."""
+    client = get_client()
+    
+    prompt = f"""You are a query parser for a GitHub repository decision graph.
+The user will ask a natural language question about the codebase.
+Your job is to extract:
+1. The exact search entity: A title, pull request number (e.g. #123), or commit sha.
+2. The mode: 'why' (if asking for motivation/reason) or 'impact' (if asking what it affects/breaks downstream).
+
+Output valid JSON ONLY in this format:
+{{"query": "extract search term", "mode": "why" or "impact"}}
+
+User question: {question}
+"""
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.0,
+        response_format={"type": "json_object"}
+    )
+    
+    result = json.loads(response.choices[0].message.content)
+    return result.get("query", ""), result.get("mode", "why")
+
+def summarize_answer(question: str, answer: Answer) -> str:
+    """Take the raw paths and summarize them for the user."""
+    client = get_client()
+    
+    # We serialize the Answer into a clean textual format for the LLM
+    text_paths = []
+    for i, path in enumerate(answer.paths, 1):
+        lines = []
+        lines.append(f"Path {i} (tier={path.tier}, depth={path.depth}):")
+        
+        # start node
+        start_id = path.node_ids[0]
+        start_type = path.types.get(start_id, "?")
+        start_title = path.titles.get(start_id, "")
+        lines.append(f"  Start: {start_type}:{start_id} \"{start_title}\"")
+        
+        for step, node_id in zip(path.steps, path.node_ids[1:]):
+            direction = "->" if step.to_node_id == node_id else "<-"
+            lines.append(f"    {direction} {step.edge_type} ({step.extractor})")
+            
+            node_type = path.types.get(node_id, "?")
+            node_title = path.titles.get(node_id, "")
+            lines.append(f"    Node: {node_type}:{node_id} \"{node_title}\"")
+        
+        text_paths.append("\n".join(lines))
+        
+    paths_str = "\n\n".join(text_paths)
+    
+    prompt = f"""You are an Organizational Intelligence Engine explaining a decision graph to an engineer.
+The user asked: "{question}"
+
+Here are the raw graph traversal paths found in the database:
+{paths_str if paths_str else 'NO PATHS FOUND'}
+
+Task: 
+Explain the result of this query clearly and concisely in plain English. 
+- Do not just read the paths back mechanically. Synthesize them.
+- If multiple paths lead to the same decision, group them.
+- State clearly what motivated the change, or what the change impacts.
+- If NO PATHS FOUND, politely state that the graph does not contain the answer.
+"""
+    
+    response = client.chat.completions.create(
+        model=MODEL,
+        messages=[{"role": "user", "content": prompt}],
+        temperature=0.2,
+    )
+    return response.choices[0].message.content

--- a/src/decision_graph/menu.py
+++ b/src/decision_graph/menu.py
@@ -175,12 +175,23 @@ def _run_query(mode: str):
     return go
 
 
+def _run_ask(_ns: argparse.Namespace) -> None:
+    from .cli import cmd_ask
+
+    question = _ask("what do you want to ask? (e.g. 'Why did we change the redirect code?')")
+    if not question:
+        print(yellow("  nothing to ask"))
+        return
+    cmd_ask(argparse.Namespace(question=question), [])
+
+
 ACTIONS = [
     Action("1", "Ingest a repository", "pull the last 12 months into the graph", _run_ingest),
     Action("2", "Ask why", "why did a change happen?", _run_query("why")),
     Action("3", "Trace impact", "what does a change affect, downstream?", _run_query("impact")),
     Action("4", "Repository status", "counts, cursors, decisions", lambda ns: cmd_status(ns)),
     Action("5", "Health check", "what works, and how to fix what does not", lambda ns: cmd_doctor(ns)),
+    Action("6", "Natural Language Q&A", "ask a question in plain English (requires Nvidia API key)", _run_ask),
     Action("i", "Setup / reconfigure", "token, target repo, migrations (safe to re-run)", _run_init),
 ]
 


### PR DESCRIPTION
Closes #38.

## Summary
- New `src/decision_graph/explain.py`: `parse_intent()` turns a free-form question into a
  search term + mode via an LLM (NVIDIA NIM, OpenAI-compatible endpoint); `summarize_answer()`
  turns the resulting `Answer` paths back into plain English.
- `cli.py`: new `dg ask "<question>"` subcommand wired to the existing
  `retrieval.find_candidates` / `reasoning.reason` pipeline — no change to graph semantics.
- `menu.py`: new interactive entry ("Natural Language Q&A").
- `Dockerfile` / `.env.example`: `openai>=1.0` dependency, `NVIDIA_API_KEY`.

## Test plan
- [x] `pytest` — 53 passed, 15 skipped, no regressions vs. main (same counts before/after).
- [x] `py_compile` on all changed files.
- [ ] Not run end-to-end: no live Postgres or `NVIDIA_API_KEY` available in this environment,
      so `dg ask` itself was not exercised against a real database or the LLM endpoint. The
      wiring was verified by reading, not by execution — worth a manual smoke test before
      merge.