### PR TITLE
Split body_closing_keyword/body_issue_mention provenance by source

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ categories:
 
 | category | edge + extractor | independent origin |
 |---|---|---|
-| DECLARED | `closes` via `body_closing_keyword`, dst an issue | the author's prose |
+| DECLARED | `closes` via `pr_body_closing_keyword`/`commit_message_closing_keyword`, dst an issue | the author's prose |
 | STRUCTURAL | `implements` via `pr_commit_list` | GitHub's PR↔commit structure |
 | ATTESTED | `reviewed` via `pr_review` | a reviewer's action |
 | PUBLISHED | `deployed_by` via `release_notes_reference` | a maintainer's release note |

--- a/db/migrations/0010_closing_keyword_provenance.sql
+++ b/db/migrations/0010_closing_keyword_provenance.sql
@@ -1,0 +1,144 @@
+-- 0010: split body_closing_keyword / body_issue_mention provenance by source (issue #12).
+--
+-- _link_body_refs is called from both extract_issue_or_pr (PR/issue body text) and
+-- extract_commit (commit message text), and both passed the same extractor label. A
+-- `closes` edge sourced from a PR description was therefore indistinguishable from one
+-- sourced from a commit message -- different artifacts, different authors, different
+-- reliability -- which made §7 explainability imprecise and per-source auditing impossible.
+--
+-- The code now labels new edges "pr_body_{closing_keyword,issue_mention}" or
+-- "commit_message_{closing_keyword,issue_mention}" depending on which extractor produced
+-- them. This relabels the edges (and any still-queued pending_reference rows) that were
+-- written under the old undifferentiated labels, keyed on the source node's type -- the
+-- same signal the code now uses going forward.
+--
+-- 0006's DECLARED corroboration category matched the extractor by exact literal
+-- ('body_closing_keyword'), which the relabelling above would silently empty. Both
+-- v_thread_corroboration and v_edge_corroboration_audit are recreated with a suffix match
+-- so DECLARED keeps recognising a closing-keyword edge regardless of which body it came
+-- from. This is the only behavioural change in this migration; category membership itself
+-- is unchanged, so apply_corroboration() is re-run only to reassert that invariant, not to
+-- move any thread across the 3-of-4 threshold.
+
+BEGIN;
+
+UPDATE edge e
+SET extractor = CASE
+    WHEN n.node_type IN ('issue', 'pull_request') THEN 'pr_body_' || split_part(e.extractor, 'body_', 2)
+    WHEN n.node_type = 'commit'                   THEN 'commit_message_' || split_part(e.extractor, 'body_', 2)
+END
+FROM node n
+WHERE e.src_node_id = n.id
+  AND e.extractor IN ('body_closing_keyword', 'body_issue_mention')
+  AND n.node_type IN ('issue', 'pull_request', 'commit');
+
+UPDATE pending_reference p
+SET extractor = CASE
+    WHEN n.node_type IN ('issue', 'pull_request') THEN 'pr_body_' || split_part(p.extractor, 'body_', 2)
+    WHEN n.node_type = 'commit'                   THEN 'commit_message_' || split_part(p.extractor, 'body_', 2)
+END
+FROM node n
+WHERE p.src_node_id = n.id
+  AND p.extractor IN ('body_closing_keyword', 'body_issue_mention')
+  AND n.node_type IN ('issue', 'pull_request', 'commit');
+
+-- Recreate DECLARED's predicate as a suffix match, not an exact literal, so it survives
+-- the relabelling above (and any future body-derived closing-keyword source).
+DROP VIEW v_edge_corroboration_audit;
+DROP VIEW v_thread_corroboration;
+
+CREATE VIEW v_thread_corroboration AS
+WITH threads AS (
+    SELECT DISTINCT thread_key FROM node WHERE thread_key IS NOT NULL
+),
+categories AS (
+    SELECT t.thread_key,
+
+           EXISTS (SELECT 1 FROM edge e
+                   JOIN node s ON s.id = e.src_node_id
+                   JOIN node d ON d.id = e.dst_node_id
+                   WHERE e.edge_type = 'closes'
+                     AND e.extractor LIKE '%\_closing_keyword' ESCAPE '\'
+                     AND e.tag = 'explicit' AND e.valid_to IS NULL
+                     AND d.node_type = 'issue'
+                     AND s.thread_key = t.thread_key
+                     AND d.thread_key = t.thread_key) AS declared,
+
+           EXISTS (SELECT 1 FROM edge e
+                   JOIN node s ON s.id = e.src_node_id
+                   JOIN node d ON d.id = e.dst_node_id
+                   WHERE e.edge_type = 'implements'
+                     AND e.extractor = 'pr_commit_list'
+                     AND e.tag = 'explicit' AND e.valid_to IS NULL
+                     AND s.thread_key = t.thread_key
+                     AND d.thread_key = t.thread_key) AS structural,
+
+           EXISTS (SELECT 1 FROM edge e
+                   JOIN node d ON d.id = e.dst_node_id
+                   WHERE e.edge_type = 'reviewed'
+                     AND e.extractor = 'pr_review'
+                     AND e.tag = 'explicit' AND e.valid_to IS NULL
+                     AND d.thread_key = t.thread_key) AS attested,
+
+           EXISTS (SELECT 1 FROM edge e
+                   JOIN node s ON s.id = e.src_node_id
+                   WHERE e.edge_type = 'deployed_by'
+                     AND e.extractor = 'release_notes_reference'
+                     AND e.tag = 'explicit' AND e.valid_to IS NULL
+                     AND s.thread_key = t.thread_key) AS published
+    FROM threads t
+)
+SELECT thread_key,
+       declared, structural, attested, published,
+       (declared::int + structural::int + attested::int + published::int) AS category_count,
+       (declared::int + structural::int + attested::int + published::int) >= 3 AS corroborates
+FROM categories;
+
+COMMENT ON VIEW v_thread_corroboration IS
+    'PRD v3.1 §5.4 corroboration categories per thread cluster. Observed extractors '
+    'only -- synthesis_* edges are excluded from counting because they are derived from '
+    'signals already counted here. DECLARED matches any *_closing_keyword extractor, '
+    'not just body_closing_keyword -- see #12.';
+
+CREATE VIEW v_edge_corroboration_audit AS
+SELECT e.id AS edge_id,
+       e.edge_type,
+       e.tag,
+       e.evidence_tier,
+       e.extractor,
+       COALESCE(
+           -- Normal edges: both endpoints in one thread (clause 2).
+           CASE WHEN s.thread_key IS NOT NULL AND s.thread_key = d.thread_key
+                THEN s.thread_key END,
+           -- Person-sourced edges are thread-less at the source, so the destination
+           -- alone carries the thread.
+           CASE WHEN s.node_type = 'person' AND d.thread_key IS NOT NULL
+                THEN d.thread_key END
+       ) AS thread_key,
+       tc.category_count,
+       tc.declared, tc.structural, tc.attested, tc.published,
+       (
+           e.tag = 'explicit'
+           AND e.valid_to IS NULL
+           AND corroboration_eligible_edge_type(e.edge_type)
+           AND COALESCE(tc.corroborates, false)
+       ) AS qualifies
+FROM edge e
+JOIN node s ON s.id = e.src_node_id
+JOIN node d ON d.id = e.dst_node_id
+LEFT JOIN v_thread_corroboration tc
+       ON tc.thread_key = COALESCE(
+              CASE WHEN s.thread_key IS NOT NULL AND s.thread_key = d.thread_key
+                   THEN s.thread_key END,
+              CASE WHEN s.node_type = 'person' AND d.thread_key IS NOT NULL
+                   THEN d.thread_key END);
+
+COMMENT ON VIEW v_edge_corroboration_audit IS
+    'Rubric result per edge. Expected invariant after apply_corroboration(): no row '
+    'where qualifies <> (evidence_tier = ''corroborated'') among explicit edges.';
+
+-- Category membership is unchanged (same edges, renamed) -- this reasserts the tier
+-- invariant, it does not move any thread across the 3-of-4 threshold.
+SELECT * FROM apply_corroboration();
+
+COMMIT;

--- a/src/decision_graph/db.py
+++ b/src/decision_graph/db.py
@@ -146,6 +146,7 @@ def upsert_explicit_edge(
                 COALESCE(%(observed_at)s, now()))
         ON CONFLICT (src_node_id, dst_node_id, edge_type) WHERE valid_to IS NULL
         DO UPDATE SET
+            extractor   = EXCLUDED.extractor,
             source_ref  = COALESCE(EXCLUDED.source_ref, edge.source_ref),
             observed_at = COALESCE(EXCLUDED.observed_at, edge.observed_at)
         RETURNING id, (xmax = 0) AS inserted

--- a/src/decision_graph/extractors.py
+++ b/src/decision_graph/extractors.py
@@ -194,7 +194,10 @@ def extract_issue_or_pr(ctx: Context, payload: dict[str, Any]) -> int:
             observed_at=parse_ts(payload.get("created_at")),
         )
 
