### PR TITLE
Add a repair step to migration 0011, found by actually running it

### DIFF
--- a/db/migrations/0011_decision_thread_repo_check.sql
+++ b/db/migrations/0011_decision_thread_repo_check.sql
@@ -17,9 +17,43 @@
 -- (decision_thread_uidx, _promote's lookup-by-thread_key) actually depends on agreeing.
 -- Other thread_key-bearing node types (issue, pull_request, commit) are not touched by
 -- this issue and are left alone.
+--
+-- This is not hypothetical. Applying this migration against the actual dev database
+-- failed the CHECK immediately: it holds two repos (pallets/flask, id 1; a second repo
+-- ingested later, id 1662), and 13 Decisions existed with repo_node_id = 1662 but
+-- thread_key = 'thread:1:...' -- the exact corruption the issue describes, produced by
+-- running synthesis for the second repo before this fix landed. Every one of the 13 had
+-- a correctly-scoped twin already at repo_node_id = 1 (same thread_key, same
+-- external_id) -- true duplicates, not real data about the second repo -- so they are
+-- deleted, not re-keyed; re-keying would have collided with the twin on
+-- node_identity_uidx anyway. A survivor with no correctly-scoped twin (not observed
+-- here, but not excluded by anything) is re-keyed to the repo its own thread_key names,
+-- so real data is repaired rather than discarded.
 
 BEGIN;
 
+-- 1. Repair: drop corrupt duplicates that already have a correctly-scoped twin.
+DELETE FROM node bad
+USING node good
+WHERE bad.node_type = 'decision'
+  AND bad.thread_key IS NOT NULL
+  AND bad.repo_node_id IS NOT NULL
+  AND bad.thread_key NOT LIKE 'thread:' || bad.repo_node_id::text || ':%'
+  AND good.node_type = 'decision'
+  AND good.thread_key = bad.thread_key
+  AND good.repo_node_id::text = split_part(bad.thread_key, ':', 2)
+  AND good.id <> bad.id;
+
+-- 2. Repair: re-key any remaining violator (no twin existed) to the repo its
+--    thread_key actually names, rather than losing real data.
+UPDATE node
+SET repo_node_id = split_part(thread_key, ':', 2)::bigint
+WHERE node_type = 'decision'
+  AND thread_key IS NOT NULL
+  AND repo_node_id IS NOT NULL
+  AND thread_key NOT LIKE 'thread:' || repo_node_id::text || ':%';
+
+-- 3. Enforce it. The guard, not the calling code, is the authority.
 ALTER TABLE node
     ADD CONSTRAINT decision_thread_key_matches_repo
         CHECK (


### PR DESCRIPTION
Closes #44.

## Summary
Migration `0011`'s CHECK-only version (from #42) had never successfully applied anywhere —
running `dg init` against the real dev database failed it immediately, because the database
genuinely holds two repos and 13 Decision nodes were already corrupted exactly as #28
described (`repo_node_id` naming one repo, `thread_key` naming another). Full details and
the diagnosis are in #44.

Since no ledger row exists for a failed migration, `0011` is amended in place rather than
split into a new migration number — it has no real applied history to preserve yet.

Repair added before the CHECK, same shape as 0009's repair-then-enforce:
1. Delete a violator that already has a correctly-scoped twin for its `thread_key` (a true
   duplicate — re-keying would collide with the twin on `node_identity_uidx`).
2. Re-key any remaining violator (no twin) to the repo its own `thread_key` names.
3. Add the CHECK.

## Test plan
- [x] Dry-run against the live dev database, inside a transaction, rolled back: `DELETE 13`,
      `UPDATE 0`, 0 violations remaining afterward.
- [x] **Applied for real** against the same dev database (backup taken first). `dg init` →
      `applied 1: 0011_decision_thread_repo_check.sql`, ledger row written with checksum
      `598eac1157148622`. Post-state: constraint `decision_thread_key_matches_repo` present,
      Decision counts `repo 1 → 13` / `repo 1662 → 0` (was 13/13), **0 violators remaining**.
      `dg doctor`: all checks pass, schema up to date, 961 nodes.
- [x] Guard verified to bite, not just exist: re-pointing a correctly-scoped Decision at the
      other repo inside a rolled-back transaction is rejected —
      `new row for relation "node" violates check constraint "decision_thread_key_matches_repo"`.
- [x] Cascade checked before deleting. `edge` has `ON DELETE CASCADE` on both endpoints, so
      the 13 deletions took 29 edges with them. Those 29 were compared against the twins'
      edges by (type, direction, other endpoint) per `thread_key`: **29 vs 29, 0 unique to
      either side** — the cascade dropped only redundant copies. Edge count after: 1261.

### What this does not establish
The repair is verified only against the one corruption pattern this database happened to
hold: every violator had a twin, so step 1 deleted all 13 and step 2 (`UPDATE`) ran against
zero rows. **The re-key path has still never executed on real data** — it is exercised by no
test and no observed row. If a twinless violator ever appears, that branch is running for the
first time.
