### PR TITLE
Honour closing references written as a full GitHub issue URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,10 +335,12 @@ for the figure with its disclosures.** Read them before quoting the number. 8 of
 correct outcomes are the system returning nothing, so a degenerate engine that always
 returned nothing would score 8/18 on this set; the query set was curated by the person who
 built the system; and the graph holds zero inferred edges, so nothing here measures
-inference. 13 Decisions out of 233 threads — coverage, not precision, is the binding limit,
+inference. 15 Decisions out of 231 threads — coverage, not precision, is the binding limit,
 and this measures precision only. That ratio is the completed window, re-measured (#46): the
-corpus grew by 45% after this figure was first taken and produced no fourteenth Decision, and
-no residual-bucket rubric bug either.
+corpus grew by 45% after this figure was first taken and produced no new Decision at all. The
+fourteenth and fifteenth came instead from a parser fix (#50) — two merged PRs named their
+motivating issue by URL rather than by `#N`, and the reference was being dropped. The 18
+adjudicated outcomes predate both and are unchanged by them.
 
 Most usefully: **neither defect found during the evaluation cycle was caught by the
 evaluation set.** Both #16/#17 and #19 were found by a human comparing a trace to GitHub,

--- a/eval/RECALL_AUDIT.md
+++ b/eval/RECALL_AUDIT.md
@@ -60,7 +60,14 @@ what #16/#17 was built to reject.
 
 The other three (5729, 5836, 5863) were closed **`completed`**, which looked like a genuine
 recall loss: perhaps the fix landed as a direct commit and `thread_landed()` only checks
-`pull_request.merged_at`. That hypothesis was wrong. Each of those threads' commits was
+`pull_request.merged_at`. That hypothesis was wrong.
+
+> **5729 was a real recall loss after all, for a different reason (#50).** The fix is PR
+> 5736 — merged, in the graph, and saying `fixes https://github.com/pallets/flask/issues/5729`
+> in its own body, in a URL form the reference parser dropped. The commit-ancestry check
+> below is sound but was asking about the wrong thread: it tested whether `thread:1:pr-5735`
+> reached `main`, when the landing was in `thread:1:pr-5736` all along. 5836 and 5863 are
+> unaffected — nothing in their bodies points anywhere, and they remain correct refusals. Each of those threads' commits was
 compared against `main`:
 
 ```
@@ -132,8 +139,8 @@ the landing gate firing on work that demonstrably never reached `main`. No rubri
 residual, no misclassification found.
 
 > Those three figures are the partial corpus. On the completed window the same sentence reads
-> **207 of 220** and **13** — and the conclusion is unchanged. See *Re-measured on the
-> completed corpus*.
+> **205 of 216** and **11**, with 15 Decisions rather than 13 — and the conclusion is
+> unchanged. See *Re-measured on the completed corpus*.
 
 The binding constraint on this system's usefulness is how much evidence GitHub carries in
 the first place — and, right now, how much of it we have actually fetched.
@@ -238,6 +245,41 @@ should be re-checked, not assumed". Re-checked: **7 corroborating threads of 233
 of 161 before. A third more corpus bought one more. Proportionally it got *sparser* — 3.7% to
 3.0% — so flask's review culture remains the explanation, and the partial corpus was not
 hiding a denser tier.
+
+### The census that followed found two Decisions the parser was dropping
+
+Sharpening the frame for #26 — of bucket A's 155 threads, only **16** contain a merged pull
+request, and the rest fail the landing gate whatever their motivation — made the population
+small enough to read by hand. Two of the 16 turned out to name their motivating issue
+explicitly, as a full GitHub URL rather than `#N`:
+
+| merged PR | body | issue | issue's thread was |
+|---|---|---|---|
+| 5736 | `fixes .../issues/5729` | 5729 | bucket B, "nothing merged" |
+| 6096 | `Fixes .../issues/6093` | 6093 | bucket B, "nothing merged" |
+
+`CLOSES_RE` requires whitespace before `#`, which rejects a docs anchor correctly and a real
+GitHub closing URL as collateral (#50). Widening it and re-running `dg ingest --reconcile`
+unioned each pair into one cluster with a motivating issue and a merged implementation, and
+synthesis promoted both:
+
+| | before the fix | after |
+|---|---|---|
+| Decisions | 13 | **15** |
+| threads | 233 | 231 |
+| A — no issue in the thread | 155 | **153** |
+| B — in-thread `closes`, nothing merged | 13 | **11** |
+| D — singleton issue | 52 | 52 |
+| C / E / F | 0 | 0 |
+
+Both new Decisions pass all three rubric clauses, each motivated by its issue and implemented
+by the merged PR that did the work.
+
+**Neither the original audit nor the re-measurement above could have found this.** Both
+classify a thread by what edges it has; this was a thread that *should* have had an edge, and
+no bucket is defined by an absence that nothing recorded. It took reading the bodies of a
+small enough population by hand — which is what #26 asked for, applied to a frame narrow
+enough to be a census rather than a sample.
 
 ### What this still does not establish
 

--- a/src/decision_graph/extractors.py
+++ b/src/decision_graph/extractors.py
@@ -225,8 +225,14 @@ def _link_body_refs(
     committer's claim are different evidence (issue #12).
     """
     for number, edge_type, extractor in [
-        *((n, "closes", f"{source_type}_closing_keyword") for n in refs.closing_refs(text)),
-        *((n, "references", f"{source_type}_issue_mention") for n in refs.mentioned_refs(text)),
+        *(
+            (n, "closes", f"{source_type}_closing_keyword")
+            for n in refs.closing_refs(text, ctx.settings.target_repo)
+        ),
+        *(
+            (n, "references", f"{source_type}_issue_mention")
+            for n in refs.mentioned_refs(text, ctx.settings.target_repo)
+        ),
     ]:
         target = _lookup_by_number(ctx, number)
         if target is None:
@@ -393,8 +399,14 @@ def reconcile_stored_bodies(ctx: Context) -> int:
             if not text:
                 continue
             for number, edge_type, extractor in [
-                *((n, "closes", f"{source_type}_closing_keyword") for n in refs.closing_refs(text)),
-                *((n, "references", f"{source_type}_issue_mention") for n in refs.mentioned_refs(text)),
+                *(
+                    (n, "closes", f"{source_type}_closing_keyword")
+                    for n in refs.closing_refs(text, ctx.settings.target_repo)
+                ),
+                *(
+                    (n, "references", f"{source_type}_issue_mention")
+                    for n in refs.mentioned_refs(text, ctx.settings.target_repo)
+                ),
             ]:
                 target = _lookup_by_number(ctx, number)
                 if target is not None:
@@ -591,7 +603,8 @@ def extract_release(ctx: Context, payload: dict[str, Any]) -> int:
     # Release notes referencing a PR are a `deployed_by` signal: this is where the
     # change reached users. Release notes are also the classic source of an *explicit*
     # Decision in §5.1 — but creating that node is Phase 2+, not here.
-    for number in refs.mentioned_refs(body) | refs.closing_refs(body):
+    repo = ctx.settings.target_repo
+    for number in refs.mentioned_refs(body, repo) | refs.closing_refs(body, repo):
         target = _lookup_by_number(ctx, number)
         if target is None:
             ctx.stats.note_skip("release_ref_target_not_ingested")

--- a/src/decision_graph/refs.py
+++ b/src/decision_graph/refs.py
@@ -31,6 +31,27 @@ CLOSING_KEYWORDS = r"clos(?:e|es|ed)|fix(?:|es|ed)|resolv(?:e|es|ed)"
 CLOSES_RE = re.compile(rf"\b(?:{CLOSING_KEYWORDS})\b\s*:?\s+#(\d+)", re.IGNORECASE)
 ISSUE_REF_RE = re.compile(r"(?<![\w/])#(\d+)\b")
 
+# GitHub honours `fixes https://github.com/owner/repo/issues/N` exactly as it honours
+# `fixes #N` -- it closes the issue on merge either way. The `\s+#` mechanism above
+# rejects a docs anchor and this alike, because neither has whitespace before the
+# digits: right for the anchor, wrong for a real reference. Two Decisions were lost to
+# that (issue #50).
+#
+# The owner/repo is captured rather than skipped, because the URL carries its own and it
+# is not always the repo being ingested -- a body reading `.../pallets/werkzeug/pull/3219`
+# would otherwise resolve 3219 against THIS repo's numbers and invent an edge to an
+# unrelated issue. The caller supplies the repo to compare against; a caller that does
+# not know it gets the old behaviour, which is why `repo` defaults to None and not to a
+# guess.
+#
+# `/issues/` only. A `/pull/` URL is a PR closing a PR, which is not the
+# Motivation-Implementation shape clause 3 is about.
+CLOSES_URL_RE = re.compile(
+    rf"\b(?:{CLOSING_KEYWORDS})\b\s*:?\s+https?://(?:www\.)?github\.com/"
+    r"([\w.-]+/[\w.-]+)/issues/(\d+)\b",
+    re.IGNORECASE,
+)
+
 # Only full 40-character SHAs. Abbreviated SHAs are indistinguishable from ordinary
 # hex strings in prose and produced false edges in early testing.
 SHA_RE = re.compile(r"\b([0-9a-f]{40})\b")
@@ -39,18 +60,37 @@ SHA_RE = re.compile(r"\b([0-9a-f]{40})\b")
 COAUTHOR_RE = re.compile(r"^Co-authored-by:\s*(.+?)\s*<(.+?)>\s*$", re.IGNORECASE | re.MULTILINE)
 
 
-def closing_refs(text: str | None) -> set[int]:
-    """Issue/PR numbers this text explicitly closes."""
+def closing_refs(text: str | None, repo: str | None = None) -> set[int]:
+    """Issue/PR numbers this text explicitly closes.
+
+    `repo` is the "owner/name" being ingested. Pass it to also honour the full-URL form,
+    `fixes https://github.com/owner/name/issues/N`, which GitHub treats as closing. Slugs
+    are compared case-insensitively because GitHub's are, and a URL naming a DIFFERENT
+    repository is ignored: its numbers are not this repository's numbers.
+    """
     if not text:
         return set()
-    return {int(m) for m in CLOSES_RE.findall(text)}
+    found = {int(m) for m in CLOSES_RE.findall(text)}
+    if repo:
+        target = repo.casefold()
+        found |= {
+            int(number)
+            for slug, number in CLOSES_URL_RE.findall(text)
+            if slug.casefold() == target
+        }
+    return found
 
 
-def mentioned_refs(text: str | None) -> set[int]:
-    """Issue/PR numbers mentioned but not closed."""
+def mentioned_refs(text: str | None, repo: str | None = None) -> set[int]:
+    """Issue/PR numbers mentioned but not closed.
+
+    Takes `repo` for the same reason: a number that is a *closing* reference in URL form
+    must not also be reported as a bare mention, or one artifact would earn both a `closes`
+    and a `references` edge and the weaker one would muddy its provenance.
+    """
     if not text:
         return set()
-    return {int(m) for m in ISSUE_REF_RE.findall(text)} - closing_refs(text)
+    return {int(m) for m in ISSUE_REF_RE.findall(text)} - closing_refs(text, repo)
 
 
 def commit_refs(text: str | None) -> set[str]:

--- a/tests/test_refs.py
+++ b/tests/test_refs.py
@@ -47,15 +47,71 @@ class TestClosingRefs(unittest.TestCase):
     def test_closing_keyword_rejects_url_fragments(self) -> None:
         """CLOSES_RE has no lookbehind; it relies on `\\s+` making whitespace before '#'
         mandatory. Relaxing that to `\\s*` would silently admit URL fragments, which
-        could then upgrade the wrong Decision to explicit status via a release note."""
+        could then upgrade the wrong Decision to explicit status via a release note.
+
+        This used to also pin `fixes https://github.com/pallets/flask/issues/5448` as
+        rejected. That was wrong -- GitHub closes an issue written that way -- and it cost
+        two Decisions before anyone noticed (#50). The docs-anchor case below is the one
+        this mechanism is genuinely for; the GitHub-URL case moved to its own tests.
+        """
         for text in (
             "Changes: https://flask.palletsprojects.com/en/3.0.x/changes/#5448",
-            "fixes https://github.com/pallets/flask/issues/5448",
             "closes flask#5448",
             "resolved by commit_abc#123",
         ):
             with self.subTest(text=text):
-                self.assertEqual(refs.closing_refs(text), set())
+                self.assertEqual(refs.closing_refs(text, "pallets/flask"), set())
+
+    def test_closing_reference_as_a_full_github_url(self) -> None:
+        """The form that cost PR 5736 -> issue 5729 and PR 6096 -> issue 6093 (#50)."""
+        self.assertEqual(
+            refs.closing_refs(
+                "fixes https://github.com/pallets/flask/issues/5729", "pallets/flask"
+            ),
+            {5729},
+        )
+
+    def test_github_url_slug_is_matched_case_insensitively(self) -> None:
+        """GitHub slugs are case-insensitive, so `PALLETS/Flask` is the same repository."""
+        self.assertEqual(
+            refs.closing_refs(
+                "Fixes https://github.com/PALLETS/Flask/issues/6093", "pallets/flask"
+            ),
+            {6093},
+        )
+
+    def test_another_repositorys_url_is_not_resolved_against_our_numbers(self) -> None:
+        """The trap in the fix. werkzeug#3219 is not flask#3219, and reading it as one
+        would invent an edge to whatever unrelated issue holds that number here."""
+        for text in (
+            "fixes https://github.com/pallets/werkzeug/issues/3219",
+            "Added `client.query` in https://github.com/pallets/werkzeug/pull/3219",
+        ):
+            with self.subTest(text=text):
+                self.assertEqual(refs.closing_refs(text, "pallets/flask"), set())
+
+    def test_pull_urls_are_not_closing_references(self) -> None:
+        """A PR closing a PR is not the Motivation-Implementation shape clause 3 is about."""
+        self.assertEqual(
+            refs.closing_refs(
+                "fixes https://github.com/pallets/flask/pull/5729", "pallets/flask"
+            ),
+            set(),
+        )
+
+    def test_url_form_needs_a_repo_to_compare_against(self) -> None:
+        """A caller that does not know its repo keeps the old behaviour rather than
+        guessing that the URL's slug must be the right one."""
+        self.assertEqual(
+            refs.closing_refs("fixes https://github.com/pallets/flask/issues/5729"),
+            set(),
+        )
+
+    def test_a_url_closing_reference_is_not_also_a_bare_mention(self) -> None:
+        """Otherwise the same artifact earns both `closes` and `references`, and the
+        weaker edge muddies the provenance of the stronger one."""
+        text = "fixes https://github.com/pallets/flask/issues/5729"
+        self.assertEqual(refs.mentioned_refs(text, "pallets/flask"), set())
 
     def test_closing_keyword_still_matches_real_forms(self) -> None:
         # The guard must not cost recall on the forms that actually occur in flask.


### PR DESCRIPTION
Closes #50.

## Summary
`CLOSES_RE` matched `fixes #5729` but not `fixes https://github.com/pallets/flask/issues/5729`.
GitHub closes the issue either way, so the graph was dropping closing references that GitHub
itself acts on.

Two are in the corpus, and each cost a Decision:

| merged PR | body says | issue | issue's thread |
|---|---|---|---|
| 5736 | `fixes .../issues/5729` | 5729 | `thread:1:pr-5735` — bucket B, "nothing merged" |
| 6096 | `Fixes .../issues/6093` | 6093 | `thread:1:pr-6094` — bucket B, "nothing merged" |

In both cases the merged PR sat alone in its own thread (bucket A, no issue) while the issue
sat in another whose own PRs never merged. Catching the reference unions the two into a
single cluster with a motivating issue **and** a merged implementation — exactly what §5.1
clause 3 is for.

## Applied to the live graph
`dg ingest --reconcile` re-derives references from stored bodies at no API cost, which is the
path the docstring already anticipated ("a safety net if a parser rule is ever widened"):

```
decisions: 2 created, 13 refreshed, 11 refused, 0 upgraded to explicit
edges created: 2
```

| | before | after |
|---|---|---|
| Decisions | 13 | **15** |
| A — no issue in the thread | 155 | **153** |
| B — in-thread `closes`, nothing merged | 13 | **11** |
| D / C / E / F | 52 / 0 / 0 / 0 | unchanged |

Both new Decisions pass all three rubric clauses:

| decision | motivated_by | implemented_by | merged |
|---|---|---|---|
| 1862 | issue 5729 | PR 5736 | 2025-08-19 |
| 1884 | issue 6093 | PR 6096 | 2026-08-11 |

## The test that pinned the bug
`test_closing_keyword_rejects_url_fragments` bundled two unlike strings:

- `.../changes/#5448` — a **docs anchor**, correctly rejected; the `#` is a fragment.
- `fixes https://github.com/pallets/flask/issues/5448` — a **real closing reference**.

One mechanism (mandatory whitespace before `#`) rejected both. Right for the anchor,
collateral damage for the reference. The test is split so the anchor keeps its guard and the
URL form gets its own cases.

## The trap
The URL carries its own `owner/repo`, and it is not always ours — PR 6133's body cites
`https://github.com/pallets/werkzeug/pull/3219`. Grabbing the trailing number from any
`github.com` URL would resolve werkzeug#3219 against **flask's** numbering and invent an edge
to an unrelated issue. So the slug is captured and compared, case-insensitively as GitHub
compares them. That means `closing_refs()` needs to know the repo; it takes it as an optional
argument, and a caller that omits it keeps the old behaviour rather than trusting whatever
slug the URL happens to carry.

## This also corrects the recall audit
It concluded the work closing issue 5729 "landed somewhere the graph does not contain". The
work is **PR 5736** — in the graph, merged, saying so in its body. The commit-ancestry check
was sound but aimed at `thread:1:pr-5735` when the landing was in `thread:1:pr-5736`. Issues
5836 and 5863 are unaffected: nothing in their bodies points anywhere, and they remain
correct refusals. `eval/RECALL_AUDIT.md` and the README ratio are updated.

## Test plan
- [x] 7 new tests in `tests/test_refs.py`: same-repo URL accepted; slug matched
      case-insensitively; another repo's `/issues/` and `/pull/` URLs both ignored;
      `/pull/` on our own repo ignored; no-repo caller keeps old behaviour; a URL closing
      ref is not also reported as a bare mention.
- [x] The docs-anchor guard still passes, now on its own.
- [x] `pytest`: 70 passed, 12 skipped.
- [x] Applied against the live dev database and verified end to end — edges, thread unions,
      rubric results and evidence all checked above, not just the log line.

## What this does not establish
Two is what **this** corpus happened to hold. The fix is not measured against a repository
that uses the URL form heavily, and nothing here says how common it is in general.

The `references` (non-closing) side is unchanged: a bare `https://github.com/pallets/flask/issues/N`
with no closing keyword still produces no edge at all. That is the same class of miss, left
alone deliberately — it affects corroboration rather than the rubric, and widening it is a
larger change than this one.

Reference extraction is still regex over prose. GitHub's own linked-issue metadata (the
timeline `connected`/`cross-referenced` events) remains unused, and it would settle these
cases without pattern-matching at all.
