### PR TITLE
Re-measure the recall audit on the completed corpus, and make it re-runnable

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,10 @@ for the figure with its disclosures.** Read them before quoting the number. 8 of
 correct outcomes are the system returning nothing, so a degenerate engine that always
 returned nothing would score 8/18 on this set; the query set was curated by the person who
 built the system; and the graph holds zero inferred edges, so nothing here measures
-inference. 13 Decisions out of 235 threads — coverage, not precision, is the binding limit,
-and this measures precision only.
+inference. 13 Decisions out of 233 threads — coverage, not precision, is the binding limit,
+and this measures precision only. That ratio is the completed window, re-measured (#46): the
+corpus grew by 45% after this figure was first taken and produced no fourteenth Decision, and
+no residual-bucket rubric bug either.
 
 Most usefully: **neither defect found during the evaluation cycle was caught by the
 evaluation set.** Both #16/#17 and #19 were found by a human comparing a trace to GitHub,

--- a/eval/RECALL_AUDIT.md
+++ b/eval/RECALL_AUDIT.md
@@ -15,6 +15,10 @@ reason it failed.
 
 ## Bucket classification — 148 threads
 
+> Measured on the **partial** corpus, before the backfill was resumed (145 pull requests,
+> 54 issues, 161 threads). Re-measured on the completed window further down — the shape
+> holds, the counts do not. Re-run it yourself with `eval/recall_audit.sql`.
+
 | bucket | threads | verdict |
 |---|---|---|
 | A — no issue in the thread | 107 | correct: no Motivation exists to find |
@@ -127,6 +131,10 @@ are threads with no motivating issue or no implementation to point at; the remai
 the landing gate firing on work that demonstrably never reached `main`. No rubric bug, no
 residual, no misclassification found.
 
+> Those three figures are the partial corpus. On the completed window the same sentence reads
+> **207 of 220** and **13** — and the conclusion is unchanged. See *Re-measured on the
+> completed corpus*.
+
 The binding constraint on this system's usefulness is how much evidence GitHub carries in
 the first place — and, right now, how much of it we have actually fetched.
 
@@ -177,8 +185,89 @@ stale key, and enforces the invariant with a partial unique index.
 **No amount of re-running against the partial corpus would have found this.** It requires a
 merge to occur *after* a Decision exists, which is precisely what more data caused.
 
+## Re-measured on the completed corpus
+
+Everything above the Resolution section was measured on 161 threads. The window has been
+complete since that resume, but the classification was never re-run, so the Conclusion kept
+quoting a corpus that no longer existed. Re-run now (#46), against repo 1 at its persisted
+`window_floor` of 2025-08-24:
+
+| bucket | partial | complete | verdict |
+|---|---|---|---|
+| A — no issue in the thread | 107 | **155** | correct: no Motivation exists to find |
+| D — singleton issue, nothing linked | 34 | **52** | correct: no Implementation exists |
+| B — in-thread `closes`, nothing merged | 7 | **13** | correct: the #17 landing gate |
+| C — issue present, no in-thread `closes` | 0 | 0 | — |
+| E — `closes` crossing a thread boundary | 0 | 0 | still vacuous, see above |
+| F — residual (should be empty) | 0 | **0** | no rubric bug |
+| non-Decision threads | 148 | **220** | |
+| Decisions | 13 | **13** | |
+
+**F is still empty on 45% more corpus.** That is the result worth having: the residual bucket
+is where a rubric bug would surface, and growing the corpus by half did not produce one.
+Every added thread fell into A, D or B — absent evidence, not rejected evidence.
+
+### Two hypotheses from this document, now testable — both wrong
+
+The audit wrote that the three `completed`-but-unlanded threads "most plausibly have their
+merged PR in the unfetched third". There is no unfetched third any more, and 5729, 5836 and
+5863 are still in bucket B. GitHub answers it directly: PRs 5735, 5846 and 5864 all report
+`merged = false`. The speculation was wrong and the landing gate was right.
+
+Issue **6065** was this document's one concrete example of a real recall loss — "in window,
+closed 2026-08-11 — never ingested". It is ingested now, and it produced no Decision: it
+lands in bucket B, with all four of its pull requests (6064, 6066, 6090, 6127) closed and
+unmerged. It was never a recall loss.
+
+Bucket B is now 13 threads, 5 `not_planned` and 8 `completed`. All 13 commits across the
+`completed` ones were compared against `main`:
+
+```
+0d2d49e diverged   568c2e9 diverged   5f21252 diverged   8b0d81d diverged
+a43b0e4 diverged   cc4bc94 diverged   d522702 diverged   9ff11f2 diverged
+b582518 diverged   d4b8600 diverged   f95f83b diverged   6d5b099 diverged
+f6b0eb6 diverged
+```
+
+Not one is an ancestor of `main`. The gate's refusal holds on the complete corpus.
+
+### Corroborated sparsity — re-checked, as this document asked for
+
+The audit flagged the corroborated tier's sparsity as "measured on a partial corpus and
+should be re-checked, not assumed". Re-checked: **7 corroborating threads of 233**, against 6
+of 161 before. A third more corpus bought one more. Proportionally it got *sparser* — 3.7% to
+3.0% — so flask's review culture remains the explanation, and the partial corpus was not
+hiding a denser tier.
+
+### What this still does not establish
+
+Bucket A is 155 threads, and every one is classified by a mechanical check for the *presence*
+of an issue node. Whether a human would say those threads embody a decision is exactly what
+#26 says cannot be measured this way, and re-running the buckets on a bigger corpus does not
+touch it. A bigger A is not evidence of a better rubric; it is 48 more threads that record no
+"why" anywhere the graph can see. The `thread_key` question stays open.
+
+Nor does any of this measure precision on the added corpus. The 13 Decisions were verified by
+hand in §9 and are unchanged — same 13 nodes, all still passing `decision_rubric` — but no
+new Decision appeared to verify, so nothing here re-tests whether the rubric admits a wrong
+one.
+
 ## Reproducing
 
-Bucket classification is a single query over `node`, `edge` and `thread_landed()`; the
-landing checks used `GET /repos/pallets/flask/compare/main...{sha}` and read `.status`.
-Cursor state is in `ingestion_cursor`.
+```
+psql -U postgres -d dg -v repo=1 -f eval/recall_audit.sql
+```
+
+`eval/recall_audit.sql` is the bucket classification, the E check, and the bucket A and B
+detail queries — the ones this document was originally written from by hand. It was added
+after the fact (#46), because the numbers above could not be *checked*, only re-derived, and
+that is how the Conclusion went stale without anyone noticing.
+
+Bucket order is load-bearing and the script says so: a singleton issue satisfies both C and
+D, and only testing D first reproduces the original's `C = 0, D = 34`.
+
+The landing checks are not in the script — they need the network. They used
+`GET /repos/pallets/flask/compare/main...{sha}`, reading `.status`; anything other than
+`identical` or `behind` means the commit is not an ancestor of `main`. Cursor state is in
+`ingestion_cursor`, but note that `phase` is inert for `issues` and `pulls` (#47) — read the
+watermark, not the phase.

--- a/eval/recall_audit.sql
+++ b/eval/recall_audit.sql
@@ -1,0 +1,120 @@
+-- Recall audit, re-runnable (issue #46).
+--
+-- The original audit (#23, eval/RECALL_AUDIT.md) classified every non-Decision thread by
+-- hand, with ad-hoc queries that were never written down. So when the corpus grew from 145
+-- pull requests to 217, none of its numbers could be checked -- they could only be
+-- re-derived from scratch. This file is those queries, so the audit is a measurement that
+-- can be repeated rather than a snapshot that can only age.
+--
+-- Usage:  psql -U postgres -d dg -v repo=1 -f eval/recall_audit.sql
+--
+-- BUCKET ORDER IS LOAD-BEARING. The buckets are not disjoint as prose; they are made
+-- disjoint by the order of the CASE below, which reproduces the original audit's order:
+--
+--   A  no issue in the thread            -- no Motivation can exist to find
+--   D  singleton issue, nothing linked   -- no Implementation can exist to find
+--   C  issue present, no in-thread closes
+--   B  in-thread closes, nothing merged  -- the #17 landing gate
+--   F  residual: passes every mechanical check and still produced no Decision
+--
+-- A singleton issue also has no in-thread `closes` edge, so it matches C as well as D;
+-- D is tested first, exactly as the original did (which is why it reported C = 0, D = 34).
+-- Read a nonzero F as a rubric bug, not as a curiosity.
+
+-- Defaults to repo 1 so the file runs with no arguments; pass -v repo=N for another.
+\if :{?repo}
+\else
+\set repo 1
+\endif
+
+-- Thread membership comes from node.thread_key, the same stand-in the rubric uses.
+CREATE OR REPLACE TEMP VIEW t_threads AS
+SELECT DISTINCT thread_key
+FROM node
+WHERE repo_node_id = :repo AND thread_key IS NOT NULL AND node_type <> 'decision';
+
+CREATE OR REPLACE TEMP VIEW t_facts AS
+SELECT
+    t.thread_key,
+    EXISTS (SELECT 1 FROM node n
+             WHERE n.thread_key = t.thread_key AND n.node_type = 'decision')  AS has_decision,
+    EXISTS (SELECT 1 FROM node n
+             WHERE n.thread_key = t.thread_key AND n.node_type = 'issue')     AS has_issue,
+    (SELECT count(*) FROM node n
+      WHERE n.thread_key = t.thread_key AND n.node_type <> 'decision')        AS members,
+    EXISTS (SELECT 1 FROM edge e
+              JOIN node s ON s.id = e.src_node_id
+              JOIN node d ON d.id = e.dst_node_id
+             WHERE e.edge_type = 'closes' AND e.valid_to IS NULL
+               AND s.thread_key = t.thread_key
+               AND d.thread_key = t.thread_key)                               AS closes_in_thread,
+    thread_landed(t.thread_key)                                               AS landed
+FROM t_threads t;
+
+\echo ''
+\echo '== Corpus =='
+SELECT
+    (SELECT count(*) FROM t_threads)                                        AS threads,
+    (SELECT count(*) FROM t_facts WHERE has_decision)                       AS decision_threads,
+    (SELECT count(*) FROM t_facts WHERE NOT has_decision)                   AS non_decision_threads,
+    (SELECT count(*) FROM node WHERE repo_node_id = :repo
+       AND node_type = 'pull_request')                                      AS pull_requests,
+    (SELECT count(*) FROM node WHERE repo_node_id = :repo
+       AND node_type = 'issue')                                             AS issues,
+    (SELECT count(*) FROM node WHERE repo_node_id = :repo
+       AND node_type = 'commit')                                            AS commits;
+
+\echo ''
+\echo '== Buckets (non-Decision threads) =='
+SELECT bucket, count(*) AS threads
+FROM (
+    SELECT CASE
+        WHEN NOT has_issue                              THEN 'A  no issue in thread'
+        WHEN members = 1                                THEN 'D  singleton issue'
+        WHEN NOT closes_in_thread                       THEN 'C  issue, no in-thread closes'
+        WHEN NOT landed                                 THEN 'B  closes, nothing merged'
+        ELSE                                                 'F  RESIDUAL -- rubric bug'
+    END AS bucket
+    FROM t_facts WHERE NOT has_decision
+) x GROUP BY bucket ORDER BY bucket;
+
+\echo ''
+\echo '== E: closes edges crossing a thread boundary =='
+\echo '   (vacuous by construction -- _link_body_refs unions the two threads at the moment'
+\echo '    it creates the edge, so a nonzero result here means that invariant broke.)'
+SELECT count(*) AS cross_thread_closes
+FROM edge e
+JOIN node s ON s.id = e.src_node_id
+JOIN node d ON d.id = e.dst_node_id
+WHERE e.edge_type = 'closes' AND e.valid_to IS NULL
+  AND s.thread_key IS DISTINCT FROM d.thread_key;
+
+\echo ''
+\echo '== B detail: closed-as-completed threads the landing gate refused =='
+\echo '   (the audit hypothesised their merged PR sat in the unfetched third of the window)'
+SELECT f.thread_key,
+       (SELECT string_agg(n.external_id, ',' ORDER BY n.external_id) FROM node n
+         WHERE n.thread_key = f.thread_key AND n.node_type = 'issue')          AS issues,
+       (SELECT string_agg(DISTINCT n.raw->>'state_reason', ',') FROM node n
+         WHERE n.thread_key = f.thread_key AND n.node_type = 'issue')          AS state_reason,
+       (SELECT count(*) FROM node n
+         WHERE n.thread_key = f.thread_key AND n.node_type = 'pull_request')   AS prs,
+       (SELECT count(*) FROM node n
+         WHERE n.thread_key = f.thread_key AND n.node_type = 'commit')         AS commits
+FROM t_facts f
+WHERE NOT f.has_decision AND f.has_issue AND f.members > 1
+  AND f.closes_in_thread AND NOT f.landed
+ORDER BY f.thread_key;
+
+\echo ''
+\echo '== A detail: how much of bucket A records any "why" at all =='
+SELECT
+    count(*) FILTER (WHERE n.node_type = 'pull_request')                       AS prs_in_A,
+    count(*) FILTER (WHERE n.node_type = 'commit')                             AS commits_in_A,
+    count(*) FILTER (WHERE n.node_type = 'pull_request'
+                       AND n.raw->>'body' ~* '(clos|fix|resolv)e[sd]?\s+#[0-9]+') AS prs_with_closing_keyword,
+    count(*) FILTER (WHERE n.node_type = 'pull_request'
+                       AND n.raw->>'body' ~ '#[0-9]+')                         AS prs_with_any_ref
+FROM t_facts f
+JOIN node n ON n.thread_key = f.thread_key
+WHERE NOT f.has_decision AND NOT f.has_issue;


### PR DESCRIPTION
Closes #46.

## Summary
`eval/RECALL_AUDIT.md`'s Conclusion still quoted **148 threads / 141 / 7** — the partial
corpus, from before the backfill was resumed. The Resolution section further down already
recorded that the window had been completed, but the bucket classification itself was never
re-run, so the paragraph a reader actually takes away described a corpus that no longer
exists.

Re-run against the completed window (repo 1, persisted `window_floor` 2025-08-24):

| bucket | partial | complete |
|---|---|---|
| A — no issue in the thread | 107 | **155** |
| D — singleton issue, nothing linked | 34 | **52** |
| B — in-thread `closes`, nothing merged | 7 | **13** |
| C — issue present, no in-thread `closes` | 0 | 0 |
| E — `closes` crossing a thread boundary | 0 | 0 (still vacuous) |
| F — residual | 0 | **0** |
| non-Decision threads | 148 | **220** |
| Decisions | 13 | **13** |

**F is still empty on 45% more corpus.** The residual bucket is where a rubric bug would
surface; growing the corpus by half produced none, and every added thread fell into A, D or
B — absent evidence, not rejected evidence.

### Two of the document's own hypotheses became testable, and both are wrong
- *"The three `completed`-but-unlanded threads most plausibly have their merged PR in the
  unfetched third."* There is no unfetched third; 5729, 5836 and 5863 are still in bucket B,
  and GitHub reports `merged = false` for PRs 5735, 5846 and 5864.
- Issue **6065** was the audit's one concrete example of a real recall loss. It is ingested
  now and produced no Decision — bucket B, all four of its PRs (6064, 6066, 6090, 6127)
  closed and unmerged. It was never a recall loss.

All 13 commits across the completed bucket-B threads were compared against `main` via
`GET /compare/main...{sha}`: **all 13 diverged**, not one an ancestor. The landing gate is
correct on the full corpus, not just the partial one.

### Corroborated sparsity, re-checked as the document asked for
**7 corroborating threads of 233**, against 6 of 161. Proportionally *sparser* (3.7% → 3.0%),
so flask's review culture survives as the explanation and the partial corpus was not hiding a
denser tier.

### Why it could go stale unnoticed
"Reproducing" *described* the classification instead of being it, so these numbers had to be
re-derived from scratch rather than checked. `eval/recall_audit.sql` is now that query.
Bucket order is load-bearing — a singleton issue matches both C and D, and only testing D
first reproduces the original's `C = 0, D = 34` — so the script documents that rather than
leaving it in someone's memory.

## Test plan
- [x] `psql -f eval/recall_audit.sql` against the live dev database, with `-v repo=1` and
      with no arguments (defaults to repo 1): identical output both ways.
- [x] Script is re-runnable in one session — `CREATE OR REPLACE TEMP VIEW`, so a second run
      in the same `psql` does not fail on the views.
- [x] Bucket totals reconcile: 155 + 52 + 13 + 0 + 0 = 220 = non-Decision threads, and
      220 + 13 Decision threads = 233 total, matching what `dg status` prints independently
      ("13 decisions from 233 thread clusters").
- [x] Landing checks re-run against GitHub, not read from cache: 13/13 `diverged`.
- [x] `pytest`: 56 passed, 12 skipped.
- [x] Corpus verified complete before measuring — graph 218 PRs / 78 issues against GitHub's
      218 / 78 for the same window.

## What this does not establish
Bucket A grew by 48 threads, and every one is classified by a mechanical check for the
*presence* of an issue node. Whether a human would call those threads decisions is #26's
question, and nothing here touches it — a bigger A is not evidence of a better rubric.

No new Decision appeared, so **nothing here re-tests precision**. The 13 are the same 13
nodes verified by hand in §9, still passing `decision_rubric`; this measures recall's shape
only.

The numbers are one repository at one moment. `eval/recall_audit.sql` is what makes them
checkable later; it does not make them general.
