### PR TITLE
Let a queued cross-reference be retracted (#61)

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,41 @@ Rate limiting is first-class: a 12-month backfill of a repo flask's size sits cl
 enough to the 5,000 req/hour budget that exhaustion is expected. The client stops
 cleanly at a configurable floor and the next run resumes.
 
+### The reference queue can now be un-said
+
+A `#N` whose target is not in the graph yet is queued rather than dropped (issue #3) —
+issues and PRs are walked updated-ascending, so a PR can be processed before the issue it
+closes. The queue was append-and-resolve: the only thing that ever happened to a row was
+becoming an edge. So a reference that was **wrong when it was queued stayed queued, armed,
+indefinitely**, and would resolve the moment its target happened to arrive.
+
+That is not hypothetical. Stopping the parser reading closing keywords out of HTML comments
+(#59) could not reach the row it was about — `<!-- Fixes #11 -->`, template boilerplate
+above a docs typo fix, waiting to become a `closes` edge, which is Validation-grade evidence
+under the §5.1 rubric, if the window ever widened far enough to ingest flask#11 (a 2010
+issue).
+
+`--reconcile` now **retracts** a queued reference when re-reading the same stored body with
+the current extractors no longer yields it (#61). The test is about the parser, not the
+target, and that distinction is the whole design:
+
+| the row | verdict |
+|---|---|
+| the current parser no longer reads it from the body | retracted |
+| the target is outside the 12-month window | **left open** — unresolvable is not wrong |
+| the number belongs to another repository (author's error) | left open — the parser still reads it |
+| the source body has no stored text | left open — silence is not evidence |
+
+On the flask graph that retracts exactly **1 of 26** open references: the `#11` above, and
+nothing else.
+
+Retraction is a column, not a `DELETE`, and the difference is the answer to the obvious
+objection — that a parser *regression* would now withdraw good references rather than
+merely fail to add them. The row stays with the reason it was withdrawn, `dg status` counts
+it, and the open-row unique index excludes retracted rows so fixing the parser and
+re-running `--reconcile` queues the reference again. A wrong retraction is visible and
+reversible; a wrong `DELETE` would be neither.
+
 **No Decision nodes are created by ingestion.** Phase 1 asserts artifacts and the links
 between them; asserting that a *decision* occurred is gated by the rubric and belongs to
 a later phase.
@@ -377,7 +412,8 @@ psql "$DATABASE_URL" -f db/tests/0005_pending_reference_checks.sql  #  4 checks
 psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  9 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 105 tests
+psql "$DATABASE_URL" -f db/tests/0013_reference_retraction_checks.sql # 6 checks
+DATABASE_URL=... python -m unittest discover -s tests               # 112 tests
 ```
 
 `.github/workflows/ci.yml` runs all of it on every push and pull request, against Postgres
@@ -393,13 +429,13 @@ then raises if anything failed, and `tests/test_sql_suites.py` asserts that ever
 `db/tests/` does, so a suite added later cannot quietly arrive without it.
 
 All SQL suites run in a transaction and roll back. The Python suite runs 90 tests
-standalone. Setting `DATABASE_URL` adds 12 integration tests — 7 for the traversal
+standalone. Setting `DATABASE_URL` adds 19 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
-and 5 for the trace annotation. Docker adds 3 more that compile the whole package on the
+5 for the trace annotation, and 7 for reference retraction. Docker adds 3 more that compile the whole package on the
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
 
-A run without those is still reported as `OK`, with 15 of the 105 quietly skipped — so a
+A run without those is still reported as `OK`, with 22 of the 112 quietly skipped — so a
 local pass and a complete pass look alike. CI sets both, and nothing is skipped there.
 
 Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell

--- a/db/migrations/0013_pending_reference_retraction.sql
+++ b/db/migrations/0013_pending_reference_retraction.sql
@@ -1,0 +1,105 @@
+-- 0013: let a queued reference be withdrawn (issue #61).
+--
+-- `pending_reference` has been append-and-resolve since 0005. A row is written when a
+-- parsed reference names an artifact that is not in the graph, and the only thing that
+-- ever happens to it afterwards is resolution into an edge. Nothing deletes one, nothing
+-- expires one, and nothing re-derives the queue from the stored bodies. So a reference
+-- that was WRONG when it was queued stays queued, armed, indefinitely.
+--
+-- The case that prompted this: PR #59 stopped the parser reading closing keywords out of
+-- HTML comments, because flask's PR 6106 carries `<!-- Fixes #11 -->` template boilerplate
+-- above a docs typo fix and GitHub honours no such thing. The fix stopped the parser
+-- producing that reference. It could not reach the row already sitting in the queue --
+-- which would resolve into a `closes` edge, Validation-tier evidence under the §5.1
+-- rubric, the moment a widened window ingested flask#11 (a 2010 issue).
+--
+-- WHY A COLUMN AND NOT A DELETE. The queue's value is that it does not silently drop
+-- things: 0005 exists because 9 of 30 closing keywords had been lost to a lookup that
+-- found nothing and moved on. Deleting a row to fix that would be the same disappearance
+-- with better intentions, and it would make the one genuinely dangerous case -- a parser
+-- REGRESSION retracting good references -- both invisible and irreversible. A retracted
+-- row stays, carrying the reason it was withdrawn, and can be counted, read, and argued
+-- with. If the retraction was wrong, fixing the parser and re-running re-queues it.
+--
+-- WHAT RETRACTION MEANS, EXACTLY. Not "this reference cannot be resolved" -- an
+-- out-of-window target is unresolvable and perfectly correct, and 5 of the 7 open `closes`
+-- references on flask are exactly that. It means "the current parser, reading the same
+-- stored body, no longer produces this reference at all". That is a statement about the
+-- extractor, not about the target, and it is the only one that can be checked mechanically
+-- without guessing at intent.
+
+BEGIN;
+
+ALTER TABLE pending_reference
+    ADD COLUMN retracted_at     timestamptz,
+    ADD COLUMN retraction_reason text;
+
+ALTER TABLE pending_reference
+    ADD CONSTRAINT pending_reference_retraction_consistent
+        CHECK ((retracted_at IS NULL) = (retraction_reason IS NULL)),
+    -- A row cannot be both. Resolution created an edge; retraction says the reference
+    -- should never have existed. Allowing both would leave the edge standing with the
+    -- queue asserting its source was withdrawn.
+    ADD CONSTRAINT pending_reference_not_both_resolved_and_retracted
+        CHECK (NOT (retracted_at IS NOT NULL AND resolved_at IS NOT NULL));
+
+COMMENT ON COLUMN pending_reference.retracted_at IS
+    'When this reference was withdrawn because the current parser no longer produces it '
+    'from the source body. Distinct from unresolved-and-unresolvable: an out-of-window '
+    'target is correct and stays open.';
+COMMENT ON COLUMN pending_reference.retraction_reason IS
+    'Why it was withdrawn, in text, so a retraction can be audited and disputed rather '
+    'than merely observed.';
+
+-- The open-row uniqueness must exclude retracted rows, or a reference the parser later
+-- produces again could never be re-queued -- the retracted row would sit in the index
+-- forever, silently swallowing the INSERT that ON CONFLICT DO NOTHING makes look like a
+-- success. That is what makes a mistaken retraction recoverable, so it is load-bearing
+-- rather than tidy. `_enqueue_reference`'s ON CONFLICT clause names this same predicate;
+-- the two must be changed together or the index is not inferred.
+DROP INDEX pending_reference_open_uidx;
+CREATE UNIQUE INDEX pending_reference_open_uidx
+    ON pending_reference (src_node_id, ref_number, edge_type)
+    WHERE resolved_at IS NULL AND retracted_at IS NULL;
+
+DROP INDEX pending_reference_open_idx;
+CREATE INDEX pending_reference_open_idx
+    ON pending_reference (repo_node_id, ref_number)
+    WHERE resolved_at IS NULL AND retracted_at IS NULL;
+
+-- The status view counted every unresolved row as open. A retracted row is unresolved and
+-- must not be counted as waiting, but it also must not vanish -- the whole argument for a
+-- column over a DELETE is that a wrong retraction stays visible. So it gets its own count
+-- alongside, in the same view, rather than a second view nobody would think to read.
+--
+-- `retracted` is appended after the existing columns rather than slotted in beside the
+-- counts it belongs with: CREATE OR REPLACE VIEW can add columns at the end and nothing
+-- else, and DROP-then-CREATE would silently take any dependent view with it. Readability
+-- of the SELECT list is not worth that.
+CREATE OR REPLACE VIEW v_pending_reference_status AS
+SELECT p.repo_node_id,
+       p.edge_type,
+       count(*) FILTER (WHERE p.retracted_at IS NULL)          AS open_refs,
+       count(*) FILTER (WHERE p.retracted_at IS NULL
+                          AND t.id IS NOT NULL)                AS resolvable_now,
+       count(*) FILTER (WHERE p.retracted_at IS NULL
+                          AND t.id IS NULL)                    AS target_outside_window,
+       max(p.attempts) FILTER (WHERE p.retracted_at IS NULL)   AS max_attempts,
+       count(*) FILTER (WHERE p.retracted_at IS NOT NULL)      AS retracted
+FROM pending_reference p
+LEFT JOIN node t
+       ON t.repo_node_id = p.repo_node_id
+      AND t.external_id = p.ref_number::text
+      AND t.node_type IN ('issue', 'pull_request')
+WHERE p.resolved_at IS NULL
+GROUP BY p.repo_node_id, p.edge_type;
+
+COMMENT ON TABLE pending_reference IS
+    'Queue of parsed cross-references whose target was not yet in the graph. Drained at '
+    'the end of every ingestion run (issue #3). An unresolved row is not necessarily a '
+    'bug: a reference to an artifact outside the backfill window can never resolve, and '
+    'stays here as a visible record rather than being silently dropped. A row the current '
+    'parser no longer produces from its source body can be retracted (issue #61) -- '
+    'withdrawn but retained, with its reason, and re-queueable if the parser changes back.';
+
+COMMIT;

--- a/db/tests/0013_reference_retraction_checks.sql
+++ b/db/tests/0013_reference_retraction_checks.sql
@@ -1,0 +1,195 @@
+-- 0013_reference_retraction_checks.sql
+-- Constraint and view behaviour for withdrawn queue rows (issue #61).
+-- Transactional; rolls back. Companion to 0005_pending_reference_checks.sql.
+--
+-- These check the SCHEMA half of retraction: that a withdrawn row cannot also claim
+-- resolution, that it stops counting as open, and -- the load-bearing one -- that the same
+-- reference can be queued again afterwards, which is what makes a mistaken retraction
+-- recoverable rather than permanent. The half that decides WHICH rows to withdraw is
+-- Python, and is tested in tests/test_reference_retraction.py against the real parser.
+
+BEGIN;
+
+CREATE TEMP TABLE test_result (
+    seq    int GENERATED ALWAYS AS IDENTITY,
+    name   text,
+    expect text,
+    passed boolean,
+    detail text
+);
+
+CREATE FUNCTION pg_temp.mk(p_type node_type, p_ext text, p_repo bigint DEFAULT NULL)
+RETURNS bigint LANGUAGE sql AS $fn$
+    INSERT INTO node (node_type, external_id, repo_node_id)
+    VALUES (p_type, p_ext, p_repo) RETURNING id;
+$fn$;
+
+CREATE FUNCTION pg_temp.enqueue(p_repo bigint, p_src bigint, p_ref int, p_type edge_type)
+RETURNS bigint LANGUAGE sql AS $fn$
+    INSERT INTO pending_reference (repo_node_id, src_node_id, ref_number, edge_type, extractor)
+    VALUES (p_repo, p_src, p_ref, p_type, 'test_fixture')
+    RETURNING id;
+$fn$;
+
+CREATE FUNCTION pg_temp.retract(p_id bigint) RETURNS void LANGUAGE sql AS $fn$
+    UPDATE pending_reference
+    SET retracted_at = now(), retraction_reason = 'test fixture'
+    WHERE id = p_id;
+$fn$;
+
+
+-- T1  A retraction must say why. The reason is what makes a withdrawal auditable instead
+--     of merely observable, so the schema refuses one without it.
+DO $t$
+DECLARE repo bigint; pr bigint; p bigint; ok boolean; err text;
+BEGIN
+    repo := pg_temp.mk('repository', 't1-repo');
+    pr   := pg_temp.mk('pull_request', 't1-pr', repo);
+    p    := pg_temp.enqueue(repo, pr, 11, 'closes');
+    BEGIN
+        UPDATE pending_reference SET retracted_at = now() WHERE id = p;
+        ok := true;
+    EXCEPTION WHEN check_violation THEN ok := false; err := SQLERRM;
+    END;
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T1 retraction without a reason refused', 'rejected', NOT ok, err);
+END;
+$t$;
+
+
+-- T2  Resolved and retracted are mutually exclusive. Resolution created an edge;
+--     retraction says the reference should never have existed. Both at once would leave
+--     the edge standing while the queue disowned its source.
+DO $t$
+DECLARE repo bigint; pr bigint; iss bigint; e bigint; p bigint; ok boolean; err text;
+BEGIN
+    repo := pg_temp.mk('repository', 't2-repo');
+    pr   := pg_temp.mk('pull_request', 't2-pr', repo);
+    iss  := pg_temp.mk('issue', 't2-issue', repo);
+    p    := pg_temp.enqueue(repo, pr, 42, 'closes');
+
+    INSERT INTO edge (src_node_id, dst_node_id, edge_type, tag, evidence_tier, extractor)
+    VALUES (pr, iss, 'closes', 'explicit', 'explicit', 'test_fixture') RETURNING id INTO e;
+    UPDATE pending_reference SET resolved_at = now(), resolved_edge_id = e WHERE id = p;
+
+    BEGIN
+        PERFORM pg_temp.retract(p);
+        ok := true;
+    EXCEPTION WHEN check_violation THEN ok := false; err := SQLERRM;
+    END;
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T2 retracting a resolved row refused', 'rejected', NOT ok, err);
+END;
+$t$;
+
+
+-- T3  The same reference may be queued again after retraction. This is the property that
+--     makes a wrong retraction recoverable: fix the parser, re-run --reconcile, and the
+--     row comes back. Without it the retracted row would sit in the open-row unique index
+--     forever and swallow the re-insert, which ON CONFLICT DO NOTHING would report as
+--     success.
+DO $t$
+DECLARE repo bigint; pr bigint; p bigint; ok boolean; err text;
+BEGIN
+    repo := pg_temp.mk('repository', 't3-repo');
+    pr   := pg_temp.mk('pull_request', 't3-pr', repo);
+    p    := pg_temp.enqueue(repo, pr, 77, 'closes');
+    PERFORM pg_temp.retract(p);
+    BEGIN
+        PERFORM pg_temp.enqueue(repo, pr, 77, 'closes');
+        ok := true;
+    EXCEPTION WHEN others THEN ok := false; err := SQLERRM;
+    END;
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T3 re-queue allowed after retraction', 'accepted', ok, err);
+END;
+$t$;
+
+
+-- T4  Uniqueness still holds among rows that are actually open. Retraction widens the
+--     index predicate, and a widening that also let duplicates in would be a regression of
+--     0005's T1 dressed as a feature.
+DO $t$
+DECLARE repo bigint; pr bigint; ok boolean; err text;
+BEGIN
+    repo := pg_temp.mk('repository', 't4-repo');
+    pr   := pg_temp.mk('pull_request', 't4-pr', repo);
+    PERFORM pg_temp.enqueue(repo, pr, 88, 'closes');
+    BEGIN
+        PERFORM pg_temp.enqueue(repo, pr, 88, 'closes');
+        ok := true;
+    EXCEPTION WHEN unique_violation THEN ok := false; err := SQLERRM;
+    END;
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T4 duplicate open reference still refused', 'rejected', NOT ok, err);
+END;
+$t$;
+
+
+-- T5  A retracted row stops counting as open but does not disappear. Both halves matter:
+--     counting it as waiting would overstate the queue, and dropping it from the view
+--     would undo the reason retraction is a column rather than a DELETE.
+DO $t$
+DECLARE repo bigint; pr bigint; p bigint; v_open int; v_retracted int;
+BEGIN
+    repo := pg_temp.mk('repository', 't5-repo');
+    pr   := pg_temp.mk('pull_request', 't5-pr', repo);
+    PERFORM pg_temp.enqueue(repo, pr, 101, 'closes');   -- stays open
+    p := pg_temp.enqueue(repo, pr, 102, 'closes');      -- withdrawn
+    PERFORM pg_temp.retract(p);
+
+    SELECT open_refs, retracted INTO v_open, v_retracted
+    FROM v_pending_reference_status WHERE repo_node_id = repo AND edge_type = 'closes';
+
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T5 view separates open from retracted', '1 and 1',
+            v_open = 1 AND v_retracted = 1,
+            format('open_refs=%s retracted=%s', v_open, v_retracted));
+END;
+$t$;
+
+
+-- T6  A retracted row whose target IS in the graph must not be reported as resolvable.
+--     `resolvable_now` reads as "the drain has not run yet" (0005 T4), and a withdrawn row
+--     that the drain will never touch again must not masquerade as work outstanding.
+DO $t$
+DECLARE repo bigint; pr bigint; p bigint; v_now int;
+BEGIN
+    repo := pg_temp.mk('repository', 't6-repo');
+    pr   := pg_temp.mk('pull_request', 't6-pr', repo);
+    PERFORM pg_temp.mk('issue', '4242', repo);          -- the target is present
+    p := pg_temp.enqueue(repo, pr, 4242, 'closes');
+    PERFORM pg_temp.retract(p);
+
+    SELECT resolvable_now INTO v_now
+    FROM v_pending_reference_status WHERE repo_node_id = repo AND edge_type = 'closes';
+
+    INSERT INTO test_result (name, expect, passed, detail)
+    VALUES ('T6 retracted row is not resolvable_now', '0',
+            v_now = 0, format('resolvable_now=%s', v_now));
+END;
+$t$;
+
+
+SELECT seq, CASE WHEN passed THEN 'PASS' ELSE 'FAIL' END AS result, name, expect,
+       left(regexp_replace(COALESCE(detail, ''), '\s+', ' ', 'g'), 60) AS detail
+FROM test_result ORDER BY seq;
+
+SELECT count(*) FILTER (WHERE passed) AS passed,
+       count(*) FILTER (WHERE NOT passed) AS failed, count(*) AS total
+FROM test_result;
+
+-- A failed check must fail the RUN, not merely appear in its output (issue #62).
+DO $fail$
+DECLARE v_failed int; v_total int;
+BEGIN
+    SELECT count(*) FILTER (WHERE NOT passed), count(*) INTO v_failed, v_total
+    FROM test_result;
+    IF v_failed > 0 THEN
+        RAISE EXCEPTION '% of % check(s) failed', v_failed, v_total;
+    END IF;
+    RAISE NOTICE 'all % checks passed', v_total;
+END
+$fail$;
+
+ROLLBACK;

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -633,6 +633,40 @@ def cmd_status(args: argparse.Namespace) -> int:
         for line in _cursor_lines(cursors):
             print(line)
 
+    # The reference queue, where the two things that look alike are worth telling apart:
+    # a row waiting for a target that has not been ingested is the bounded window working,
+    # while a row the parser no longer produces is an obsolete claim that would fire if
+    # that target ever arrived (issue #61). Printed because a queue nobody can see is how
+    # the one in #61 stayed loaded for two months.
+    refs_rows = conn.execute(
+        """
+        SELECT r.external_id AS repo, s.edge_type::text AS edge_type,
+               s.open_refs, s.target_outside_window, s.retracted
+        FROM v_pending_reference_status s
+        JOIN node r ON r.id = s.repo_node_id
+        WHERE s.open_refs > 0 OR s.retracted > 0
+        ORDER BY r.external_id, s.edge_type
+        """
+    ).fetchall()
+    if refs_rows:
+        heading("Cross-references not yet linked")
+        for r in refs_rows:
+            print(f"  {r['repo']}  {bold(str(r['open_refs']))} {r['edge_type']} queued")
+            if r["target_outside_window"]:
+                print(
+                    dim(
+                        f"    {r['target_outside_window']} name a target the graph does "
+                        "not hold; an out-of-window reference never resolves, correctly"
+                    )
+                )
+            if r["retracted"]:
+                print(
+                    dim(
+                        f"    {r['retracted']} retracted — the current parser no longer "
+                        "reads them from the source body"
+                    )
+                )
+
     decisions = conn.execute("SELECT count(*) AS n FROM decision").fetchone()["n"]
     threads = conn.execute(
         "SELECT count(DISTINCT thread_key) AS n FROM node WHERE thread_key IS NOT NULL"

--- a/src/decision_graph/extractors.py
+++ b/src/decision_graph/extractors.py
@@ -201,6 +201,61 @@ def extract_issue_or_pr(ctx: Context, payload: dict[str, Any]) -> int:
     return node_id
 
 
+def _parsed_references(
+    text: str | None, repo: str | None, source_type: str
+) -> list[tuple[int, str, str]]:
+    """Every reference the CURRENT extractors read out of one body.
+
+    Returns (number, edge_type, extractor). One definition, three callers: the inline
+    extraction path, `reconcile_stored_bodies`, and `retract_stale_references`. Retraction
+    withdraws a queued row precisely when this function no longer yields it, so the two
+    must be the same code or a retraction would be measuring a second implementation's
+    disagreement with the first rather than a parser change (issue #61).
+    """
+    return [
+        *((n, "closes", f"{source_type}_closing_keyword") for n in refs.closing_refs(text, repo)),
+        *(
+            (n, "references", f"{source_type}_issue_mention")
+            for n in refs.mentioned_refs(text, repo)
+        ),
+    ]
+
+
+# Where a queued reference can have come from. Both `_enqueue_reference` call sites parse
+# one of these three bodies, so this is the complete set of text a retraction can re-read.
+# `source_type` matches _link_body_refs: an issue body and a PR body are both "pr_body",
+# which is #12's split between an author's prose and a committer's, not a node-type label.
+_BODY_SOURCES = (
+    ("pull_request", "body", "pr_body"),
+    ("issue", "body", "pr_body"),
+    ("commit", "message", "commit_message"),
+)
+
+
+def _stored_bodies(ctx: Context):
+    """Yield (node_id, text, source_type) for every stored body that has text.
+
+    Scoped to this run's repository. `_lookup_by_number` resolves "#N" against one repo's
+    numbers, so re-parsing another repository's bodies here would offer them this repo's
+    artifacts to link to — the cross-repo edge #42 went and closed elsewhere.
+
+    Bodies with no text are skipped rather than yielded as empty. The difference matters
+    only to retraction, and there it is the whole safety margin: "this body no longer says
+    that" is evidence, while "there is no body here to read" is not, and a NULL that came
+    from an ingestion gap would otherwise read as a licence to withdraw the reference.
+    """
+    for table, column, source_type in _BODY_SOURCES:
+        rows = ctx.conn.execute(
+            f"SELECT d.node_id AS id, d.{column} AS text "  # noqa: S608 - fixed literals
+            f"FROM {table} d JOIN node n ON n.id = d.node_id "
+            "WHERE n.repo_node_id = %s",
+            (ctx.repo_node_id,),
+        ).fetchall()
+        for row in rows:
+            if row["text"]:
+                yield row["id"], row["text"], source_type
+
+
 def _link_body_refs(
     ctx: Context,
     src_node_id: int,
@@ -224,16 +279,9 @@ def _link_body_refs(
     `closes` edge's provenance says which artifact it came from — a PR author's claim and a
     committer's claim are different evidence (issue #12).
     """
-    for number, edge_type, extractor in [
-        *(
-            (n, "closes", f"{source_type}_closing_keyword")
-            for n in refs.closing_refs(text, ctx.settings.target_repo)
-        ),
-        *(
-            (n, "references", f"{source_type}_issue_mention")
-            for n in refs.mentioned_refs(text, ctx.settings.target_repo)
-        ),
-    ]:
+    for number, edge_type, extractor in _parsed_references(
+        text, ctx.settings.target_repo, source_type
+    ):
         target = _lookup_by_number(ctx, number)
         if target is None:
             _enqueue_reference(
@@ -292,7 +340,8 @@ def _enqueue_reference(
         INSERT INTO pending_reference (repo_node_id, src_node_id, ref_number, edge_type,
                                        extractor, source_ref, observed_at)
         VALUES (%s, %s, %s, %s, %s, %s, %s)
-        ON CONFLICT (src_node_id, ref_number, edge_type) WHERE resolved_at IS NULL
+        ON CONFLICT (src_node_id, ref_number, edge_type)
+            WHERE resolved_at IS NULL AND retracted_at IS NULL
         DO NOTHING
         """,
         (
@@ -315,12 +364,16 @@ def drain_pending_references(ctx: Context) -> tuple[int, int]:
     is never fetched — so the bounded backfill window stays bounded. A reference to an
     artifact genuinely outside the window simply never resolves, which is correct, and
     stays visible as a row with a climbing attempts count.
+
+    Retracted rows are excluded (issue #61). A reference the current parser no longer
+    produces must not resolve into an edge on the run where its target finally arrives —
+    that arrival is exactly when an obsolete row does its damage.
     """
     rows = ctx.conn.execute(
         """
         SELECT id, src_node_id, ref_number, edge_type, extractor, source_ref, observed_at
         FROM pending_reference
-        WHERE repo_node_id = %s AND resolved_at IS NULL
+        WHERE repo_node_id = %s AND resolved_at IS NULL AND retracted_at IS NULL
         ORDER BY id
         """,
         (ctx.repo_node_id,),
@@ -379,54 +432,112 @@ def reconcile_stored_bodies(ctx: Context) -> int:
     text. Also a safety net if a parser rule is ever widened — reconcile picks up what
     the new rule now matches, without re-polling GitHub.
     """
-    sources = (
-        ("pull_request", "SELECT node_id AS id, body AS text FROM pull_request"),
-        ("issue", "SELECT node_id AS id, body AS text FROM issue"),
-        ("commit", "SELECT node_id AS id, message AS text FROM commit"),
-    )
-
-    source_type_by_label = {
-        "pull_request": "pr_body",
-        "issue": "pr_body",
-        "commit": "commit_message",
-    }
-
     queued = 0
-    for label, query in sources:
-        source_type = source_type_by_label[label]
-        for row in ctx.conn.execute(query).fetchall():
-            text = row["text"]
-            if not text:
+    for src_node_id, text, source_type in _stored_bodies(ctx):
+        for number, edge_type, extractor in _parsed_references(
+            text, ctx.settings.target_repo, source_type
+        ):
+            target = _lookup_by_number(ctx, number)
+            if target is not None:
+                # Idempotent: an edge that already exists is refreshed, not doubled.
+                before = ctx.stats.edges
+                _link(ctx, src_node_id, target, edge_type, extractor, None, None)
+                queued += ctx.stats.edges - before
                 continue
-            for number, edge_type, extractor in [
-                *(
-                    (n, "closes", f"{source_type}_closing_keyword")
-                    for n in refs.closing_refs(text, ctx.settings.target_repo)
-                ),
-                *(
-                    (n, "references", f"{source_type}_issue_mention")
-                    for n in refs.mentioned_refs(text, ctx.settings.target_repo)
-                ),
-            ]:
-                target = _lookup_by_number(ctx, number)
-                if target is not None:
-                    # Idempotent: an edge that already exists is refreshed, not doubled.
-                    before = ctx.stats.edges
-                    _link(ctx, row["id"], target, edge_type, extractor, None, None)
-                    queued += ctx.stats.edges - before
-                    continue
-                _enqueue_reference(
-                    ctx,
-                    src_node_id=row["id"],
-                    number=number,
-                    edge_type=edge_type,
-                    extractor=extractor,
-                    source_ref=None,
-                    observed_at=None,
-                )
-        log.info("reconciled %s bodies", label)
+            _enqueue_reference(
+                ctx,
+                src_node_id=src_node_id,
+                number=number,
+                edge_type=edge_type,
+                extractor=extractor,
+                source_ref=None,
+                observed_at=None,
+            )
 
+    log.info("reconciled stored bodies: %s reference(s) linked", queued)
     return queued
+
+
+def retract_stale_references(ctx: Context) -> int:
+    """Withdraw queued references the current parser no longer produces (issue #61).
+
+    The queue is append-and-resolve. A row written under an older parser rule stays armed
+    forever, and resolves into a real edge the moment its target happens to arrive — which
+    is how `<!-- Fixes #11 -->`, HTML-commented template boilerplate that GitHub honours as
+    nothing at all, remained a `closes` edge waiting to happen after #59 stopped the parser
+    reading it.
+
+    The test is deliberately narrow, and it is a claim about the extractor rather than
+    about the target: retract iff re-reading the SAME stored body with the CURRENT
+    extractors no longer yields that (number, edge_type). It says nothing about whether the
+    reference could ever resolve. An out-of-window target is unresolvable and entirely
+    correct, and stays open — 5 of flask's 7 open `closes` references are that case.
+
+    Three things bound the damage a parser regression could do here, because the obvious
+    objection to this function is that a broken parser now deletes good references rather
+    than merely failing to add them:
+
+    1. **Retraction is a column, not a DELETE.** The row stays, with its reason, and is
+       counted in `v_pending_reference_status`.
+    2. **It is reversible.** The open-row unique index excludes retracted rows (migration
+       0013), so fixing the parser and re-running `--reconcile` queues the reference again.
+    3. **Silence is not evidence.** A body with no stored text is skipped, so a missing
+       body cannot be read as the parser declining to produce anything.
+
+    Returns the number retracted. Runs only under `--reconcile`, which is the command that
+    already re-derives from stored bodies and costs no API calls.
+    """
+    produced: dict[int, set[tuple[int, str]]] = {}
+    for src_node_id, text, source_type in _stored_bodies(ctx):
+        produced.setdefault(src_node_id, set()).update(
+            (number, edge_type)
+            for number, edge_type, _ in _parsed_references(
+                text, ctx.settings.target_repo, source_type
+            )
+        )
+
+    rows = ctx.conn.execute(
+        """
+        SELECT id, src_node_id, ref_number, edge_type, extractor, source_ref
+        FROM pending_reference
+        WHERE repo_node_id = %s AND resolved_at IS NULL AND retracted_at IS NULL
+        ORDER BY id
+        """,
+        (ctx.repo_node_id,),
+    ).fetchall()
+
+    retracted = 0
+    for row in rows:
+        current = produced.get(row["src_node_id"])
+        if current is None:
+            # No text to re-read. Not evidence either way; see point 3 above.
+            ctx.stats.note_skip("pending_ref_source_body_absent")
+            continue
+        if (row["ref_number"], row["edge_type"]) in current:
+            continue
+
+        reason = (
+            f"re-parsing the source body with the current extractors no longer yields "
+            f"{row['edge_type']} #{row['ref_number']} (was {row['extractor']})"
+        )
+        ctx.conn.execute(
+            "UPDATE pending_reference SET retracted_at = now(), retraction_reason = %s "
+            "WHERE id = %s",
+            (reason, row["id"]),
+        )
+        retracted += 1
+        log.info(
+            "retracted queued %s #%s from %s: %s",
+            row["edge_type"],
+            row["ref_number"],
+            row["source_ref"] or f"node {row['src_node_id']}",
+            reason,
+        )
+
+    log.info(
+        "stale references: %s retracted, %s still open", retracted, len(rows) - retracted
+    )
+    return retracted
 
 
 def _lookup_by_number(ctx: Context, number: int) -> int | None:

--- a/src/decision_graph/migrate.py
+++ b/src/decision_graph/migrate.py
@@ -68,6 +68,9 @@ SENTINELS: dict[str, str] = {
     "0012": """EXISTS (SELECT 1 FROM information_schema.columns
                 WHERE table_name = 'ingestion_cursor' AND column_name = 'phase'
                   AND is_nullable = 'YES')""",
+    "0013": """EXISTS (SELECT 1 FROM information_schema.columns
+                WHERE table_name = 'pending_reference'
+                  AND column_name = 'retracted_at')""",
 }
 
 

--- a/src/decision_graph/run.py
+++ b/src/decision_graph/run.py
@@ -56,6 +56,12 @@ def ingest(
             log.info("--- reconcile stored bodies ---")
             extractors.reconcile_stored_bodies(ctx)
             conn.commit()
+            # Retraction is the same re-derivation read the other way round: reconcile adds
+            # what the current parser now produces, this withdraws what it no longer does
+            # (issue #61). It runs here rather than on every ingestion because it is only
+            # meaningful against stored text, and --reconcile is the pass that re-reads it.
+            extractors.retract_stale_references(ctx)
+            conn.commit()
 
         for resource in resources:
             log.info("--- %s ---", resource)

--- a/tests/test_reference_retraction.py
+++ b/tests/test_reference_retraction.py
@@ -1,0 +1,199 @@
+"""Which queued references get withdrawn, and which must not (issue #61).
+
+`db/tests/0013_reference_retraction_checks.sql` covers the schema half — that a withdrawal
+is auditable, exclusive with resolution, and reversible. This covers the decision half:
+`retract_stale_references` withdraws a row iff re-reading the same stored body with the
+current extractors no longer yields it.
+
+The distinction under test is the one the issue turns on. "The parser no longer produces
+this" and "this can never resolve" look alike in the queue and are opposite verdicts: the
+first is an obsolete row that will fire the moment its target arrives, the second is the
+bounded window working correctly. Getting them the wrong way round either leaves the
+loaded row in place or deletes five perfectly good references to out-of-window issues.
+
+Requires a live database, and rolls back. Skipped when DATABASE_URL is unset.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+
+from decision_graph import extractors
+from decision_graph.config import Settings
+
+DSN = os.environ.get("DATABASE_URL")
+REPO = "pallets/flask"
+
+
+@unittest.skipUnless(DSN, "DATABASE_URL not set")
+class ReferenceRetractionTest(unittest.TestCase):
+    def setUp(self) -> None:
+        from decision_graph import db
+
+        self.conn = db.connect(DSN)
+        self.conn.execute("SET CONSTRAINTS ALL DEFERRED")
+        self._seq = 0
+        self.repo_node_id = self.node("repository", external_id=f"fixture-repo-{id(self)}")
+        self.ctx = extractors.Context(
+            conn=self.conn,
+            # Retraction reads stored text and never calls GitHub — that is what makes it
+            # safe to run on --reconcile, which is documented as costing no API calls. A
+            # None client is therefore not a shortcut here; a client this code could reach
+            # for would be the bug.
+            client=None,  # type: ignore[arg-type]
+            settings=Settings(database_url=DSN, github_token="unused", target_repo=REPO),
+            repo_node_id=self.repo_node_id,
+        )
+
+    def tearDown(self) -> None:
+        self.conn.rollback()
+        self.conn.close()
+
+    # -- fixture helpers ---------------------------------------------------
+
+    def node(self, node_type: str, *, external_id: str | None = None) -> int:
+        self._seq += 1
+        repo = getattr(self, "repo_node_id", None)
+        row = self.conn.execute(
+            "INSERT INTO node (node_type, external_id, repo_node_id) VALUES (%s, %s, %s) "
+            "RETURNING id",
+            (
+                node_type,
+                external_id or f"fixture-{id(self)}-{self._seq}",
+                repo if node_type != "repository" else None,
+            ),
+        ).fetchone()
+        return row["id"]
+
+    def pull_request(self, number: int, body: str | None) -> int:
+        node_id = self.node("pull_request", external_id=str(number))
+        self.conn.execute(
+            "INSERT INTO pull_request (node_id, number, state, body) VALUES (%s, %s, %s, %s)",
+            (node_id, number, "closed", body),
+        )
+        return node_id
+
+    def enqueue(self, src: int, ref_number: int, edge_type: str = "closes") -> int:
+        row = self.conn.execute(
+            """
+            INSERT INTO pending_reference (repo_node_id, src_node_id, ref_number,
+                                           edge_type, extractor)
+            VALUES (%s, %s, %s, %s, 'test_fixture') RETURNING id
+            """,
+            (self.repo_node_id, src, ref_number, edge_type),
+        ).fetchone()
+        return row["id"]
+
+    def state(self, pending_id: int) -> tuple[bool, str | None]:
+        row = self.conn.execute(
+            "SELECT retracted_at, retraction_reason FROM pending_reference WHERE id = %s",
+            (pending_id,),
+        ).fetchone()
+        return row["retracted_at"] is not None, row["retraction_reason"]
+
+    # -- the case the issue is about ---------------------------------------
+
+    def test_reference_only_present_in_an_html_comment_is_retracted(self) -> None:
+        # flask PR 6106, reduced: commented-out template scaffolding above a real change.
+        # #59 stopped the parser reading it; the row it had already queued stayed armed.
+        pr = self.pull_request(6106, "<!-- Fixes #11 -->\n\nFix a typo in the docs.")
+        stale = self.enqueue(pr, 11)
+
+        self.assertEqual(extractors.retract_stale_references(self.ctx), 1)
+
+        retracted, reason = self.state(stale)
+        self.assertTrue(retracted)
+        self.assertIn("#11", reason or "")
+
+    def test_reference_the_parser_still_produces_survives(self) -> None:
+        pr = self.pull_request(6110, "Fixes #5200 — real closing keyword, visible text.")
+        live = self.enqueue(pr, 5200)
+
+        self.assertEqual(extractors.retract_stale_references(self.ctx), 0)
+        self.assertFalse(self.state(live)[0])
+
+    def test_out_of_window_target_is_not_retracted(self) -> None:
+        # The failure mode this function must not have. #5199 is a genuine closing
+        # reference to an issue outside the 12-month window: unresolvable, and correct.
+        # Retracting it would be reading "cannot resolve" as "was never produced".
+        pr = self.pull_request(6111, "Fixes #5199")
+        out_of_window = self.enqueue(pr, 5199)
+
+        extractors.retract_stale_references(self.ctx)
+
+        self.assertFalse(self.state(out_of_window)[0])
+
+    def test_edge_type_must_match_not_just_the_number(self) -> None:
+        # The body mentions 4242 but does not close it. A queued `closes` for that number
+        # is a different claim from the `references` the parser now produces, and the
+        # weaker edge standing in for the stronger one is exactly the substitution the
+        # §5.1 rubric would then read as Validation.
+        pr = self.pull_request(6112, "Related to #4242, but not fixed here.")
+        wrong_type = self.enqueue(pr, 4242, "closes")
+        right_type = self.enqueue(pr, 4242, "references")
+
+        self.assertEqual(extractors.retract_stale_references(self.ctx), 1)
+        self.assertTrue(self.state(wrong_type)[0])
+        self.assertFalse(self.state(right_type)[0])
+
+    def test_a_body_with_no_text_is_not_evidence(self) -> None:
+        # A NULL body cannot distinguish "the author removed it" from "we never stored
+        # it", so it licenses nothing. Silence is not the parser declining to produce.
+        pr = self.pull_request(6113, None)
+        unknown = self.enqueue(pr, 999)
+
+        self.assertEqual(extractors.retract_stale_references(self.ctx), 0)
+        self.assertFalse(self.state(unknown)[0])
+
+    def test_retraction_is_reversible_by_re_reconciling(self) -> None:
+        # The recovery path for a parser regression: withdraw a reference, restore the
+        # rule that produces it, and the row comes back. If the open-row unique index
+        # still covered retracted rows, the re-enqueue would be swallowed by ON CONFLICT
+        # DO NOTHING and report success while changing nothing.
+        pr = self.pull_request(6114, "<!-- Fixes #12 -->")
+        self.enqueue(pr, 12)
+        self.assertEqual(extractors.retract_stale_references(self.ctx), 1)
+
+        extractors._enqueue_reference(
+            self.ctx,
+            src_node_id=pr,
+            number=12,
+            edge_type="closes",
+            extractor="test_fixture",
+            source_ref=None,
+            observed_at=None,
+        )
+
+        open_rows = self.conn.execute(
+            "SELECT count(*) AS n FROM pending_reference WHERE src_node_id = %s "
+            "AND ref_number = 12 AND resolved_at IS NULL AND retracted_at IS NULL",
+            (pr,),
+        ).fetchone()
+        self.assertEqual(open_rows["n"], 1, "a retracted reference must be re-queueable")
+
+    def test_a_retracted_reference_never_resolves_into_an_edge(self) -> None:
+        # The whole point. The damage an obsolete row does happens on the run where its
+        # target finally arrives, so the drain must not pick it up afterwards.
+        pr = self.pull_request(6115, "<!-- Fixes #13 -->")
+        self.enqueue(pr, 13)
+        extractors.retract_stale_references(self.ctx)
+
+        target = self.node("issue", external_id="13")
+        self.conn.execute(
+            "INSERT INTO issue (node_id, number, state) VALUES (%s, 13, 'closed')",
+            (target,),
+        )
+
+        resolved, still_pending = extractors.drain_pending_references(self.ctx)
+
+        self.assertEqual(resolved, 0)
+        edges = self.conn.execute(
+            "SELECT count(*) AS n FROM edge WHERE src_node_id = %s AND dst_node_id = %s",
+            (pr, target),
+        ).fetchone()
+        self.assertEqual(edges["n"], 0, "a withdrawn reference became an edge anyway")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #61.

## The choice, since the issue asked for a second opinion first

Option (1), re-derivation under `--reconcile`, narrowed to one mechanical test:

> retract a queued row iff re-reading the **same stored body** with the **current
> extractors** no longer yields that `(number, edge_type)`.

That is a statement about the parser, not about the target, and it is what keeps the cases
that must not move out of scope:

| the row | verdict |
|---|---|
| the current parser no longer reads it from the body | **retracted** |
| the target is outside the 12-month window (`#5199`, `#5200`) | left open — unresolvable is not wrong |
| the number belongs to another repository (`#3168`, `#3193`, `#58254`) | left open — the parser still reads it |
| the source body has no stored text | left open — silence is not evidence |

Option (2), expiry by age or attempts, is rejected for the reason the issue already gives:
time is the wrong axis. An out-of-window reference is not wrong, it is unreachable, and it
becomes resolvable the moment the window moves. Option (3) leaves a known-loaded queue.

**The objection to (1) — that a parser regression would now delete good references rather
than merely fail to add them — is answered structurally, not by care:**

1. **Retraction is a column, not a `DELETE`.** The row stays, with the reason it was
   withdrawn, and is counted in `v_pending_reference_status` and in `dg status`.
2. **It is reversible.** The open-row unique index excludes retracted rows, so fixing the
   parser and re-running `--reconcile` queues the reference again. `0013` T3 pins that:
   without the index change, `ON CONFLICT DO NOTHING` would swallow the re-insert and
   report success while changing nothing.
3. **Silence is not evidence.** A body with no stored text is skipped, so a NULL from an
   ingestion gap cannot read as the parser declining to produce anything.

A wrong retraction is visible and reversible; a wrong `DELETE` would be neither.

## Measured against the real graph

```
open before: 26   retracted: 1

  56 closes #11  https://github.com/pallets/flask/pull/6106
     reason: re-parsing the source body with the current extractors no longer yields
             closes #11 (was pr_body_closing_keyword)
```

Exactly the row #61 is about. The other 6 open `closes` and all 19 `references` are
untouched.

## Also in here

- **`_parsed_references()` is now the single definition** of what the extractors read from a
  body, shared by the inline extraction path, `reconcile_stored_bodies`, and retraction.
  Retraction measures a parser *change* only if it is the same parser — two implementations
  would measure their own disagreement instead.
- **`_stored_bodies()` is scoped to the run's repository**, which `reconcile_stored_bodies`
  was not. `_lookup_by_number` resolves `#N` against one repository's numbers, so re-parsing
  another repository's bodies offered them *this* repository's artifacts to link to — #42's
  failure one caller over. Not hypothetical: the development database holds a second repo,
  and that is how it was noticed.
- **`dg status` prints the reference queue**, separating "waiting for a target the graph
  does not hold" from "withdrawn". A queue nobody can see is how the row in #61 stayed
  loaded for two months (the same argument as #49).

## Verification

- migration 0013 applies to the populated database, and a second pass is a no-op
- `db/tests/0013_reference_retraction_checks.sql` — 6 checks, all pass
- `tests/test_reference_retraction.py` — 7 integration tests
- full suite: **112 tests, nothing skipped** with `DATABASE_URL` set and Docker present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CKgTDYCV3TwH1yzhxwscQ