### PR TITLE
Move CI off the deprecated Node 20 action runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,9 +56,9 @@ jobs:
       PGPASSWORD: dg
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python-version }}
 


### PR DESCRIPTION
Closes #57.

The first CI run (#56) passed and annotated itself:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to
> run on Node.js 24: `actions/checkout@v4`, `actions/setup-python@v5`.

Both were pinned a major version behind. `actions/checkout@v5` and `actions/setup-python@v6`
target Node 24 natively.

GitHub is forcing the old ones onto Node 24 for now, so this is a warning rather than a
failure — until that forcing is withdrawn. CI failing for a reason unrelated to the change
under test is the specific failure mode #55 was about, so it is worth not waiting for.

The run on this PR is the verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011PQRcncbERE44f7vungYL4