-    _link_body_refs(ctx, node_id, body, source_ref=payload.get("html_url"), observed_at=updated)
+    _link_body_refs(
+        ctx, node_id, body, source_ref=payload.get("html_url"), observed_at=updated,
+        source_type="pr_body",
+    )
     return node_id
 
 
@@ -205,6 +208,7 @@ def _link_body_refs(
     *,
     source_ref: str | None,
     observed_at: datetime | None,
+    source_type: str,
 ) -> None:
     """Turn #-references in body text into edges.
 
@@ -215,10 +219,14 @@ def _link_body_refs(
     clause 3 pass on unrelated work.
 
     A reference whose target is not in the graph yet is QUEUED, not dropped (issue #3).
+
+    `source_type` ("pr_body" or "commit_message") is folded into the extractor label so a
+    `closes` edge's provenance says which artifact it came from — a PR author's claim and a
+    committer's claim are different evidence (issue #12).
     """
     for number, edge_type, extractor in [
-        *((n, "closes", "body_closing_keyword") for n in refs.closing_refs(text)),
-        *((n, "references", "body_issue_mention") for n in refs.mentioned_refs(text)),
+        *((n, "closes", f"{source_type}_closing_keyword") for n in refs.closing_refs(text)),
+        *((n, "references", f"{source_type}_issue_mention") for n in refs.mentioned_refs(text)),
     ]:
         target = _lookup_by_number(ctx, number)
         if target is None:
