### PR TITLE
Add implements to WHY_EDGES

### DIFF
--- a/src/decision_graph/reasoning.py
+++ b/src/decision_graph/reasoning.py
@@ -51,10 +51,17 @@ class Mode(Enum):
 
 # §5.3 backward: motivation -> discussion -> decision -> implementation -> follow-ups.
 # implemented_by is included because the PRD's own description of the causal chain ends
-# at implementation, even though the prose list omits it.
+# at implementation, even though the prose list omits it. implements is the same argument
+# one hop further down the chain (issue #14): synthesis picks exactly one implementer per
+# thread via DISTINCT ON, so a thread's other commits -- the vast majority of commit nodes,
+# 213 vs 20 implemented_by edges on flask -- are never the target of implemented_by and
+# were dead ends for Why without it. commit <- implements <- PR <- implemented_by <-
+# decision is the chain that answers "why" for one of those commits; without this edge
+# backward traversal had nothing to walk from most commits at all.
 WHY_EDGES: tuple[str, ...] = (
     "motivated_by",
     "implemented_by",
+    "implements",
     "discussed_in",
     "references",
     "supersedes",


### PR DESCRIPTION
Closes #14.

## Summary
One-line fix per the issue's own "Fix direction": add `implements` to `reasoning.WHY_EDGES`.

`dg-query <sha> --mode why` returned no path for a commit whose only edges were `created`
(in), `implements` (in, from its PR), and `closes` (out) — none of which WHY_EDGES included.
`implemented_by` was already in WHY_EDGES on the same reasoning the issue restates: §5.3's
chain description ends at implementation even though its prose list of backward edge types
stops one step short. `implements` is that same argument one hop further down — synthesis
credits exactly one implementer per thread (`DISTINCT ON`), so every other commit in the
thread only reaches a Decision via its own `implements` edge to the credited PR.

## Deliberately not done
Per the issue: **not** made by having synthesis emit `implemented_by` to every commit in a
thread — that would inflate the Implementation signal and change which clusters qualify as
Decisions, a correctness change disguised as a traversal fix.

## What this PR does NOT establish
The issue explicitly asks, after the fix: "does it widen Why answers usefully, or does it
pull in noise via `implements` edges from unrelated PRs sharing a thread?" **That check was
not run.** There is no live Postgres or ingested graph in this environment, so the §9 eval
set could not be re-run against this change — only the code change itself and the existing
unit suite were verified. The issue itself flags evaluating against the eval set as
necessary follow-up, not optional; treat this PR as the mechanical half of #14, with that
eval comparison still outstanding before merge.

## Test plan
- [x] `pytest` — 53 passed, 15 skipped, no regressions vs. main.
- [x] `py_compile` on the changed file.
- [ ] `eval` set (§9) not re-run — see above. No database or GitHub data available here.