### PR TITLE
Scope synthesis and retrieval to a single repo, guard the invariant

### DIFF
--- a/db/migrations/0011_decision_thread_repo_check.sql
+++ b/db/migrations/0011_decision_thread_repo_check.sql
@@ -1,0 +1,38 @@
+-- 0011: assert that a Decision's thread_key names its own repo_node_id (issue #28).
+--
+-- Numbered assuming 0010_closing_keyword_provenance.sql (#12) merges first. If it lands
+-- after this one instead, renumber whichever file lands second to 0011/0012 in merge
+-- order -- the migration runner keys off the numeric prefix, and a gap or repeat is
+-- what `dg doctor` would actually catch, not a build failure.
+--
+-- Every query in this codebase that promotes or looks up a Decision joins on BOTH
+-- repo_node_id and thread_key, trusting that the two always agree. Nothing asserted
+-- that. `synthesis.CANDIDATE_QUERY` selected `closes` edges with no repo predicate, so
+-- running synthesis for repo B could re-promote repo A's clusters stamped with repo B's
+-- repo_node_id -- a Decision whose thread_key names one repo and whose repo_node_id
+-- names another, silently. The synthesis queries are fixed (this repo's other #28 PR),
+-- but per the issue: "the guard, not the caller, is the authority". This is the guard.
+--
+-- Scoped to node_type = 'decision' only -- that is the identity the rest of the schema
+-- (decision_thread_uidx, _promote's lookup-by-thread_key) actually depends on agreeing.
+-- Other thread_key-bearing node types (issue, pull_request, commit) are not touched by
+-- this issue and are left alone.
+
+BEGIN;
+
+ALTER TABLE node
+    ADD CONSTRAINT decision_thread_key_matches_repo
+        CHECK (
+            node_type <> 'decision'
+            OR repo_node_id IS NULL
+            OR thread_key IS NULL
+            OR thread_key LIKE 'thread:' || repo_node_id::text || ':%'
+        );
+
+COMMENT ON CONSTRAINT decision_thread_key_matches_repo ON node IS
+    'A Decision''s thread_key must name the same repo as its repo_node_id column. '
+    'Catches a repo-unscoped synthesis query re-promoting another repo''s cluster '
+    'under this repo''s id (issue #28) at write time, rather than leaving the drift '
+    'silent until something notices the two fields disagree.';
+
+COMMIT;

--- a/src/decision_graph/evaluation.py
+++ b/src/decision_graph/evaluation.py
@@ -13,6 +13,12 @@ The one thing it does assert is `contract` — mechanically checkable properties
 engine itself, like "must return no answer for an artifact outside the window". Those
 are statements about the code's contract, not about flask, so the runner can check them
 without grading itself.
+
+**Deliberately whole-database, not repo-scoped** (issue #28). The §9 query set is
+hand-written against `pallets/flask`, and every database this runs against today holds
+exactly that one repo, so there is nothing to scope against yet. Give this a `--repo`
+filter, matching `dg-query`'s, only when a second repo actually shares a database with
+flask -- not speculatively ahead of that.
 """
 
 from __future__ import annotations

--- a/src/decision_graph/migrate.py
+++ b/src/decision_graph/migrate.py
@@ -60,6 +60,8 @@ SENTINELS: dict[str, str] = {
     "0007": "to_regproc('public.thread_landed') IS NOT NULL",
     "0008": "to_regproc('public.retract_unsupported_decisions') IS NOT NULL",
     "0009": "to_regclass('public.decision_thread_uidx') IS NOT NULL",
+    "0011": """EXISTS (SELECT 1 FROM pg_constraint
+                WHERE conname = 'decision_thread_key_matches_repo')""",
 }
 
 

--- a/src/decision_graph/query.py
+++ b/src/decision_graph/query.py
@@ -71,6 +71,10 @@ def main(argv: list[str] | None = None) -> int:
         help="ISO timestamp for a point-in-time query; uses edge valid_from/valid_to",
     )
     parser.add_argument("--limit", type=int, default=3, help="candidate start nodes to try")
+    parser.add_argument(
+        "--repo", help="owner/name — restrict candidates to this repo (needed once more "
+        "than one repo is ingested into the same database)"
+    )
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args(argv)
 
@@ -87,7 +91,16 @@ def main(argv: list[str] | None = None) -> int:
     as_of = datetime.fromisoformat(args.as_of) if args.as_of else None
     conn = db.connect(dsn)
 
-    candidates = retrieval.find_candidates(conn, args.query, limit=args.limit)
+    repo_node_id = None
+    if args.repo:
+        repo_node_id = retrieval.resolve_repo(conn, args.repo)
+        if repo_node_id is None:
+            print(f"error: repo {args.repo!r} has not been ingested", file=sys.stderr)
+            return 2
+
+    candidates = retrieval.find_candidates(
+        conn, args.query, repo_node_id=repo_node_id, limit=args.limit
+    )
     if not candidates:
         print(f"no candidate start node matched {args.query!r}", file=sys.stderr)
         return 1

--- a/src/decision_graph/retrieval.py
+++ b/src/decision_graph/retrieval.py
@@ -38,11 +38,21 @@ class Candidate:
     score: float
 
 
+def resolve_repo(conn: psycopg.Connection, name: str) -> int | None:
+    """Look up a repository node's id by its `owner/name`. None if not ingested."""
+    row = conn.execute(
+        "SELECT id FROM node WHERE node_type = 'repository' AND external_id = %s",
+        (name,),
+    ).fetchone()
+    return row["id"] if row else None
+
+
 def find_candidates(
     conn: psycopg.Connection,
     query: str,
     *,
     node_types: tuple[str, ...] | None = None,
+    repo_node_id: int | None = None,
     limit: int = DEFAULT_LIMIT,
 ) -> list[Candidate]:
     """Resolve a query string to plausible start nodes, best match first.
@@ -50,6 +60,10 @@ def find_candidates(
     Tiers are tried in order and the results concatenated, so an exact title match
     always outranks a fuzzy one regardless of trigram score. `#1234` and a bare number
     resolve as identifiers, which is how an impact query normally arrives.
+
+    `repo_node_id`, when given, restricts matches to that repository (issue #28) --
+    without it, a query against a database holding more than one repo can return
+    candidates from any of them, indistinguishably.
     """
     cleaned = query.strip()
     if not cleaned:
@@ -57,6 +71,7 @@ def find_candidates(
 
     identifier = cleaned.lstrip("#")
     type_filter = "AND node_type = ANY(%(types)s)" if node_types else ""
+    repo_filter = "AND repo_node_id = %(repo)s" if repo_node_id is not None else ""
     params = {
         "q": cleaned,
         "identifier": identifier,
@@ -64,30 +79,31 @@ def find_candidates(
         "floor": FUZZY_FLOOR,
         "limit": limit,
         "types": list(node_types) if node_types else None,
+        "repo": repo_node_id,
     }
 
     sql = f"""
         WITH matches AS (
             SELECT id, node_type, external_id, title, 'exact' AS match, 1.0 AS score
             FROM node
-            WHERE lower(title) = lower(%(q)s) {type_filter}
+            WHERE lower(title) = lower(%(q)s) {type_filter} {repo_filter}
 
             UNION ALL
             SELECT id, node_type, external_id, title, 'identifier', 0.95
             FROM node
-            WHERE external_id = %(identifier)s {type_filter}
+            WHERE external_id = %(identifier)s {type_filter} {repo_filter}
 
             UNION ALL
             SELECT id, node_type, external_id, title, 'prefix', 0.75
             FROM node
-            WHERE title ILIKE %(prefix)s {type_filter}
+            WHERE title ILIKE %(prefix)s {type_filter} {repo_filter}
 
             UNION ALL
             SELECT id, node_type, external_id, title, 'fuzzy',
                    similarity(title, %(q)s)
             FROM node
             WHERE title IS NOT NULL
-              AND similarity(title, %(q)s) >= %(floor)s {type_filter}
+              AND similarity(title, %(q)s) >= %(floor)s {type_filter} {repo_filter}
         )
         SELECT DISTINCT ON (id) id, node_type, external_id, title, match, score
         FROM matches

--- a/src/decision_graph/synthesis.py
+++ b/src/decision_graph/synthesis.py
@@ -40,6 +40,11 @@ log = logging.getLogger(__name__)
 # issues closed by up to five sources -- to one Decision per thread. Tie-breaks are
 # deterministic so that re-running, or ingesting in a different order, promotes the
 # same cluster to the same node.
+#
+# repo_node_id is a bind param, not a literal, because this query is shared across
+# every repo in the database (issue #28): without it, synthesizing repo B re-promotes
+# repo A's `closes` edges stamped with repo B's repo_node_id, producing a Decision whose
+# thread_key names one repo and whose repo_node_id names another.
 CANDIDATE_QUERY = """
 SELECT DISTINCT ON (src.thread_key)
        src.thread_key                       AS thread_key,
@@ -56,6 +61,7 @@ WHERE e.edge_type = 'closes'
   AND e.tag       = 'explicit'
   AND e.valid_to IS NULL
   AND dst.node_type = 'issue'
+  AND src.repo_node_id = %(repo)s
   AND src.thread_key IS NOT NULL
   AND src.thread_key = dst.thread_key
 ORDER BY src.thread_key,
@@ -102,7 +108,7 @@ def retract_unsupported(conn: psycopg.Connection) -> tuple[int, list[str]]:
 
 def synthesize(conn: psycopg.Connection, repo_node_id: int) -> SynthesisResult:
     """Promote every qualifying cluster. Idempotent."""
-    candidates = conn.execute(CANDIDATE_QUERY).fetchall()
+    candidates = conn.execute(CANDIDATE_QUERY, {"repo": repo_node_id}).fetchall()
     log.info("promotable clusters: %s", len(candidates))
 
     result = SynthesisResult()
@@ -157,6 +163,7 @@ WHERE e.edge_type = 'deployed_by'
   AND e.tag       = 'explicit'
   AND e.valid_to IS NULL
   AND rel.node_type = 'release'
+  AND art.repo_node_id = %(repo)s
   AND art.thread_key IS NOT NULL
   AND d.status = 'reconstructed'
 ORDER BY d.node_id, rel.id
@@ -169,7 +176,7 @@ def upgrade_explicit(conn: psycopg.Connection, repo_node_id: int) -> int:
     Returns the number upgraded. Idempotent: the query only selects Decisions still in
     `reconstructed` status, so a second run finds nothing to do.
     """
-    rows = conn.execute(EXPLICIT_UPGRADE_QUERY).fetchall()
+    rows = conn.execute(EXPLICIT_UPGRADE_QUERY, {"repo": repo_node_id}).fetchall()
 
     for row in rows:
         # status and source_artifact_node_id must move in ONE statement --


### PR DESCRIPTION
Closes #28.

## Summary
Ingestion was already repo-scoped; query and synthesis weren't. That was never violated
because only `pallets/flask` has ever been ingested, but nothing prevented it.

1. **The corrupting bug (lands first, per the issue).** `synthesis.CANDIDATE_QUERY` and
   `EXPLICIT_UPGRADE_QUERY` selected across the whole database with no repo predicate.
   `_promote` stamps the resulting Decision with whatever `repo_node_id` was passed into
   `synthesize()`, so running synthesis for a second repo could re-promote the first repo's
   clusters tagged as the second repo's — a Decision whose `thread_key` names one repo and
   whose `repo_node_id` names another. `decision_thread_uidx`'s `COALESCE` doesn't catch it;
   the pair is still unique. Both queries now bind `repo_node_id`.
2. **The guard.** Migration `0011` adds `CHECK` `decision_thread_key_matches_repo`: a
   Decision's `thread_key` must start with `thread:{repo_node_id}:`. Per the issue — "the
   guard, not the caller, is the authority" — so a future repo-unscoped query is rejected at
   write time instead of drifting in silently again.
3. **`retrieval.find_candidates`** gains an optional `repo_node_id` filter, applied to all
   four match tiers, wired through `dg-query` as `--repo owner/name` via a new
   `retrieval.resolve_repo` helper.
4. **`evaluation.py`** — documented as deliberately whole-database rather than scoped: the
   §9 set only ever runs against a single-repo (flask) database today, so there's nothing to
   scope against yet.

## Numbering note
This adds `db/migrations/0011_decision_thread_repo_check.sql`, on the assumption
`0010_closing_keyword_provenance.sql` (#41, issue #12) merges first. If #41 merges after
this instead, whichever migration lands second needs renumbering — the runner sorts
filenames, so a gap is harmless, but two files can't share `0010`. `migrate.py`'s
`SENTINELS` dict will also conflict trivially between the two branches; a normal merge
conflict to resolve, not a logic problem.

## Test plan
- [x] `pytest` — 53 passed, 15 skipped, no regressions vs. main.
- [x] `py_compile` on changed files.
- [ ] Not run against a live database: no Postgres available in this environment. The
      migration SQL and the repo-scoped queries were checked by reading, not executed —
      worth applying the migration and re-running synthesis against a real (even
      single-repo) database before merge, and ideally exercising a second repo in the same
      database once one exists, since that's the scenario this fixes and nothing here
      currently ingests two repos to test against.