@@ -371,15 +379,22 @@ def reconcile_stored_bodies(ctx: Context) -> int:
         ("commit", "SELECT node_id AS id, message AS text FROM commit"),
     )
 
+    source_type_by_label = {
+        "pull_request": "pr_body",
+        "issue": "pr_body",
+        "commit": "commit_message",
+    }
+
     queued = 0
     for label, query in sources:
+        source_type = source_type_by_label[label]
         for row in ctx.conn.execute(query).fetchall():
             text = row["text"]
             if not text:
                 continue
             for number, edge_type, extractor in [
-                *((n, "closes", "body_closing_keyword") for n in refs.closing_refs(text)),
-                *((n, "references", "body_issue_mention") for n in refs.mentioned_refs(text)),
+                *((n, "closes", f"{source_type}_closing_keyword") for n in refs.closing_refs(text)),
+                *((n, "references", f"{source_type}_issue_mention") for n in refs.mentioned_refs(text)),
             ]:
                 target = _lookup_by_number(ctx, number)
                 if target is not None:
@@ -498,7 +513,10 @@ def extract_commit(ctx: Context, payload: dict[str, Any]) -> int:
 
     # Commit messages carry the same closing keywords as PR bodies, and on flask this
     # is a primary source of issue linkage.
-    _link_body_refs(ctx, node_id, message, source_ref=sha, observed_at=committed)
+    _link_body_refs(
+        ctx, node_id, message, source_ref=sha, observed_at=committed,
+        source_type="commit_message",
+    )
 
     for parent in payload.get("parents") or []:
         parent_row = ctx.conn.execute(

--- a/src/decision_graph/migrate.py
+++ b/src/decision_graph/migrate.py
@@ -60,6 +60,7 @@ SENTINELS: dict[str, str] = {
     "0007": "to_regproc('public.thread_landed') IS NOT NULL",
     "0008": "to_regproc('public.retract_unsupported_decisions') IS NOT NULL",
     "0009": "to_regclass('public.decision_thread_uidx') IS NOT NULL",
+    "0010": "pg_get_viewdef('public.v_thread_corroboration'::regclass) LIKE '%ESCAPE%'",
 }
 
 


### PR DESCRIPTION
Closes #12.

## Summary
- `_link_body_refs` gains a `source_type` param ("pr_body" or "commit_message"), folded
  into the extractor label: `pr_body_closing_keyword` / `commit_message_closing_keyword`
  (and the `_issue_mention` equivalents). `extract_issue_or_pr` and `extract_commit` each
  pass their own source type; `reconcile_stored_bodies` derives it from which table a row
  came from.
- `db.upsert_explicit_edge`'s `ON CONFLICT DO UPDATE` now refreshes `extractor` (it
  previously only refreshed `source_ref`/`observed_at`), so re-running `--reconcile` actually
  relabels edges in place instead of leaving the first-seen label stuck.
- Migration `0010_closing_keyword_provenance.sql` relabels existing `edge` rows and any
  still-queued `pending_reference` rows, keyed on the source node's type.
- 0006's `v_thread_corroboration` matched DECLARED by the exact literal
  `'body_closing_keyword'`, which the relabelling would have silently zeroed out. The
  migration recreates both corroboration views with a `LIKE '%_closing_keyword'` suffix
  match instead, so DECLARED keeps firing regardless of source, and re-runs
  `apply_corroboration()` to reassert the tier invariant (no thread should actually move
  across the 3-of-4 threshold — same edges, renamed).
- `README.md`'s corroboration table updated to the new label names.
- Added a `SENTINELS["0010"]` probe (`tests/test_cli.py` enforces every migration has one).

## Test plan
- [x] `pytest` — 53 passed, 15 skipped, no regressions vs. main.
- [x] `py_compile` on changed files.
- [ ] Migration not run against a live database: no Postgres available in this environment,
      so `0010`'s UPDATE/view-recreation SQL was checked by reading, not executed. Worth
      running `dg init` / the migration runner and confirming
      `v_edge_corroboration_audit` still reports 6 corroborated threads before merge.