### PR TITLE
Make a failing SQL check fail the build (#62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -377,7 +377,7 @@ psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  9 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 94 tests
+DATABASE_URL=... python -m unittest discover -s tests               # 105 tests
 ```
 
 `.github/workflows/ci.yml` runs all of it on every push and pull request, against Postgres
@@ -385,14 +385,21 @@ DATABASE_URL=... python -m unittest discover -s tests               # 94 tests
 aborting on its first statement since migration 0011 added a CHECK its fixture violated,
 and all five of its checks were silently dead until something finally ran them (#55).
 
-All SQL suites run in a transaction and roll back. The Python suite runs 79 tests
+**A failing check now fails the run.** CI passes `ON_ERROR_STOP=1`, which turns a SQL
+*error* into a red build; a check that merely recorded `passed = false` was not an error,
+so four of the five suites printed `FAIL` inside a collapsed group and exited 0 — 30 of the
+39 checks could not turn the build red (#62). Each suite now prints its results table and
+then raises if anything failed, and `tests/test_sql_suites.py` asserts that every file in
+`db/tests/` does, so a suite added later cannot quietly arrive without it.
+
+All SQL suites run in a transaction and roll back. The Python suite runs 90 tests
 standalone. Setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 and 5 for the trace annotation. Docker adds 3 more that compile the whole package on the
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
 
-A run without those is still reported as `OK`, with 15 of the 94 quietly skipped — so a
+A run without those is still reported as `OK`, with 15 of the 105 quietly skipped — so a
 local pass and a complete pass look alike. CI sets both, and nothing is skipped there.
 
 Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell

--- a/db/tests/0002_rubric_checks.sql
+++ b/db/tests/0002_rubric_checks.sql
@@ -384,4 +384,21 @@ SELECT count(*) FILTER (WHERE passed)       AS passed,
        count(*)                             AS total
 FROM test_result;
 
+-- A failed check must fail the RUN, not merely appear in its output. CI invokes psql with
+-- ON_ERROR_STOP=1, which promotes a SQL *error* to a non-zero exit; a 'FAIL' row in the
+-- table above is not an error and left the job green (issue #62). The table is printed
+-- first and deliberately kept -- it is what makes the failure diagnosable -- and the raise
+-- comes after it, so the diagnosis survives the abort.
+DO $fail$
+DECLARE v_failed int; v_total int;
+BEGIN
+    SELECT count(*) FILTER (WHERE NOT passed), count(*) INTO v_failed, v_total
+    FROM test_result;
+    IF v_failed > 0 THEN
+        RAISE EXCEPTION '% of % check(s) failed', v_failed, v_total;
+    END IF;
+    RAISE NOTICE 'all % checks passed', v_total;
+END
+$fail$;
+
 ROLLBACK;

--- a/db/tests/0005_pending_reference_checks.sql
+++ b/db/tests/0005_pending_reference_checks.sql
@@ -119,4 +119,21 @@ SELECT count(*) FILTER (WHERE passed) AS passed,
        count(*) FILTER (WHERE NOT passed) AS failed, count(*) AS total
 FROM test_result;
 
+-- A failed check must fail the RUN, not merely appear in its output. CI invokes psql with
+-- ON_ERROR_STOP=1, which promotes a SQL *error* to a non-zero exit; a 'FAIL' row in the
+-- table above is not an error and left the job green (issue #62). The table is printed
+-- first and deliberately kept -- it is what makes the failure diagnosable -- and the raise
+-- comes after it, so the diagnosis survives the abort.
+DO $fail$
+DECLARE v_failed int; v_total int;
+BEGIN
+    SELECT count(*) FILTER (WHERE NOT passed), count(*) INTO v_failed, v_total
+    FROM test_result;
+    IF v_failed > 0 THEN
+        RAISE EXCEPTION '% of % check(s) failed', v_failed, v_total;
+    END IF;
+    RAISE NOTICE 'all % checks passed', v_total;
+END
+$fail$;
+
 ROLLBACK;

--- a/db/tests/0006_corroboration_checks.sql
+++ b/db/tests/0006_corroboration_checks.sql
@@ -205,4 +205,21 @@ SELECT count(*) FILTER (WHERE passed) AS passed,
        count(*) FILTER (WHERE NOT passed) AS failed, count(*) AS total
 FROM test_result;
 
+-- A failed check must fail the RUN, not merely appear in its output. CI invokes psql with
+-- ON_ERROR_STOP=1, which promotes a SQL *error* to a non-zero exit; a 'FAIL' row in the
+-- table above is not an error and left the job green (issue #62). The table is printed
+-- first and deliberately kept -- it is what makes the failure diagnosable -- and the raise
+-- comes after it, so the diagnosis survives the abort.
+DO $fail$
+DECLARE v_failed int; v_total int;
+BEGIN
+    SELECT count(*) FILTER (WHERE NOT passed), count(*) INTO v_failed, v_total
+    FROM test_result;
+    IF v_failed > 0 THEN
+        RAISE EXCEPTION '% of % check(s) failed', v_failed, v_total;
+    END IF;
+    RAISE NOTICE 'all % checks passed', v_total;
+END
+$fail$;
+
 ROLLBACK;

--- a/db/tests/0008_landing_checks.sql
+++ b/db/tests/0008_landing_checks.sql
@@ -157,4 +157,21 @@ SELECT count(*) FILTER (WHERE passed) AS passed,
        count(*) FILTER (WHERE NOT passed) AS failed, count(*) AS total
 FROM test_result;
 
+-- A failed check must fail the RUN, not merely appear in its output. CI invokes psql with
+-- ON_ERROR_STOP=1, which promotes a SQL *error* to a non-zero exit; a 'FAIL' row in the
+-- table above is not an error and left the job green (issue #62). The table is printed
+-- first and deliberately kept -- it is what makes the failure diagnosable -- and the raise
+-- comes after it, so the diagnosis survives the abort.
+DO $fail$
+DECLARE v_failed int; v_total int;
+BEGIN
+    SELECT count(*) FILTER (WHERE NOT passed), count(*) INTO v_failed, v_total
+    FROM test_result;
+    IF v_failed > 0 THEN
+        RAISE EXCEPTION '% of % check(s) failed', v_failed, v_total;
+    END IF;
+    RAISE NOTICE 'all % checks passed', v_total;
+END
+$fail$;
+
 ROLLBACK;

--- a/tests/test_sql_suites.py
+++ b/tests/test_sql_suites.py
@@ -1,0 +1,55 @@
+"""Every SQL suite must be able to fail the run (issue #62).
+
+CI invokes each file in `db/tests/` with `psql -v ON_ERROR_STOP=1`, which promotes a SQL
+*error* to a non-zero exit. A check that merely records `passed = false` in the results
+table is not an error: four of the five suites printed a `FAIL` row inside a collapsed CI
+group and exited 0, so 30 of the 39 advertised checks could not turn the build red.
+
+That is #55's failure one layer out — there, five checks were dead because the file aborted
+on its first statement and nothing ran them; here they run and cannot fail. Both are silent,
+and a suite that cannot fail is worth roughly what a suite nobody runs is worth.
+
+Standalone: reads the files, needs no database. The point is to catch a NEW suite written
+without the ending rather than to re-verify the four that have it, since the new one is the
+one nobody will think to check.
+"""
+
+from __future__ import annotations
+
+import unittest
+from pathlib import Path
+
+SUITES = sorted((Path(__file__).resolve().parent.parent / "db" / "tests").glob("*.sql"))
+
+
+class SqlSuiteFailureTest(unittest.TestCase):
+    def test_suites_are_discovered(self) -> None:
+        # A glob that matches nothing would make every assertion below vacuously true.
+        self.assertGreaterEqual(len(SUITES), 5, "no SQL suites found to check")
+
+    def test_every_suite_raises_on_a_failed_check(self) -> None:
+        for path in SUITES:
+            with self.subTest(suite=path.name):
+                self.assertIn(
+                    "RAISE EXCEPTION",
+                    path.read_text(encoding="utf-8"),
+                    f"{path.name} records check results but never raises, so a failing "
+                    "check would exit 0 and leave CI green",
+                )
+
+    def test_every_suite_rolls_back(self) -> None:
+        # The suites seed fixtures into the real database. They are safe to run against a
+        # populated graph only because each one ends by discarding its work; a file that
+        # forgot would quietly leave test nodes behind in whatever database CI or a
+        # contributor pointed it at.
+        for path in SUITES:
+            with self.subTest(suite=path.name):
+                self.assertIn(
+                    "ROLLBACK",
+                    path.read_text(encoding="utf-8"),
+                    f"{path.name} does not roll back",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #62.

CI runs every `db/tests/*.sql` with `ON_ERROR_STOP=1`, which promotes a SQL *error* to a
non-zero exit. A check that records `passed = false` in the results table is not an error.
Four of the five suites printed a `FAIL` row inside a collapsed `::group::` and exited 0,
so 30 of the 39 checks the README advertises could not turn the build red.

Verified rather than assumed. Inverting one assertion in `0002_rubric_checks.sql`:

```
 passed | failed | total
--------+--------+-------
      4 |      9 |    13
exit=0
```

and after this change, the same inverted file:

```
ERROR:  9 of 13 check(s) failed
exit=3
```

## What changed

`0009_decision_identity_checks.sql` already raised on a failed check. The other four now
share that ending: print the results table first — it is what makes a failure diagnosable —
then raise, so the diagnosis survives the abort. The raise aborts the transaction, which is
the rollback these files end with anyway.

`tests/test_sql_suites.py` pins the property for suites written later, which are the ones
nobody will think to check. It reads the files and needs no database, and also asserts each
one rolls back, since they seed fixtures into whatever database they are pointed at.

## Verification

All five suites pass unchanged against the populated flask graph, exit 0. The Python suite
is 105 tests, nothing skipped with `DATABASE_URL` set and Docker present.

README's Python count was already stale at 94 before this change (79 standalone); corrected
to 105 / 90.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CKgTDYCV3TwH1yzhxwscQ