### PR TITLE
Handle the workflows envelope response in paginate

### DIFF
--- a/src/decision_graph/github.py
+++ b/src/decision_graph/github.py
@@ -139,12 +139,18 @@ class GitHubClient:
         params: dict[str, Any] | None = None,
         etag: str | None = None,
         max_pages: int | None = None,
+        items_key: str | None = None,
     ) -> Iterator[Page]:
         """Yield pages, following Link rel="next".
 
         Pages are yielded rather than accumulated so the caller can commit a cursor
         after each one. That is what makes a killed run resumable at page
         granularity instead of losing the whole window.
+
+        Most list endpoints return a bare JSON array. A few (`actions/workflows`,
+        the search endpoints) wrap it in an envelope object, e.g.
+        `{"total_count": N, "workflows": [...]}`. Pass `items_key` to unwrap those
+        instead of treating the whole envelope as a single item.
         """
         query = dict(params or {})
         query.setdefault("per_page", self.per_page)
@@ -167,7 +173,10 @@ class GitHubClient:
 
             resp.raise_for_status()
             payload = resp.json()
-            items = payload if isinstance(payload, list) else [payload]
+            if items_key is not None:
+                items = payload.get(items_key, []) if isinstance(payload, dict) else []
+            else:
+                items = payload if isinstance(payload, list) else [payload]
 
             yield Page(items=items, etag=resp.headers.get("ETag") if first else None)
 

--- a/src/decision_graph/run.py
+++ b/src/decision_graph/run.py
@@ -159,7 +159,8 @@ def _ingest_resource(ctx: Context, resource: str, run_id: int, max_pages: int | 
 
     saw_any = False
 
-    for page in ctx.client.paginate(path, params, etag=etag, max_pages=max_pages):
+    items_key = _items_key(resource)
+    for page in ctx.client.paginate(path, params, etag=etag, max_pages=max_pages, items_key=items_key):
         if page.not_modified:
             log.info("%s: unchanged since last poll (304)", resource)
             return
@@ -233,6 +234,12 @@ def _resource_path(repo: str, resource: str) -> str:
     }[resource]
 
 
+def _items_key(resource: str) -> str | None:
+    # Most list endpoints return a bare array. `actions/workflows` wraps its array
+    # in an envelope object instead: {"total_count": N, "workflows": [...]}.
+    return {"workflows": "workflows"}.get(resource)
+
+
 def _report(ctx: Context, client: GitHubClient) -> None:
     log.info("")
     log.info("nodes upserted : %s", ctx.stats.nodes)
@@ -244,9 +251,7 @@ def _report(ctx: Context, client: GitHubClient) -> None:
             log.info("  %-36s %s", reason, count)
 
 
-# workflows sits behind a paginated object rather than a bare list, so it is excluded
-# from the default set until the response shape is handled.
-DEFAULT_RESOURCES = ["issues", "commits", "releases", "codeowners", "wiki"]
+DEFAULT_RESOURCES = ["issues", "commits", "releases", "codeowners", "wiki", "workflows"]
 
 
 def main(argv: list[str] | None = None) -> int:


### PR DESCRIPTION
Closes #4.

## Summary
- `GitHubClient.paginate` gains an optional `items_key` param: when set, unwraps
  `payload[items_key]` instead of treating a dict payload as a single item. Needed because
  `GET /repos/{owner}/{repo}/actions/workflows` returns `{"total_count": N, "workflows": [...]}`,
  not a bare list — the same shape the search endpoints use (`items`) if those are ever added.
- `run.py` threads this through via a small `_items_key(resource)` lookup, mirroring the
  existing `_resource_path` pattern.
- `workflows` moves back into `DEFAULT_RESOURCES` now that the paging shape is handled.
  `extract_workflow` was already correct per #4 — only pagination was broken.

## Test plan
- [x] `pytest` — 53 passed, 15 skipped, no regressions vs. main.
- [x] `py_compile` on changed files.
- [ ] Not run against live GitHub: no network/API access in this environment, so the actual
      `actions/workflows` response was not fetched — the fix is verified against the documented
      envelope shape from the issue, not a live call. Worth a real ingestion smoke test before
      merge (`dg-ingest --resources workflows`).