### PR TITLE
Fix dg status: label cursor rows by repo, and stop printing an inert phase

### DIFF
--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -500,6 +500,51 @@ def _verdict(states: list[str]) -> int:
 # ---------------------------------------------------------------------------
 
 
+def _cursor_lines(cursors: list) -> list[str]:
+    """Render the ingestion_cursor rows. Split out from cmd_status so the two things
+    that were wrong here can be tested without a database (issue #47).
+
+    Grouped by repository, because ordering by resource alone turns two ingested repos
+    into pairs of identically-labelled rows with different watermarks, and nothing on
+    screen says which row is which. The repo header is omitted for a single repository:
+    the Repositories section above has already named it, and repeating it there would be
+    noise for the common case.
+
+    `phase` is printed for commits alone. It is owned by COMMITTED_DESC, the only strategy
+    that pages backwards and therefore the only one with a transition to make; for every
+    other resource the column holds its 'backfill' default forever, whatever the true
+    state is. Printing it there does not merely fail to inform, it misleads — which is how
+    the recall audit came to cite `issues phase=backfill` as evidence of a stalled backfill
+    that had in fact completed.
+    """
+    from .cursors import RESOURCE_STRATEGY, Strategy
+
+    lines: list[str] = []
+    multi = len({c["repo"] for c in cursors}) > 1
+    shown_repo = None
+    phased = False
+    for c in cursors:
+        if multi and c["repo"] != shown_repo:
+            lines.append(f"  {bold(c['repo'])}")
+            shown_repo = c["repo"]
+        indent = "    " if multi else "  "
+        wm = f"{c['steady_watermark']:%Y-%m-%d}" if c["steady_watermark"] else "—"
+        if RESOURCE_STRATEGY.get(c["resource"]) is Strategy.COMMITTED_DESC:
+            phase, phased = c["phase"], True
+        else:
+            phase = ""
+        lines.append(f"{indent}{c['resource']:<10} {phase:<9} up to {wm}")
+
+    lines.append(dim("\n  A watermark short of today means there is more to fetch — re-run"))
+    lines.append(dim("  `dg ingest` to continue from exactly there."))
+    if multi:
+        lines.append(dim("  `dg ingest` reads TARGET_REPO, so it advances that repository only."))
+    if phased:
+        lines.append(dim("  backfill/steady applies to commits alone: they page backwards and"))
+        lines.append(dim("  have a floor to reach. The rest walk forward from the watermark."))
+    return lines
+
+
 def cmd_status(args: argparse.Namespace) -> int:
     try:
         conn = _connect()
@@ -571,15 +616,17 @@ def cmd_status(args: argparse.Namespace) -> int:
         print(dim("  no runs recorded"))
 
     cursors = conn.execute(
-        "SELECT resource, phase, steady_watermark FROM ingestion_cursor ORDER BY resource"
+        """
+        SELECT r.external_id AS repo, c.resource, c.phase, c.steady_watermark
+        FROM ingestion_cursor c
+        JOIN node r ON r.id = c.repo_node_id
+        ORDER BY r.external_id, c.resource
+        """
     ).fetchall()
     if cursors:
         print()
