### PR TITLE
Stop storing a phase for the resources that can never leave it

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,6 +206,12 @@ Three cursor strategies, because the endpoints genuinely differ:
 `window_floor` is pinned on first contact rather than recomputed, so resuming a backfill
 days later cannot move the floor forward and leave an unfetched hole mid-window.
 
+`phase` belongs to `COMMITTED_DESC` alone and is NULL for the other two strategies, because
+a forward walker has no floor to reach and so no transition to record. It used to sit on
+`backfill` forever for issues and pulls, which nothing could ever retract — and the recall
+audit read exactly that as proof of a stalled ingestion (#47, migration 0012). Read
+`steady_watermark` for progress; it is the field that moves.
+
 **Resume has now been exercised for real.** The first backfill stopped a third of the way
 short and sat that way through the whole §9 cycle — the graph held 54 of 80 issues and 145
 of 219 PRs without anything noticing. Re-running picked up from the committed watermark and

--- a/db/migrations/0012_cursor_phase_not_applicable.sql
+++ b/db/migrations/0012_cursor_phase_not_applicable.sql
@@ -1,0 +1,73 @@
+-- 0012: let `phase` be NULL for the resources that never backfill (issue #47 follow-up).
+--
+-- 0003 added `phase` as NOT NULL DEFAULT 'backfill' and, in the same file, documented that
+-- only one strategy ever uses it:
+--
+--     COMMENT ON COLUMN ingestion_cursor.phase IS '... Only COMMITTED_DESC resources pass
+--     through backfill.'
+--
+-- The writer never honoured that. `cursors.load()` seeded 'steady' for FULL resources and
+-- fell through to the 'backfill' default for everything else, so every `issues` and `pulls`
+-- row has claimed since 0003 to be walking towards a window floor by a mechanism that has
+-- no floor to reach and no transition to make. The column comment and the column contents
+-- have disagreed from the day the column existed.
+--
+-- This is not a cosmetic disagreement. UPDATED_ASC resources reach `steady` by never
+-- leaving it -- backfill and steady-state are the same forward walk, seeded differently
+-- (0003's own header says so) -- so nothing in the codebase can ever move that value off
+-- 'backfill'. It is a latch wired shut, and it read as evidence: the recall audit cited
+-- `ingestion_cursor: issues phase=backfill` as proof that ingestion had stalled mid-window
+-- (eval/RECALL_AUDIT.md). The backfill had in fact stalled, but this column was not
+-- evidence of it and would have read identically had it completed.
+--
+-- PR #49 stopped `dg status` printing the field. That fixed one reader. It left the value
+-- in the table for `dg ingest`'s own log line and for anyone querying `ingestion_cursor`
+-- directly, and left the audit's methodology note warning readers away from a column the
+-- database populates on their behalf ("read the watermark, not the phase").
+--
+-- NULL is the fix because NULL is the only value that declines to make a claim. 'steady'
+-- would be a second false statement -- it asserts a floor was reached -- and the honest
+-- reading of `phase` for a forward walker is not "true" or "false" but "not applicable".
+--
+-- WHAT THIS DOES NOT DO. It adds no CHECK constraint pinning phase to NULL for non-commit
+-- resources, though 0011 argued that the guard and not the caller should be the authority.
+-- That guard would have to name the COMMITTED_DESC resources in SQL, duplicating
+-- cursors.RESOURCE_STRATEGY into the schema; adding a second backwards-paging endpoint
+-- would then fail at the constraint rather than at the code, which is a worse failure than
+-- the one being prevented. The invariant stays in Python, where the strategy table lives.
+-- The repair below hard-codes 'commits' too, but a migration describes the data at one
+-- moment and does not outlive it -- a constraint would.
+
+-- ORDERING. `cursors.load()` writes NULL for these resources from the moment this change
+-- lands, so the code requires this migration. On a database still short of it, `dg ingest`
+-- fails on the NOT NULL constraint rather than silently writing the old value -- the loud
+-- direction, and `dg doctor` already reports the pending migration by name with `dg init`
+-- as the fix. That is the same bargain every migration-bearing change here makes (0007's
+-- thread_landed(), 0011's constraint); it is called out because a NOT NULL violation on a
+-- cursor table reads less obviously than a missing function.
+
+BEGIN;
+
+-- 1. `phase` becomes optional. The existing CHECK (phase IN ('backfill','steady')) needs no
+--    change: a CHECK holds unless it evaluates to FALSE, and NULL IN (...) is NULL.
+ALTER TABLE ingestion_cursor ALTER COLUMN phase DROP NOT NULL;
+
+-- 2. And loses its default, so 'backfill' cannot come back by omission. There is exactly
+--    one INSERT into this table (cursors.load) and it always states the phase explicitly;
+--    a default here would only ever serve to reintroduce the value being withdrawn.
+ALTER TABLE ingestion_cursor ALTER COLUMN phase DROP DEFAULT;
+
+-- 3. Repair. Every existing row for a resource that does not page backwards is asserting a
+--    phase it cannot have; withdraw the assertion. Scoped by resource rather than by
+--    strategy because the strategy table is Python-side -- see the note above. At the time
+--    of writing `commits` is the only COMMITTED_DESC resource.
+UPDATE ingestion_cursor SET phase = NULL, updated_at = now()
+WHERE resource <> 'commits' AND phase IS NOT NULL;
+
+COMMENT ON COLUMN ingestion_cursor.phase IS
+    'backfill = still walking towards window_floor; steady = floor reached, now polling '
+    'forward from steady_watermark. NULL = not applicable: this resource''s strategy has no '
+    'backfill phase to be in. Only COMMITTED_DESC resources (commits) are ever non-NULL. '
+    'Do not read this column as progress for anything else -- read steady_watermark.';
+
+COMMIT;

--- a/eval/RECALL_AUDIT.md
+++ b/eval/RECALL_AUDIT.md
@@ -9,9 +9,11 @@ reason it failed.
 1. The rubric is not losing decisions. Every rejection traces to evidence the graph does
    not contain, and the residual bucket — passes every mechanical check yet produced no
    Decision — is empty.
-2. **The graph is two-thirds of the intended window.** The `issues` cursor is still in
-   `phase = backfill`. Ingestion stopped mid-window and was never resumed, so every
-   coverage number reported in §9 is measured on a partial corpus.
+2. **The graph is two-thirds of the intended window.** The `issues` watermark sits at
+   2026-07-30 with 106 items updated after it. Ingestion stopped mid-window and was never
+   resumed, so every coverage number reported in §9 is measured on a partial corpus. (This
+   originally cited `phase = backfill` instead. That column could not have shown otherwise
+   — see the note under Finding 2.)
 
 ## Bucket classification — 148 threads
 
@@ -99,6 +101,13 @@ here.** Tracked as issue #26 so it is not read as settled once this cycle closes
 ```
 ingestion_cursor:  issues   phase=backfill   steady_watermark=2026-07-30
 ```
+
+> **`phase=backfill` was not evidence and never could have been.** The conclusion below is
+> right, but this line does not support it: `issues` is `UPDATED_ASC`, a strategy with no
+> floor to reach and so no transition to make, and nothing in the codebase could ever have
+> moved that value. It would have read `backfill` just the same had the window completed.
+> The watermark on the same line is the part that carried the finding. The column now reads
+> NULL for this resource (#47, migration 0012), so the trap is closed rather than annotated.
 
 The backfill never reached its floor. Comparing the graph against GitHub for the same
 window (`updated:>=2025-08-17`):
@@ -311,5 +320,7 @@ D, and only testing D first reproduces the original's `C = 0, D = 34`.
 The landing checks are not in the script — they need the network. They used
 `GET /repos/pallets/flask/compare/main...{sha}`, reading `.status`; anything other than
 `identical` or `behind` means the commit is not an ancestor of `main`. Cursor state is in
-`ingestion_cursor`, but note that `phase` is inert for `issues` and `pulls` (#47) — read the
-watermark, not the phase.
+`ingestion_cursor`; read `steady_watermark`, which is the field that moves. `phase` is now
+NULL for `issues` and `pulls` rather than permanently 'backfill' (#47, migration 0012), so
+the column can no longer be misread the way it was here — but on a database that predates
+0012 it will still read 'backfill', and it still means nothing there.

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -511,11 +511,12 @@ def _cursor_lines(cursors: list) -> list[str]:
     noise for the common case.
 
     `phase` is printed for commits alone. It is owned by COMMITTED_DESC, the only strategy
-    that pages backwards and therefore the only one with a transition to make; for every
-    other resource the column holds its 'backfill' default forever, whatever the true
-    state is. Printing it there does not merely fail to inform, it misleads — which is how
-    the recall audit came to cite `issues phase=backfill` as evidence of a stalled backfill
-    that had in fact completed.
+    that pages backwards and therefore the only one with a transition to make. It used to
+    hold its 'backfill' default forever for every other resource, whatever the true state
+    was — which does not merely fail to inform, it misleads, and is how the recall audit
+    came to cite `issues phase=backfill` as evidence of a stalled backfill that had in fact
+    completed. Migration 0012 stores NULL there instead, so the suppression below and the
+    stored value now agree rather than the display having to paper over the data.
     """
     from .cursors import RESOURCE_STRATEGY, Strategy
 
@@ -529,7 +530,11 @@ def _cursor_lines(cursors: list) -> list[str]:
             shown_repo = c["repo"]
         indent = "    " if multi else "  "
         wm = f"{c['steady_watermark']:%Y-%m-%d}" if c["steady_watermark"] else "—"
-        if RESOURCE_STRATEGY.get(c["resource"]) is Strategy.COMMITTED_DESC:
+        # Two gates on purpose. RESOURCE_STRATEGY is the authority; NULL is what 0012
+        # writes for the rest. Either would do today, but keeping both means neither a
+        # database still short of 0012 nor a future strategy can put a meaningless phase
+        # back on screen.
+        if RESOURCE_STRATEGY.get(c["resource"]) is Strategy.COMMITTED_DESC and c["phase"]:
             phase, phased = c["phase"], True
         else:
             phase = ""

--- a/src/decision_graph/cursors.py
+++ b/src/decision_graph/cursors.py
@@ -22,6 +22,12 @@ Three strategies, because the GitHub endpoints genuinely differ:
                   Small, unwindowed, refreshed whole each run; ETag makes the
                   no-change case cost one request.
 
+Because only one of the three has a phase to be in, `phase` is NULL for the other two
+rather than parked on a default. It used to hold 'backfill' forever for issues and pulls,
+which nothing could retract and which the recall audit reasonably misread as a stalled
+ingestion (#47, migration 0012). A column that cannot change is worse than an absent one:
+it invites exactly that inference.
+
 The window floor is persisted on first contact rather than recomputed per run. If it
 were recomputed, resuming a backfill a week later would move the floor forward and
 leave an unfetched hole in the middle of the window that nothing would ever revisit.
@@ -62,7 +68,7 @@ RESOURCE_STRATEGY: dict[str, Strategy] = {
 class Cursor:
     repo_node_id: int
     resource: str
-    phase: str
+    phase: str | None
     window_floor: datetime | None
     backfill_cursor: datetime | None
     steady_watermark: datetime | None
@@ -75,6 +81,21 @@ class Cursor:
     @property
     def is_backfilling(self) -> bool:
         return self.phase == "backfill"
+
+
+def initial_phase(resource: str) -> str | None:
+    """The phase a cursor is born in, or None where the field does not apply.
+
+    Only COMMITTED_DESC has a backfill to be in the middle of: it pages backwards and has a
+    floor to reach, so 'backfill' -> 'steady' is a transition it genuinely makes. UPDATED_ASC
+    arrives in steady state and never leaves, because its backfill and its steady poll are
+    the same forward walk seeded differently; FULL has no window at all.
+
+    Storing 'backfill' for those was a claim nothing could ever retract — the audit read it
+    as a stalled ingestion (#47). NULL is the only value that declines to make the claim;
+    'steady' would assert a floor had been reached, which is equally untrue.
+    """
+    return "backfill" if RESOURCE_STRATEGY[resource] is Strategy.COMMITTED_DESC else None
 
 
 def load(
@@ -95,8 +116,7 @@ def load(
             repo_node_id,
             resource,
             floor,
-            # FULL resources have no window to walk, so they start life in steady.
-            "steady" if RESOURCE_STRATEGY[resource] is Strategy.FULL else "backfill",
+            initial_phase(resource),
         ),
     ).fetchone()
     assert row is not None

--- a/src/decision_graph/migrate.py
+++ b/src/decision_graph/migrate.py
@@ -63,6 +63,11 @@ SENTINELS: dict[str, str] = {
     "0010": "pg_get_viewdef('public.v_thread_corroboration'::regclass) LIKE '%ESCAPE%'",
     "0011": """EXISTS (SELECT 1 FROM pg_constraint
                 WHERE conname = 'decision_thread_key_matches_repo')""",
+    # 0012 is a data repair, so it has no new object to probe; the DROP NOT NULL it
+    # depends on is the schema change that exists iff it ran.
+    "0012": """EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'ingestion_cursor' AND column_name = 'phase'
+                  AND is_nullable = 'YES')""",
 }
 
 

--- a/src/decision_graph/run.py
+++ b/src/decision_graph/run.py
@@ -153,9 +153,13 @@ def _ingest_resource(ctx: Context, resource: str, run_id: int, max_pages: int | 
     path = _resource_path(ctx.settings.target_repo, resource)
     etag = cursor.last_etag if cursor.strategy is Strategy.FULL else None
 
-    log.info(
-        "%s: phase=%s params=%s", resource, cursor.phase, {k: v for k, v in params.items()}
-    )
+    # `phase` is printed only by the strategy that owns it. For everything else it is NULL
+    # (migration 0012) and saying so on every run would restate a non-fact — the same
+    # misreading `dg status` used to invite (#47).
+    if cursor.phase is not None:
+        log.info("%s: phase=%s params=%s", resource, cursor.phase, dict(params))
+    else:
+        log.info("%s: params=%s", resource, dict(params))
 
     saw_any = False
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -144,10 +144,6 @@ class ParserTest(unittest.TestCase):
         self.assertEqual(extra, ["--bogus"])
 
 
-if __name__ == "__main__":
-    unittest.main()
-
-
 def _row(repo, resource, phase="backfill", watermark=None):
     return {"repo": repo, "resource": resource, "phase": phase, "steady_watermark": watermark}
 
@@ -219,3 +215,23 @@ class CursorLinesTest(unittest.TestCase):
         with_commits = "\n".join(cli._cursor_lines([_row("a/one", "commits", phase="steady")]))
         self.assertNotIn("backfill/steady applies", without)
         self.assertIn("backfill/steady applies", with_commits)
+
+    def test_a_null_phase_prints_nothing_and_raises_no_footnote(self) -> None:
+        """What migration 0012 actually stores for a forward walker. The row must still
+        render its watermark, and `None` must never reach the screen."""
+        rows = [_row("a/one", "issues", phase=None, watermark=datetime(2026, 8, 22))]
+        lines = cli._cursor_lines(rows)
+        self.assertIn("2026-08-22", lines[0])
+        self.assertNotIn("None", lines[0])
+        self.assertNotIn("backfill/steady applies", "\n".join(lines))
+
+    def test_a_null_phase_on_commits_is_not_printed_as_none(self) -> None:
+        """Belt and braces: a commits row whose phase is somehow NULL — a database short of
+        0012's repair, or a hand-edited row — must degrade to blank, not to the string
+        'None' padded into the column."""
+        line = cli._cursor_lines([_row("a/one", "commits", phase=None)])[0]
+        self.assertNotIn("None", line)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_cursors.py
+++ b/tests/test_cursors.py
@@ -1,0 +1,115 @@
+"""Cursor phase semantics (issue #47 follow-up, migration 0012).
+
+stdlib unittest, no test dependency: `python -m unittest discover tests`.
+
+`phase` is owned by one strategy of three. These tests pin both halves of that: that only
+COMMITTED_DESC is born with a phase, and — the part that makes the change safe — that
+withdrawing the phase from the other two changes no query parameter they send. If the
+second half ever fails, the field was load-bearing after all and 0012 was wrong.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+
+from decision_graph.cursors import (
+    RESOURCE_STRATEGY,
+    Cursor,
+    Strategy,
+    initial_phase,
+    query_params,
+)
+
+FLOOR = datetime(2025, 9, 1, tzinfo=timezone.utc)
+MARK = datetime(2026, 8, 22, tzinfo=timezone.utc)
+
+
+def _cursor(resource: str, phase: str | None, **kw) -> Cursor:
+    return Cursor(
+        repo_node_id=1,
+        resource=resource,
+        phase=phase,
+        window_floor=kw.get("window_floor", FLOOR),
+        backfill_cursor=kw.get("backfill_cursor"),
+        steady_watermark=kw.get("steady_watermark"),
+        last_etag=None,
+    )
+
+
+class InitialPhaseTest(unittest.TestCase):
+    def test_only_committed_desc_is_born_with_a_phase(self) -> None:
+        """Table-driven so a new resource cannot be added without deciding this."""
+        for resource, strategy in RESOURCE_STRATEGY.items():
+            with self.subTest(resource=resource):
+                phase = initial_phase(resource)
+                if strategy is Strategy.COMMITTED_DESC:
+                    self.assertEqual(phase, "backfill")
+                else:
+                    self.assertIsNone(phase)
+
+    def test_commits_starts_in_backfill(self) -> None:
+        self.assertEqual(initial_phase("commits"), "backfill")
+
+    def test_forward_walkers_have_no_phase_at_all(self) -> None:
+        """Not 'steady' — that would assert a floor had been reached. NULL declines to
+        claim anything, which is the only true statement available (#47)."""
+        self.assertIsNone(initial_phase("issues"))
+        self.assertIsNone(initial_phase("pulls"))
+
+    def test_unwindowed_resources_have_no_phase_either(self) -> None:
+        for resource in ("releases", "workflows", "codeowners"):
+            with self.subTest(resource=resource):
+                self.assertIsNone(initial_phase(resource))
+
+    def test_a_null_phase_is_not_backfilling(self) -> None:
+        self.assertFalse(_cursor("issues", None).is_backfilling)
+        self.assertTrue(_cursor("commits", "backfill").is_backfilling)
+
+
+class PhaseIsInertForForwardWalkersTest(unittest.TestCase):
+    """The safety argument for 0012, as a test.
+
+    Dropping the phase is only safe if nothing outside COMMITTED_DESC reads it. Rather than
+    assert that by inspection, compare the parameters a forward walker actually sends with
+    the phase set every possible way.
+    """
+
+    def test_updated_asc_params_do_not_depend_on_phase(self) -> None:
+        for resource in ("issues", "pulls"):
+            for state in ("backfill", "steady", None):
+                with self.subTest(resource=resource, phase=state):
+                    self.assertEqual(
+                        query_params(_cursor(resource, state, steady_watermark=MARK)),
+                        query_params(_cursor(resource, "backfill", steady_watermark=MARK)),
+                    )
+
+    def test_updated_asc_walks_from_the_watermark_regardless_of_phase(self) -> None:
+        params = query_params(_cursor("issues", None, steady_watermark=MARK))
+        self.assertEqual(params["since"], "2026-08-22T00:00:00Z")
+        self.assertEqual(params["direction"], "asc")
+
+    def test_updated_asc_falls_back_to_the_window_floor_with_no_watermark(self) -> None:
+        params = query_params(_cursor("issues", None))
+        self.assertEqual(params["since"], "2025-09-01T00:00:00Z")
+
+    def test_full_resources_send_no_params_whatever_the_phase(self) -> None:
+        self.assertEqual(query_params(_cursor("releases", None)), {})
+        self.assertEqual(query_params(_cursor("releases", "backfill")), {})
+
+    def test_committed_desc_still_reads_its_phase(self) -> None:
+        """The other side of the claim: for the one strategy that owns the field, phase
+        genuinely changes the request. If this ever passes trivially, the field is dead."""
+        backfilling = query_params(
+            _cursor("commits", "backfill", backfill_cursor=MARK, steady_watermark=MARK)
+        )
+        steady = query_params(
+            _cursor("commits", "steady", backfill_cursor=MARK, steady_watermark=MARK)
+        )
+        self.assertIn("until", backfilling)
+        self.assertNotIn("until", steady)
+        self.assertNotEqual(backfilling, steady)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #53. The database side of the second defect in #47 — #49 fixed the display, this
fixes the data.

## What was wrong

`ingestion_cursor.phase` was `NOT NULL DEFAULT 'backfill'`, and `cursors.load()` only ever
overrode it for FULL resources. So `issues` and `pulls` rows have asserted since migration
0003 that they are mid-backfill, by a strategy that walks forward and has no floor to reach
— while 0003's own `COMMENT ON COLUMN`, in the same file, said "Only COMMITTED_DESC
resources pass through backfill". The comment and the contents disagreed from the day the
column existed.

`complete_backfill()` is reachable only from the `COMMITTED_DESC` branch of `run.py`, so no
code path could ever move the value. It was a latch wired shut, and `eval/RECALL_AUDIT.md`
cited it as evidence of a stalled ingestion.

## What this does

- **Migration 0012** drops `NOT NULL` and the default, and repairs existing rows for
  non-`commits` resources to NULL.
- **`cursors.initial_phase()`** replaces the inline expression in `load()`, returning
  `'backfill'` for `COMMITTED_DESC` and `None` otherwise.
- **`run.py`** stops logging `phase=` for resources that have none — the last unfixed
  reader from #47.
- **`cli._cursor_lines`** gains a second gate so a NULL never renders as the string `None`,
  and its docstring stops describing the old behaviour as current.
- **`README.md` and `eval/RECALL_AUDIT.md`** are corrected: the audit's headline finding 2
  now cites the watermark it should always have cited, with a note under the evidence block
  saying why the phase line never supported the conclusion.

## Why NULL and not `'steady'`

NULL is the only value that declines to make a claim. `'steady'` asserts a floor was
reached, which for a forward walker is as untrue as `'backfill'`.

## Alternative considered, and rejected

Make `phase` genuinely work for `UPDATED_ASC` — flip it to `'steady'` when the walk passes
the floor — which would retroactively make the audit's inference valid. Rejected because
0003's header and `cursors.py`'s module docstring both state that `UPDATED_ASC` needs no
phase transition, its backfill and its steady poll being the same forward walk seeded
differently. Changing a documented contract is a bigger call than fixing an implementation
that violates one. Worth a second opinion if you disagree.

## No CHECK constraint, deliberately

0011 argued the guard rather than the caller should be the authority. Here that guard would
have to name the `COMMITTED_DESC` resources in SQL, duplicating `cursors.RESOURCE_STRATEGY`
into the schema; adding a second backwards-paging endpoint would then fail at the constraint
rather than at the code, which is a worse failure than the one prevented. The migration's
repair hard-codes `'commits'` too, but a migration describes one moment and does not outlive
it — a constraint would.

## Ordering hazard

The code writes NULL from the moment this lands, so it **requires** migration 0012. On a
database short of it, `dg ingest` fails on the NOT NULL constraint. That is the loud
direction, and `dg doctor` already names the pending migration with `dg init` as the fix,
but a NOT NULL violation on a cursor table reads less obviously than a missing function, so
the migration header calls it out.

## Verification

Test suite: **94 tests, 79 passed, 15 skipped** (skips are all `Docker not available` or
`DATABASE_URL not set` — environmental, unrelated). 12 of those tests are new.

The new tests are not vacuous: reverting `initial_phase()` to the old expression fails 9 of
them.

Against the live database:

- `dg init` applied 0012 and repaired **5 rows** (2 `issues`, 2 `releases`, 1 `workflows`);
  both `commits` rows kept `steady`. Column is now `is_nullable=YES` with no default.
- Re-running `dg init` reports `already up to date — 12 migrations`, so the sentinel probe
  (`is_nullable = 'YES'`) is idempotent.
- `dg status` prints `steady` for `commits` and blank for the rest, watermarks intact, no
  `None` on screen.
- `dg ingest --resources issues commits releases --max-pages 1`:

  ```
  issues: params={'state': 'all', 'sort': 'updated', 'direction': 'asc', 'since': ...}
  commits: phase=steady params={'since': '2026-08-16T18:35:31Z'}
  releases: params={}
  ```

- The `ON CONFLICT DO UPDATE` path ran for real during that ingest (the `issues` watermark
  advanced to 2026-09-03 with `phase` still NULL), and the fresh-INSERT-with-NULL path was
  confirmed separately in a rolled-back transaction — which also confirms the existing
  `CHECK (phase IN ('backfill','steady'))` needs no change, since `NULL IN (...)` is NULL
  and a CHECK holds unless it is FALSE.

**What this does not establish:** the ingest was capped at one page per resource and did not
exercise a `backfill` → `steady` transition, because no cursor in this database is currently
backfilling — both `commits` rows already read `steady`. That path is covered by unit test
only (`test_committed_desc_still_reads_its_phase`), not by a live run. A pre-migration backup
is at `scratchpad/dg-pre-0012.sql` if the repair needs undoing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PQRcncbERE44f7vungYL4
