### PR TITLE
Run the SQL suites in CI, and repair the one that had stopped working

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,121 @@
+# Runs everything the README tells a contributor to run by hand.
+#
+# It exists because one of those suites had stopped working and nobody knew: migration 0011
+# added a CHECK that the 0009 test fixture violated, so that file aborted on its first
+# INSERT and all five of its checks went silent (#55). Nothing was watching. The Python
+# tests carry the same assumption in writing — test_every_migration_declares_a_sentinel says
+# a missing sentinel "should break here, not in someone's terminal" — which is only true if
+# something runs it on every change.
+#
+# Two things this deliberately does NOT do: it does not call the GitHub API (no token, and
+# ingestion is not what is under test), and it does not run `dg`. `dg` is the Docker
+# wrapper; running the suite through it would test the wrapper and hide everything else
+# behind an image build.
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both ends of the supported range. pyproject declares >=3.11 while the Dockerfile
+        # pins 3.13, and that gap is not hypothetical: `dg status` once shipped f-string
+        # syntax that only parses on 3.12+, and every containerised command ran it happily.
+        # tests/test_python_floor.py guards compilation at the floor; this runs the suite
+        # there too.
+        python-version: ["3.11", "3.13"]
+
+    services:
+      db:
+        image: postgres:16
+        env:
+          # Same disposable local credential as docker-compose.yml, for the same reason:
+          # a throwaway container holding public data, reachable only from this job.
+          POSTGRES_PASSWORD: dg
+          POSTGRES_USER: postgres
+          POSTGRES_DB: dg
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d dg"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 30
+
+    env:
+      DATABASE_URL: postgresql://postgres:dg@localhost:5432/dg
+      PGPASSWORD: dg
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install
+        # Editable install rather than PYTHONPATH, so a broken pyproject fails here too.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Install psql
+        # The SQL suites are run with psql, as the README documents them.
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends postgresql-client
+
+      - name: Apply migrations
+        # migrate.apply_all is the same code path `dg init` uses, called directly because
+        # `dg init` also wants a GitHub token and a target repo, neither of which this needs.
+        run: |
+          python - <<'PY'
+          import os
+          from decision_graph import db, migrate
+
+          conn = db.connect(os.environ["DATABASE_URL"])
+          result = migrate.apply_all(conn, "db/migrations")
+          print(f"applied {len(result.applied)}: {result.applied}")
+          if result.changed:
+              raise SystemExit(f"checksum drift in already-applied migrations: {result.changed}")
+          PY
+
+      - name: Migrations are idempotent
+        # `dg init` is documented as safe to re-run, and the sentinel probes are the only
+        # thing making that true. A second pass must apply nothing.
+        run: |
+          python - <<'PY'
+          import os
+          from decision_graph import db, migrate
+
+          conn = db.connect(os.environ["DATABASE_URL"])
+          result = migrate.apply_all(conn, "db/migrations")
+          if not result.up_to_date:
+              raise SystemExit(f"re-running migrations was not a no-op: applied={result.applied} adopted={result.adopted}")
+          print("second pass applied nothing")
+          PY
+
+      - name: Python suite
+        # DATABASE_URL is set for the whole job, so the 12 integration tests run rather than
+        # skipping. Docker is present on the runner, so the 3 python-floor tests run too:
+        # nothing here should be skipped, and a skip is worth noticing in the log.
+        run: python -m unittest discover -s tests -v
+
+      - name: SQL suites
+        # Each file opens a transaction and rolls back, so order does not matter and the
+        # database is unchanged afterwards. ON_ERROR_STOP is what turns a failed check into
+        # a failed job; without it psql reports success on a suite that aborted.
+        run: |
+          set -euo pipefail
+          for f in db/tests/*.sql; do
+            echo "::group::$f"
+            psql -h localhost -U postgres -d dg -v ON_ERROR_STOP=1 -f "$f"
+            echo "::endgroup::"
+          done

--- a/README.md
+++ b/README.md
@@ -376,16 +376,24 @@ psql "$DATABASE_URL" -f db/tests/0002_rubric_checks.sql             # 13 checks
 psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
-psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  5 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 68 checks
+psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  9 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 94 tests
 ```
 
-All SQL suites run in a transaction and roll back. The Python suite runs 53 tests
+`.github/workflows/ci.yml` runs all of it on every push and pull request, against Postgres
+16 on both ends of the supported Python range. That is recent: the 0009 suite had been
+aborting on its first statement since migration 0011 added a CHECK its fixture violated,
+and all five of its checks were silently dead until something finally ran them (#55).
+
+All SQL suites run in a transaction and roll back. The Python suite runs 79 tests
 standalone. Setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 and 5 for the trace annotation. Docker adds 3 more that compile the whole package on the
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
+
+A run without those is still reported as `OK`, with 15 of the 94 quietly skipped — so a
+local pass and a complete pass look alike. CI sets both, and nothing is skipped there.
 
 Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell
 5.1 decodes a BOM-less script using the system ANSI codepage, where an em-dash's last byte

--- a/db/tests/0009_decision_identity_checks.sql
+++ b/db/tests/0009_decision_identity_checks.sql
@@ -1,6 +1,16 @@
 -- Behavioural checks for 0009: one Decision per thread cluster (issue #25).
 --
 -- Runs in a transaction and rolls back.
+--
+-- Thread keys are built from v_repo rather than written out. They used to hard-code
+-- `thread:1:`, which was harmless until 0011 added
+--
+--     CHECK (... thread_key LIKE 'thread:' || repo_node_id::text || ':%')
+--
+-- and the fixture became the first thing that constraint rejected. It aborted at T1, so
+-- every check below it stopped running and stayed stopped (#55). The keys are derived now
+-- because a fixture that states the repo id twice can disagree with itself; one that
+-- derives it cannot.
 
 BEGIN;
 SET CONSTRAINTS ALL DEFERRED;
@@ -10,19 +20,26 @@ DECLARE
     v_repo   bigint;
     v_a      bigint;
     v_b      bigint;
+    v_k1     text;
+    v_k2     text;
+    v_k3     text;
     v_failed int := 0;
     v_ok     boolean;
 BEGIN
     INSERT INTO node (node_type, external_id, title)
     VALUES ('repository', 'test/identity', 'fixture repo') RETURNING id INTO v_repo;
 
+    v_k1 := format('thread:%s:pr-1', v_repo);
+    v_k2 := format('thread:%s:pr-2', v_repo);
+    v_k3 := format('thread:%s:pr-3', v_repo);
+
     -- T1: two Decisions in DIFFERENT clusters are fine.
     INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
-    VALUES ('decision', v_repo, 'thread:1:pr-1', 'thread:1:pr-1') RETURNING id INTO v_a;
+    VALUES ('decision', v_repo, v_k1, v_k1) RETURNING id INTO v_a;
     INSERT INTO decision (node_id, status) VALUES (v_a, 'reconstructed');
 
     INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
-    VALUES ('decision', v_repo, 'thread:1:pr-2', 'thread:1:pr-2') RETURNING id INTO v_b;
+    VALUES ('decision', v_repo, v_k2, v_k2) RETURNING id INTO v_b;
     INSERT INTO decision (node_id, status) VALUES (v_b, 'reconstructed');
     RAISE NOTICE 'T1 PASS: distinct clusters may each hold a Decision';
 
@@ -30,7 +47,7 @@ BEGIN
     -- 6072/6095 duplicate took -- different external_id, same thread_key.
     BEGIN
         INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
-        VALUES ('decision', v_repo, 'thread:1:pr-99', 'thread:1:pr-1');
+        VALUES ('decision', v_repo, format('thread:%s:pr-99', v_repo), v_k1);
         v_failed := v_failed + 1;
         RAISE WARNING 'T2 FAIL: a duplicate Decision for one cluster was accepted';
     EXCEPTION WHEN unique_violation THEN
@@ -40,9 +57,9 @@ BEGIN
     -- T3: the guard is scoped to Decisions. Ordinary artifacts share a thread_key by
     -- design -- that is what a thread IS -- so the index must not touch them.
     INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
-    VALUES ('pull_request', v_repo, '1', 'thread:1:pr-1');
+    VALUES ('pull_request', v_repo, '1', v_k1);
     INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
-    VALUES ('issue', v_repo, '2', 'thread:1:pr-1');
+    VALUES ('issue', v_repo, '2', v_k1);
     RAISE NOTICE 'T3 PASS: non-Decision nodes still share a thread freely';
 
     -- T4: a thread-less Decision is not caught by the partial index. It cannot pass the
@@ -60,18 +77,65 @@ BEGIN
     END;
 
     -- T5: the real-world repair. A Decision whose cluster was renamed by a merge must be
-    -- re-keyable in place, not blocked by the index it now conflicts with.
-    UPDATE node SET thread_key = 'thread:1:pr-2' WHERE id = v_a AND FALSE;  -- no-op guard
+    -- re-keyable in place, not blocked by the index it now conflicts with. This is what
+    -- 0009's own repair step does, and it is the operation the partial index is most
+    -- likely to obstruct by accident.
+    --
+    -- The UPDATE used to end `AND FALSE  -- no-op guard`, so the rename this check is
+    -- named for never happened. What ran was the global duplicate assertion that follows
+    -- it (now T9) -- a real check, but one T2 already makes, and not the one described.
+    -- Renaming into a FREE cluster is the case that must be allowed; renaming into an
+    -- OCCUPIED one is T6.
+    UPDATE node SET thread_key = v_k3 WHERE id = v_a;
+    SELECT EXISTS (SELECT 1 FROM node WHERE id = v_a AND thread_key = v_k3) INTO v_ok;
+    IF NOT v_ok THEN
+        v_failed := v_failed + 1;
+        RAISE WARNING 'T5 FAIL: re-keying a Decision into a free cluster did not take';
+    ELSE
+        RAISE NOTICE 'T5 PASS: a Decision can be re-keyed into a free cluster';
+    END IF;
+
+    -- T6: the same rename into an OCCUPIED cluster must still be refused. Without this,
+    -- T5 alone would pass just as happily against an index that had been dropped.
+    BEGIN
+        UPDATE node SET thread_key = v_k2 WHERE id = v_a;
+        v_failed := v_failed + 1;
+        RAISE WARNING 'T6 FAIL: a Decision was re-keyed onto a cluster that already had one';
+    EXCEPTION WHEN unique_violation THEN
+        RAISE NOTICE 'T6 PASS: re-keying onto an occupied cluster is refused';
+    END;
+
+    -- T7: 0011's constraint -- a Decision's thread_key must name its own repo. It has no
+    -- suite of its own, and it is what silently killed this file from the day it landed
+    -- (#55), so it is checked here: in the fixture it broke.
+    BEGIN
+        INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
+        VALUES ('decision', v_repo, 'wrong-repo', 'thread:999999:pr-1');
+        v_failed := v_failed + 1;
+        RAISE WARNING 'T7 FAIL: a Decision keyed to another repo was accepted';
+    EXCEPTION WHEN check_violation THEN
+        RAISE NOTICE 'T7 PASS: a Decision keyed to another repo is refused';
+    END;
+
+    -- T8: and that guard is scoped to Decisions. An ordinary artifact may legitimately
+    -- carry a thread_key naming a different repo id while a merge is in flight; only the
+    -- Decision -- the thing synthesis writes per repo -- is pinned.
+    INSERT INTO node (node_type, repo_node_id, external_id, thread_key)
+    VALUES ('pull_request', v_repo, '3', 'thread:999999:pr-1');
+    RAISE NOTICE 'T8 PASS: the repo-match guard does not touch non-Decision nodes';
+
+    -- T9: the invariant the whole file is about, asserted over the fixture and everything
+    -- else in the database.
     SELECT NOT EXISTS (
         SELECT 1 FROM node n JOIN decision d ON d.node_id = n.id
         WHERE n.thread_key IS NOT NULL
         GROUP BY n.repo_node_id, n.thread_key HAVING count(*) > 1
     ) INTO v_ok;
     IF v_ok THEN
-        RAISE NOTICE 'T5 PASS: no cluster holds more than one Decision';
+        RAISE NOTICE 'T9 PASS: no cluster holds more than one Decision';
     ELSE
         v_failed := v_failed + 1;
-        RAISE WARNING 'T5 FAIL: a cluster holds multiple Decisions';
+        RAISE WARNING 'T9 FAIL: a cluster holds multiple Decisions';
     END IF;
 
     IF v_failed > 0 THEN


### PR DESCRIPTION
Closes #55.

## The bug

`db/tests/0009_decision_identity_checks.sql` has been aborting on its **first INSERT** since
migration 0011 landed (#42, 2026-08-21). Exit code 3, all five checks dead:

```
ERROR:  new row for relation "node" violates check constraint "decision_thread_key_matches_repo"
DETAIL:  Failing row contains (2144, decision, 2143, thread:1:pr-1, ...).
```

The fixture creates its own repository node and captures the generated id in `v_repo`, then
wrote thread keys hard-coding repo `1`. 0011 added

```sql
CHECK (... thread_key LIKE 'thread:' || repo_node_id::text || ':%')
```

which is precisely the invariant the fixture violated. The constraint is right and the
fixture was wrong — but the file died at T1, so T2 through T5, including the
one-Decision-per-cluster guard that issue #25 was about, stopped running and stayed stopped.

Keys are now derived from `v_repo`. A fixture that states the repo id twice can disagree
with itself; one that derives it cannot.

## Two more defects, found only by making it run again

**T5 tested nothing.** It claimed to check that a Decision whose cluster was renamed by a
merge is re-keyable in place — the operation the partial index is most likely to obstruct by
accident — but its UPDATE ended `AND FALSE  -- no-op guard`. No rename happened. What
actually executed was the global duplicate assertion after it, which is a real check but the
one T2 already makes. T5 now performs the rename into a free cluster and asserts it took;
**T6** covers the rename into an occupied cluster, which must still be refused; the old
assertion survives as **T9**.

**0011's constraint had no test at all.** `db/tests/` has suites for 0002, 0005, 0006, 0008
and 0009 — none for 0011, though it is the thing that killed this file. **T7** asserts a
Decision keyed to another repo is refused; **T8** asserts the guard does not touch
non-Decision nodes, which share a `thread_key` by design.

## The checks are not vacuous

Dropping both guards inside a rolled-back transaction:

```
T1 PASS   T2 FAIL   T3 PASS   T4 PASS   T5 PASS
T6 FAIL   T7 FAIL   T8 PASS   T9 FAIL     ERROR: 4 check(s) failed
```

T2, T6, T7 and T9 catch it. T5 and T8 still pass, correctly — they test what must be
*allowed*, so a missing guard cannot make them fail.

## Why it went unnoticed, and the fix for that

There was no `.github/` directory. 94 Python tests and 35 SQL checks, run by hand from a
README block or not at all — while `test_every_migration_declares_a_sentinel` states in its
own comment that a missing sentinel "should break here, not in someone's terminal", which is
only true if something runs it.

`.github/workflows/ci.yml` runs the Python suite and all five SQL suites against Postgres 16,
on **Python 3.11 and 3.13** — both ends of the range `pyproject.toml` declares. The
Dockerfile pins only the top, and `tests/test_python_floor.py` exists precisely because that
gap once shipped `dg status` with f-string syntax no supported interpreter but the pinned one
could parse.

Migrations are applied via `migrate.apply_all` (not `dg init`, which also wants a GitHub
token) and then **re-applied**, so the documented "safe to re-run" claim is enforced rather
than asserted. `ON_ERROR_STOP=1` is set on every psql invocation — without it psql exits 0
on a suite that aborted, which is part of how this stayed invisible.

## Verification

Ran the whole CI flow locally against a scratch database first:

- 12 migrations applied from nothing; second pass applied nothing.
- Python suite: **94 tests, 91 passed, 3 skipped** (only the Docker-in-Docker floor tests).
- All five SQL suites green on a freshly migrated, otherwise empty database — which is what
  CI will have, and is not the same database the suites had ever been run against before.
- Against the real graph: same result, 0009 now reporting all 9 checks passing.

README's counts were stale — it advertised 68 checks and 53 standalone tests against an
actual 94 and 79 — and are corrected, with a note that a run missing `DATABASE_URL` and
Docker still prints `OK` while quietly skipping 15 tests, so a local pass and a complete
pass look identical.

## Not fixed here

- The Dockerfile installs `openai`, which nothing in `src/`, `tests/` or `eval/` imports and
  which is not in `pyproject.toml`'s dependencies. Possibly staged for planned work, so I
  left it; worth a decision either way.
- CI has never actually executed — this repository has no workflow history — so the first
  run on this PR is the real test of the workflow file. It is verified by local
  reconstruction, not by GitHub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PQRcncbERE44f7vungYL4