-        for c in cursors:
-            wm = f"{c['steady_watermark']:%Y-%m-%d}" if c["steady_watermark"] else "—"
-            print(f"  {c['resource']:<10} {c['phase']:<9} up to {wm}")
-        print(dim("\n  A watermark short of today means there is more to fetch — re-run"))
-        print(dim("  `dg ingest` to continue from exactly there."))
+        for line in _cursor_lines(cursors):
+            print(line)
 
     decisions = conn.execute("SELECT count(*) AS n FROM decision").fetchone()["n"]
     threads = conn.execute(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,6 +8,7 @@ something it shouldn't, an error translator that stops translating.
 from __future__ import annotations
 
 import unittest
+from datetime import datetime
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
@@ -145,3 +146,76 @@ class ParserTest(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+def _row(repo, resource, phase="backfill", watermark=None):
+    return {"repo": repo, "resource": resource, "phase": phase, "steady_watermark": watermark}
+
+
+class CursorLinesTest(unittest.TestCase):
+    """`dg status` cursor rendering (issue #47).
+
+    Both defects were invisible to a reader of the output: a second repository appeared as
+    a duplicate row with no label, and `issues` reported a phase that is structurally
+    incapable of ever changing. The audit was misled by the second one, so it is worth a
+    test rather than a careful eye.
+    """
+
+    def test_single_repo_prints_no_repo_header(self) -> None:
+        lines = cli._cursor_lines([_row("pallets/flask", "issues"), _row("pallets/flask", "commits")])
+        self.assertFalse(any(line.strip() == "pallets/flask" for line in lines))
+        self.assertTrue(all(not line.startswith("    ") for line in lines if "up to" in line))
+
+    def test_two_repos_are_labelled_and_grouped(self) -> None:
+        rows = [
+            _row("a/one", "commits", phase="steady"),
+            _row("a/one", "issues"),
+            _row("b/two", "commits", phase="steady"),
+            _row("b/two", "issues"),
+        ]
+        lines = cli._cursor_lines(rows)
+        headers = [line.strip() for line in lines if line.strip() in {"a/one", "b/two"}]
+        self.assertEqual(headers, ["a/one", "b/two"])
+        # Every resource row sits under a header, indented, so no two rows read alike.
+        self.assertEqual(len([line for line in lines if "up to" in line]), 4)
+        self.assertTrue(all(line.startswith("    ") for line in lines if "up to" in line))
+
+    def test_repo_header_is_not_repeated_per_row(self) -> None:
+        rows = [_row("a/one", "commits"), _row("a/one", "issues"), _row("b/two", "issues")]
+        lines = cli._cursor_lines(rows)
+        self.assertEqual(len([line for line in lines if line.strip() == "a/one"]), 1)
+
+    def test_phase_is_shown_for_commits_only(self) -> None:
+        """COMMITTED_DESC owns `phase`; the forward-walking strategies never set it, so the
+        column would read 'backfill' forever for issues no matter what the truth was."""
+        lines = cli._cursor_lines([_row("a/one", "commits", phase="steady")])
+        self.assertIn("steady", lines[0])
+
+        lines = cli._cursor_lines([_row("a/one", "issues", phase="backfill")])
+        self.assertNotIn("backfill", lines[0])
+
+    def test_a_stuck_backfill_phase_on_issues_is_never_displayed(self) -> None:
+        """The exact state that misled the recall audit: phase says backfill, the watermark
+        says today. Only the watermark should reach the screen."""
+        rows = [_row("a/one", "issues", phase="backfill", watermark=datetime(2026, 8, 22))]
+        line = cli._cursor_lines(rows)[0]
+        self.assertIn("2026-08-22", line)
+        self.assertNotIn("backfill", line)
+
+    def test_missing_watermark_renders_as_a_dash_not_none(self) -> None:
+        line = cli._cursor_lines([_row("a/one", "releases", watermark=None)])[0]
+        self.assertIn("—", line)
+        self.assertNotIn("None", line)
+
+    def test_the_single_repo_hint_does_not_mention_target_repo_scoping(self) -> None:
+        """That caveat only makes sense when a repo the user can see will not advance."""
+        one = "\n".join(cli._cursor_lines([_row("a/one", "issues")]))
+        two = "\n".join(cli._cursor_lines([_row("a/one", "issues"), _row("b/two", "issues")]))
+        self.assertNotIn("TARGET_REPO", one)
+        self.assertIn("TARGET_REPO", two)
+
+    def test_the_phase_footnote_appears_only_when_a_phase_was_printed(self) -> None:
+        without = "\n".join(cli._cursor_lines([_row("a/one", "issues")]))
+        with_commits = "\n".join(cli._cursor_lines([_row("a/one", "commits", phase="steady")]))
+        self.assertNotIn("backfill/steady applies", without)
+        self.assertIn("backfill/steady applies", with_commits)


### PR DESCRIPTION
Closes #47.

## Summary
Two defects in the `dg status` cursor block, both invisible to a reader of the output.

**Rows were unlabelled and mis-ordered.** The query selected no `repo_node_id` and ordered
by `resource` alone, so two ingested repositories rendered as pairs of identical labels with
different watermarks:

```
  commits    steady    up to 2026-08-16
  commits    steady    up to 2026-08-20
  issues     backfill  up to 2026-08-22
  issues     backfill  up to —
```

Nothing said which row was whose — or that a second repo existed at all — and the pairs came
out in opposite repo order for `commits` and `releases`, because only `resource` was in the
`ORDER BY`. The hint underneath then told the reader to re-run `dg ingest` for a watermark
belonging to a repo that `dg ingest`, scoped to `TARGET_REPO`, will not advance. #42 scoped
synthesis and retrieval to a single repo; status was missed.

**`phase` was printed for resources whose strategy never sets it.** Per `cursors.py`, `phase`
belongs to `COMMITTED_DESC` — the only strategy that pages backwards, and so the only one with
a transition to make. `UPDATED_ASC` walks forward and never touches it, so `issues` holds the
`'backfill'` default forever. Above, it reads `backfill` beside a watermark of *today*, with
nothing pending.

That one is not cosmetic. `eval/RECALL_AUDIT.md` cites exactly this value as its evidence for
finding #2:

```
ingestion_cursor:  issues   phase=backfill   steady_watermark=2026-07-30
```

The watermark was real evidence. `phase=backfill` was not evidence of anything, and was read
as if it were.

## After

```
  Harsh-Yadav-664/Idea-Hunt
    commits    steady    up to 2026-08-20
    issues               up to —
    releases             up to —
  pallets/flask
    commits    steady    up to 2026-08-16
    issues               up to 2026-08-22
    releases             up to 2026-02-19
    workflows            up to 2026-05-02

  A watermark short of today means there is more to fetch — re-run
  `dg ingest` to continue from exactly there.
  `dg ingest` reads TARGET_REPO, so it advances that repository only.
  backfill/steady applies to commits alone: they page backwards and
  have a floor to reach. The rest walk forward from the watermark.
```

The repo header is omitted for a single repository — the Repositories section above has
already named it, and repeating it would be noise for the common case. Both footnotes are
conditional on the situation that makes them true.

## Test plan
- [x] Rendering split out as `_cursor_lines()` so both defects are testable with no database.
      Eight tests: grouping, header-not-repeated, header suppressed for one repo, phase shown
      for commits only, missing watermark as `—` not `None`, and both conditional footnotes.
- [x] One test pins the exact state that misled the audit — `phase='backfill'` with
      `watermark=2026-08-22` — and asserts only the watermark reaches the screen.
- [x] **Mutation-checked**: reverting `_cursor_lines` to the old behaviour (always print
      phase, never group) fails **6 of the 8**. The 2 that still pass cover rendering that
      was already correct and are regression guards, not new coverage.
- [x] `pytest`: 64 passed, 12 skipped.
- [x] `dg status` run against the live dev database with two repositories ingested — output
      above is the real thing, not a mock.

## What this does not establish
The single-repo layout is covered by unit tests only. Every **live** run here had two repos
in the database, so the one-repo path — the common case for a real user — has not been seen
on screen, only asserted.

`phase` is now hidden rather than fixed for `UPDATED_ASC`. The column still holds a
permanently-wrong `'backfill'` in `ingestion_cursor`; anything querying that table directly
(including a future audit) can still read it and be misled exactly as this one was. Making
the stored value honest is a schema change and is not attempted here.

The rest of `cmd_status` remains repo-unscoped — "Nodes by type" and the Graph counts still
sum across every repository. That is currently harmless because the second repo holds no
threads (233 thread clusters, all repo 1), but it is the same flattening and will mislead the
moment a second repo has data worth counting.
