### PR TITLE
Make dg query explain itself, not just print its traversal (#69)

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,8 +71,70 @@ Every menu choice maps to one of these, so you can skip the menu once you know t
 .\dg.ps1 query "#5898" --mode impact --depth 2
 ```
 
+An answer states what the graph holds, grades the evidence, shows the traversal that
+produced it, and links every artifact it names:
+
+```
+Why did this happen?   'change default redirect code to 303'
+
+  starting from  issue #5895  change default redirect code to 303
+                 exact title match
+
+  What the graph says
+    issue #5895 "change default redirect code to 303" motivated the decision in this thread
+        that decision is reconstructed, implemented by PR #5898, merged 2026-01-25
+
+  evidence: explicit - stated in the repository itself, a closing keyword, a review, a commit list
+
+  Evidence trail  (1 path)
+  [1] == explicit  1 hop
+      issue #5895 - change default redirect code to 303
+       \- motivated  [explicit]
+      decision - change default redirect code to 303
+          reconstructed, implemented by PR #5898, merged 2026-01-25
+
+  Check it on GitHub
+    issue #5895              https://github.com/pallets/flask/issues/5895
+    pull request #5898       https://github.com/pallets/flask/pull/5898
+```
+
+**The summary sentence is generated from the graph, not by a model.** A Decision with a
+`motivated_by` and an `implemented_by` edge determines that sentence completely; writing it
+is templating, and nothing there is an inference. `dg ask` is the command that involves a
+model, and it prints this same trace beside its prose.
+
+Three things about that output are deliberate:
+
+- **Artifacts are named as GitHub names them.** The trace used to print `issue:620`, a
+  database primary key. The number and the URL have been stored on every node since the
+  first migration and were printed on none of them, while §9's entire method is a human
+  opening the artifact and comparing it to the claim (#69).
+- **`-v` shows node ids and the extractor behind each edge.** Moved, not removed: they are
+  what you query the graph with directly once something looks wrong.
+- **The credited implementer is named and linked**, with its merge date. A Why-walk stops at
+  the Decision and never reaches the pull request that did the work, so the only number a
+  reader used to see was the one inside the `thread_key` — which names the *cluster*, and for
+  6 of 15 Decisions names a pull request that was abandoned (#19).
+
+A refusal is treated as a result, because it is one — 8 of the 18 §9 outcomes are refusals:
+
+```
+  No answer - and that is a result, not a failure
+
+    Nothing in the ingested window records why this happened. The rubric needs
+    a motivating issue and merged work in the same conversation; a change made
+    without an issue leaves nothing to reconstruct a decision from.
+
+    engine: no path found, explicit or inferred
+    the inferred fallback was tried and also found nothing
+
+  What to try
+    - widen the walk:      --depth 3
+    ...
+```
+
 `ingest` and `query` forward any flag they do not recognise to the underlying tools, so
-`--months`, `--resources`, `--max-pages`, `--as-of` and `--limit` all still work.
+`--months`, `--resources`, `--max-pages`, `--as-of`, `--limit` and `--all` all still work.
 
 ### What to expect
 
@@ -460,7 +522,7 @@ psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  9 checks
 psql "$DATABASE_URL" -f db/tests/0013_reference_retraction_checks.sql # 6 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 127 tests
+DATABASE_URL=... python -m unittest discover -s tests               # 146 tests
 ```
 
 `.github/workflows/ci.yml` runs all of it on every push and pull request, against Postgres
@@ -475,14 +537,14 @@ so four of the five suites printed `FAIL` inside a collapsed group and exited 0 
 then raises if anything failed, and `tests/test_sql_suites.py` asserts that every file in
 `db/tests/` does, so a suite added later cannot quietly arrive without it.
 
-All SQL suites run in a transaction and roll back. The Python suite runs 105 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 124 tests
 standalone. Setting `DATABASE_URL` adds 19 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 5 for the trace annotation, and 7 for reference retraction. Docker adds 3 more that compile the whole package on the
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
 
-A run without those is still reported as `OK`, with 22 of the 127 quietly skipped — so a
+A run without those is still reported as `OK`, with 22 of the 146 quietly skipped — so a
 local pass and a complete pass look alike. CI sets both, and nothing is skipped there.
 
 Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -737,7 +737,7 @@ def cmd_ask(args: argparse.Namespace, extra: list[str]) -> int:
     reads identically whether it rests on four corroborated edges or one inferred guess
     (issue #65). The trace is the answer; the paragraph is a reading of it.
     """
-    from . import explain, db, query, retrieval, reasoning
+    from . import explain, db, query, retrieval, reasoning, trace
 
     print(f"Parsing intent for: {args.question!r}")
     try:
@@ -759,15 +759,22 @@ def cmd_ask(args: argparse.Namespace, extra: list[str]) -> int:
         return 1
 
     c = candidates[0]
-    print(f"Found candidate: node:{c.node_id} {c.node_type} \"{(c.title or '')[:56]}\"\n")
+    print(f"Found candidate: {trace.ref(c.node_type, c.external_id)} \"{(c.title or '')[:56]}\"\n")
     print("Traversing the graph...\n")
     answer = reasoning.reason(conn, c.node_id, reasoning.Mode(mode))
+    # Read the Decision facts before closing: they are a second query against the same
+    # connection, and the whole point of them is that a Why-walk stops at the Decision and
+    # never reaches the pull request that did the work (#19).
+    annotations, statuses, links = query._decision_facts(conn, answer)
     conn.close()
 
-    # The evidence, in the same form `dg query` prints it, tier marks and all. `sys.stdout`
-    # is passed rather than left to render's default, which binds at import and so ignores
-    # any later redirection -- including the one the test for this uses.
-    query.render(answer, sys.stdout)
+    # The evidence, in the same form `dg query` prints it -- one renderer, so the prose and
+    # the trace beside it cannot describe the answer differently. `sys.stdout` is passed
+    # rather than left to a default, which would bind at import and ignore any later
+    # redirection, including the one the test for this uses.
+    query.render_answer(
+        answer, annotations=annotations, statuses=statuses, links=links, out=sys.stdout
+    )
 
     try:
         explanation = explain.summarize_answer(args.question, answer)

--- a/src/decision_graph/evaluation.py
+++ b/src/decision_graph/evaluation.py
@@ -32,7 +32,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
-from . import db, reasoning, retrieval
+from . import db, reasoning, retrieval, trace
 from .reasoning import Mode
 
 log = logging.getLogger(__name__)
@@ -80,69 +80,14 @@ class QueryResult:
     notes: str | None = None
 
 
-# A Decision carries the motivating issue's title and sits under a thread_key naming its
-# cluster. That key is chosen by `threads._rank` — PR-preferring, then lowest number —
-# purely so two ingestion orders produce the same key. It is a stable LABEL, not a claim
-# about which pull request did the work, and when a change took two attempts it names the
-# ABANDONED one: decision 928 sits in `thread:30:pr-5867`, but 5867 was never merged and
-# PR 5899 is the credited implementer.
-#
-# A Why-walk reaching a Decision across `motivated_by` stops there and never traverses
-# `implemented_by`, so the only PR number a reader saw was the wrong one (issue #19).
-# The graph was right; the report was misleading — which is worse than it sounds, because
-# it makes a stale label and a stale edge look identical on the page. Adjudication depends
-# on telling those apart.
-DECISION_FACTS_SQL = """
-SELECT d.node_id,
-       im.node_type   AS implementer_type,
-       im.external_id AS implementer_ref,
-       pr.merged_at
-FROM decision d
-LEFT JOIN edge e  ON e.src_node_id = d.node_id
-                 AND e.edge_type   = 'implemented_by'
-                 AND e.valid_to IS NULL
-LEFT JOIN node im ON im.id = e.dst_node_id
-LEFT JOIN pull_request pr ON pr.node_id = im.id
-WHERE d.node_id = ANY(%s)
-ORDER BY d.node_id, im.external_id
-"""
-
-
-def _format_implementer(row: dict[str, Any]) -> str:
-    kind = row["implementer_type"]
-    ref = row["implementer_ref"]
-    if kind == "commit":
-        return f"commit {ref[:7]}"
-    if kind != "pull_request":
-        return f"{kind} {ref}"
-    # Merge state is spelled out rather than implied. An unmerged implementer should not
-    # be able to sit quietly in a trace — post-#17 it cannot exist, and this is how a
-    # regression would announce itself instead of reading as an ordinary path.
-    when = f"merged {row['merged_at']:%Y-%m-%d}" if row["merged_at"] else "NOT MERGED"
-    return f"PR {ref}, {when}"
-
-
-def decision_annotations(conn, node_ids: list[int]) -> dict[int, str]:
-    """Map Decision node ids to a short statement of what the graph credits them to."""
-    if not node_ids:
-        return {}
-
-    grouped: dict[int, list[dict[str, Any]]] = {}
-    for row in conn.execute(DECISION_FACTS_SQL, (sorted(set(node_ids)),)).fetchall():
-        grouped.setdefault(row["node_id"], []).append(row)
-
-    notes: dict[int, str] = {}
-    for node_id, rows in grouped.items():
-        credited = [r for r in rows if r["implementer_ref"]]
-        if not credited:
-            # Unreachable while the rubric holds. Surfaced rather than skipped: a Decision
-            # asserting nothing is the single most important thing to show an adjudicator.
-            notes[node_id] = "no current implementer"
-            continue
-        # Every current implementer, not the first. A LIMIT 1 here would have concealed
-        # the double-implementer bug that the #17 fix introduced and then repaired.
-        notes[node_id] = "implemented by " + "; ".join(_format_implementer(r) for r in credited)
-    return notes
+# What a Decision is credited to, and how a node is named, both live in `trace` now: this
+# worksheet and `dg query` render the same answer for the same reader, and an adjudicator
+# comparing one against the other is doing the job §9 exists for. Two implementations would
+# drift precisely there (issue #69). The names are kept bound here because they were part of
+# this module's surface and the tests address them by it.
+DECISION_FACTS_SQL = trace.DECISION_FACTS_SQL
+_format_implementer = trace.format_implementer
+decision_annotations = trace.decision_annotations
 
 
 def _describe(

--- a/src/decision_graph/explain.py
+++ b/src/decision_graph/explain.py
@@ -31,6 +31,7 @@ import json
 import os
 import sys
 
+from . import trace
 from .reasoning import Answer, Mode
 
 MODEL = "meta/llama-3.1-70b-instruct"
@@ -139,22 +140,23 @@ def render_paths(answer: Answer) -> str:
     evidence grade would be asking the model to describe a claim while withholding how
     well founded it is.
     """
+    def name(path, node_id: int) -> str:
+        ref = path.ref(node_id)
+        # The GitHub identity, not the database key. A summary is only checkable if the
+        # artifacts it cites are the ones a reader can open, and a model handed `issue:620`
+        # can only write `issue:620` back (issue #69).
+        return f"{trace.ref(ref.node_type, ref.external_id)} \"{ref.title or ''}\""
+
     blocks: list[str] = []
     for i, path in enumerate(answer.paths, 1):
         lines = [f"Path {i} (evidence tier={path.tier}, depth={path.depth}):"]
-        start = path.node_ids[0]
-        lines.append(
-            f"  Start: {path.types.get(start, '?')}:{start} \"{path.titles.get(start, '')}\""
-        )
+        lines.append(f"  Start: {name(path, path.node_ids[0])}")
         for step, node_id in zip(path.steps, path.node_ids[1:]):
             direction = "->" if step.to_node_id == node_id else "<-"
             lines.append(
                 f"    {direction} {step.edge_type} [{step.evidence_tier}] ({step.extractor})"
             )
-            lines.append(
-                f"    Node: {path.types.get(node_id, '?')}:{node_id} "
-                f"\"{path.titles.get(node_id, '')}\""
-            )
+            lines.append(f"    Node: {name(path, node_id)}")
         blocks.append("\n".join(lines))
     return "\n\n".join(blocks)
 

--- a/src/decision_graph/query.py
+++ b/src/decision_graph/query.py
@@ -2,8 +2,13 @@
 
 A thin view over Retrieval + Reasoning. It holds no logic of its own — per §6, no
 feature may introduce engine-level behaviour, and formatting a path is presentation.
-The trace it prints is the path data Engine 2 already computed, which is what
-Explainability Mode (Phase 4) will render properly.
+Rendering lives in `render.py`, shared with `dg ask` so the two cannot disagree about
+what an answer looks like.
+
+By default this answers the question once, from the best-matching artifact, and says how
+many other candidates it declined. It used to run every candidate and print three
+separately-headed traversals of what is usually one finding seen from three nodes, which
+left the reader to work out that they were the same (issue #69). `--all` restores that.
 """
 
 from __future__ import annotations
@@ -14,47 +19,63 @@ import os
 import sys
 from datetime import datetime
 
-from . import db, reasoning, retrieval
-from .reasoning import Answer, Mode, Path
+from . import db, reasoning, render, retrieval, trace
+from .reasoning import Answer, Mode
 
-TIER_MARK = {"explicit": "==", "corroborated": "++", "inferred": "~~"}
+# Kept as a module attribute because it was one, and `from .query import TIER_MARK` is the
+# kind of import that exists in someone's script.
+TIER_MARK = trace.TIER_MARK
+
+# How a retrieval tier reads. `exact` and `fuzzy` are the system's words for how the start
+# node was found, and a reader deciding whether the tool understood them needs to know
+# which happened -- a fuzzy match on a paraphrase is a different claim from a title hit.
+_MATCH_MEANING = {
+    "exact": "exact title match",
+    "identifier": "matched by identifier",
+    "prefix": "title starts with your query",
+    "fuzzy": "closest text match",
+}
 
 
-def _label(path: Path, node_id: int) -> str:
-    node_type = path.types.get(node_id) or "?"
-    title = (path.titles.get(node_id) or "").strip()
-    if len(title) > 58:
-        title = title[:55] + "..."
-    return f"{node_type}:{node_id}" + (f' "{title}"' if title else "")
+def render_answer(
+    answer: Answer,
+    *,
+    annotations: dict[int, str] | None = None,
+    statuses: dict[int, str] | None = None,
+    links: dict[str, str] | None = None,
+    verbose: bool = False,
+    out=None,
+) -> None:
+    render.render(
+        answer, annotations=annotations, statuses=statuses, links=links,
+        verbose=verbose, out=out,
+    )
 
 
-def render(answer: Answer, out=sys.stdout) -> None:
-    header = f"{answer.mode.value.upper()}  start=node:{answer.start_node_id}"
-    print(header, file=out)
-    print("-" * len(header), file=out)
+def _decision_facts(
+    conn, answer: Answer
+) -> tuple[dict[int, str], dict[int, str], dict[str, str]]:
+    """What the graph credits each Decision in this answer to (issues #19, #69).
 
-    if not answer.found:
-        print(f"  no answer — {answer.explanation}", file=out)
-        return
-
-    if answer.used_inferred_fallback:
-        # Never let this pass silently: an inferred answer is a different kind of claim.
-        print("  !! INFERRED FALLBACK — no explicit path existed", file=out)
-    print(f"  {answer.explanation}\n", file=out)
-
-    for i, path in enumerate(sorted(answer.paths, key=lambda p: (p.depth, p.target_id)), 1):
-        print(f"  [{i}] tier={path.tier}  depth={path.depth}", file=out)
-        print(f"      {_label(path, path.node_ids[0])}", file=out)
-        for step, node_id in zip(path.steps, path.node_ids[1:]):
-            mark = TIER_MARK.get(step.evidence_tier, "??")
-            arrow = "->" if step.to_node_id == node_id else "<-"
-            print(
-                f"        {mark}{arrow} {step.edge_type} [{step.evidence_tier}]"
-                f" ({step.extractor})",
-                file=out,
-            )
-            print(f"      {_label(path, node_id)}", file=out)
-        print(file=out)
+    A Why-walk stops at the Decision and never traverses `implemented_by`, so without this
+    lookup the only pull request a reader sees is the one inside the `thread_key` -- which
+    names the cluster, and for 6 of 15 Decisions names a pull request that never merged.
+    The evaluation report has printed this since #19; the command people actually run did
+    not.
+    """
+    ids = [
+        nid
+        for path in answer.paths
+        for nid in path.node_ids
+        if path.ref(nid).node_type == "decision"
+    ]
+    if not ids:
+        return {}, {}, {}
+    return (
+        trace.decision_annotations(conn, ids),
+        trace.decision_statuses(conn, ids),
+        trace.decision_links(conn, ids),
+    )
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -72,10 +93,18 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--limit", type=int, default=3, help="candidate start nodes to try")
     parser.add_argument(
+        "--all",
+        action="store_true",
+        help="answer from every candidate, not just the best match",
+    )
+    parser.add_argument(
         "--repo", help="owner/name — restrict candidates to this repo (needed once more "
         "than one repo is ingested into the same database)"
     )
-    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument(
+        "-v", "--verbose", action="store_true",
+        help="show node ids and the extractor behind each edge",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(
@@ -102,19 +131,45 @@ def main(argv: list[str] | None = None) -> int:
         conn, args.query, repo_node_id=repo_node_id, limit=args.limit
     )
     if not candidates:
-        print(f"no candidate start node matched {args.query!r}", file=sys.stderr)
+        print(f"Nothing in the graph matches {args.query!r}.", file=sys.stderr)
+        print(file=sys.stderr)
+        print("  Retrieval tries exact title, then identifier, then prefix, then fuzzy —", file=sys.stderr)
+        print("  so a miss means no artifact in the ingested window resembles this.", file=sys.stderr)
+        print("  Try `#5898` or a commit sha, or check `dg status` for what is ingested.", file=sys.stderr)
         return 1
 
-    print(f"candidates for {args.query!r}:")
-    for c in candidates:
-        print(f"  node:{c.node_id:<5} {c.node_type:<13} {c.match:<11} {(c.title or '')[:56]}")
+    question = "Why did this happen?" if args.mode == Mode.WHY.value else "What does this affect?"
+    print(render.bold(f"{question}   {render.dim(repr(args.query))}"))
     print()
 
-    for c in candidates:
+    chosen = candidates if args.all else candidates[:1]
+    for c in chosen:
+        how = _MATCH_MEANING.get(c.match, c.match)
+        print(
+            f"  starting from  {render.bold(trace.ref(c.node_type, c.external_id))}"
+            f"  {(c.title or '')[:56]}"
+        )
+        print(render.dim(f"                 {how}"))
+        print()
+
         answer = reasoning.reason(
             conn, c.node_id, Mode(args.mode), max_depth=args.depth, as_of=as_of
         )
-        render(answer)
+        annotations, statuses, links = _decision_facts(conn, answer)
+        render_answer(
+            answer, annotations=annotations, statuses=statuses, links=links,
+            verbose=args.verbose,
+        )
+
+    skipped = len(candidates) - len(chosen)
+    if skipped:
+        print(render.dim(
+            f"  {render.plural(skipped, 'other candidate')} matched this query — "
+            "`--all` answers from each of them."
+        ))
+        for c in candidates[len(chosen):]:
+            print(render.dim(f"    {trace.ref(c.node_type, c.external_id)}  {(c.title or '')[:52]}"))
+        print()
 
     conn.close()
     return 0

--- a/src/decision_graph/reasoning.py
+++ b/src/decision_graph/reasoning.py
@@ -93,14 +93,43 @@ class Step:
     source_ref: str | None
 
 
+@dataclass(frozen=True)
+class NodeRef:
+    """What a path knows about one node it passed through.
+
+    `external_id` and `url` are carried because every renderer needs them and none had
+    them: a trace printed `issue:620` while the graph held `#5895` and the issue's URL
+    (issue #69). They are read in the same query as the title, so this costs nothing.
+    """
+
+    node_type: str | None = None
+    title: str | None = None
+    external_id: str | None = None
+    url: str | None = None
+
+
 @dataclass
 class Path:
     """One route from the start node to a reached node, with its evidence trail."""
 
     node_ids: list[int]
     steps: list[Step]
-    titles: dict[int, str] = field(default_factory=dict)
-    types: dict[int, str] = field(default_factory=dict)
+    nodes: dict[int, NodeRef] = field(default_factory=dict)
+
+    # `titles` and `types` were two parallel dicts, and adding external_id and url would
+    # have made four. They stay as views over `nodes` rather than being deleted, because
+    # every caller reads them by `.get()` and a rename would touch three renderers and the
+    # evaluation runner to no benefit.
+    @property
+    def titles(self) -> dict[int, str | None]:
+        return {nid: n.title for nid, n in self.nodes.items()}
+
+    @property
+    def types(self) -> dict[int, str | None]:
+        return {nid: n.node_type for nid, n in self.nodes.items()}
+
+    def ref(self, node_id: int) -> NodeRef:
+        return self.nodes.get(node_id, NodeRef())
 
     @property
     def target_id(self) -> int:
@@ -231,9 +260,15 @@ def _walk(
         ).fetchall()
     }
     nodes = {
-        n["id"]: (n["node_type"], n["title"])
+        n["id"]: NodeRef(
+            node_type=n["node_type"],
+            title=n["title"],
+            external_id=n["external_id"],
+            url=n["url"],
+        )
         for n in conn.execute(
-            "SELECT id, node_type, title FROM node WHERE id = ANY(%s)", (list(node_ids),)
+            "SELECT id, node_type, title, external_id, url FROM node WHERE id = ANY(%s)",
+            (list(node_ids),),
         ).fetchall()
     }
 
@@ -241,8 +276,7 @@ def _walk(
         Path(
             node_ids=list(r["path_nodes"]),
             steps=[edges[eid] for eid in r["path_edges"]],
-            titles={nid: (nodes.get(nid) or (None, None))[1] for nid in r["path_nodes"]},
-            types={nid: (nodes.get(nid) or (None, None))[0] for nid in r["path_nodes"]},
+            nodes={nid: nodes.get(nid, NodeRef()) for nid in r["path_nodes"]},
         )
         for r in rows
     ]

--- a/src/decision_graph/render.py
+++ b/src/decision_graph/render.py
@@ -1,0 +1,280 @@
+"""Turning an Engine 2 answer into something a person can read (issue #69).
+
+The old renderer printed the traversal and stopped: `issue:620`, `tier=explicit`,
+`==<- motivated_by (synthesis_closes_cluster)`. Every one of those is true and none of them
+is an answer. A reader had to know that 620 is a primary key, that `#5895` is the number
+they actually wanted, that a `motivated_by` edge means the issue asked for the change, and
+that `explicit` is the strongest tier rather than the weakest.
+
+This module is the presentation layer that was missing. Three rules hold it in place:
+
+1. **The summary is generated from the graph, never from a model.** A Decision with a
+   `motivated_by` and an `implemented_by` edge determines an English sentence completely;
+   producing it is templating, not inference. `dg ask` already follows this rule for
+   refusals (#65), and the reason is the same — this system's whole value is that its
+   claims are checkable, and a sentence nobody can trace back is not.
+2. **Nothing is removed to make room.** Node ids, extractor names and edge directions are
+   what an adjudicator uses; they move behind `--verbose` rather than disappearing, and the
+   evidence tier moves *forward* because it is the most important thing on the page.
+3. **A refusal gets the same care as an answer.** 8 of the 18 §9 outcomes are refusals. An
+   answer that says only "no path found" tells the reader nothing about whether they asked
+   the wrong question or found a real gap in the graph.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from . import trace
+from .reasoning import Answer, Mode, Path
+
+_COLOR = sys.stdout.isatty() and os.environ.get("NO_COLOR") is None
+
+
+def _c(code: str, text: str) -> str:
+    return f"\033[{code}m{text}\033[0m" if _COLOR else text
+
+
+def bold(t: str) -> str:
+    return _c("1", t)
+
+
+def dim(t: str) -> str:
+    return _c("2", t)
+
+
+def _tier_colour(tier: str, text: str) -> str:
+    # Inferred is the one a reader must not skim past, so it is the one that is yellow.
+    return {"corroborated": _c("36", text), "inferred": _c("33", text)}.get(
+        tier, _c("32", text)
+    )
+
+
+# How each edge type reads in a sentence, in both directions. The graph stores a direction
+# and a type; a reader needs a verb. These are translations of the edge, not additions to
+# it -- `motivated_by` from a Decision to an issue means that issue motivated the decision,
+# which is what the edge says and all it says.
+_EDGE_PHRASE = {
+    ("motivated_by", "out"): "was motivated by",
+    ("motivated_by", "in"): "motivated",
+    ("implemented_by", "out"): "was implemented by",
+    ("implemented_by", "in"): "implemented",
+    ("implements", "out"): "implements",
+    ("implements", "in"): "is implemented by",
+    ("closes", "out"): "closes",
+    ("closes", "in"): "was closed by",
+    ("references", "out"): "references",
+    ("references", "in"): "is referenced by",
+    ("reviewed", "out"): "reviewed",
+    ("reviewed", "in"): "was reviewed by",
+    ("discussed_in", "out"): "was discussed in",
+    ("discussed_in", "in"): "hosted discussion of",
+    ("deployed_by", "out"): "shipped in",
+    ("deployed_by", "in"): "shipped",
+    ("supersedes", "out"): "supersedes",
+    ("supersedes", "in"): "is superseded by",
+    ("superseded_by", "out"): "is superseded by",
+    ("superseded_by", "in"): "supersedes",
+    ("created", "out"): "created",
+    ("created", "in"): "was created by",
+    ("depends_on", "out"): "depends on",
+    ("depends_on", "in"): "is depended on by",
+}
+
+
+def phrase(edge_type: str, forward: bool) -> str:
+    return _EDGE_PHRASE.get((edge_type, "out" if forward else "in"), edge_type)
+
+
+def label(path: Path, node_id: int, *, verbose: bool = False) -> str:
+    """One node on its own line, as `issue #5895 — change default redirect code to 303`."""
+    ref = path.ref(node_id)
+    head = trace.ref(ref.node_type, ref.external_id)
+    title = _clip(ref.title, 62)
+    text = f"{head} — {title}" if title else head
+    return f"{text}  {dim(f'node:{node_id}')}" if verbose else text
+
+
+def inline(path: Path, node_id: int) -> str:
+    """One node inside a sentence, as `issue #5895 "change default redirect code to 303"`.
+
+    Quoted rather than dash-separated, because the dash form reads as punctuation when it
+    sits mid-sentence and the title runs into the verb that follows it.
+    """
+    ref = path.ref(node_id)
+    if ref.node_type == "decision":
+        # Synthesis gives a Decision the title of the issue that motivated it, so
+        # `issue #5895 "X" motivated decision "X"` states the same thing twice and reads as
+        # though two separate artifacts were found. What the decision IS follows on the
+        # next line, where it can be said once and properly.
+        return "the decision in this thread"
+    head = trace.ref(ref.node_type, ref.external_id)
+    title = _clip(ref.title, 52)
+    return f'{head} "{title}"' if title else head
+
+
+def plural(n: int, noun: str, suffix: str = "s") -> str:
+    """`1 path` / `2 paths`. "1 path(s)" is what a tool prints when nobody read its output."""
+    return f"{n} {noun}" if n == 1 else f"{n} {noun}{suffix}"
+
+
+def _clip(text: str | None, limit: int) -> str:
+    text = (text or "").strip()
+    return text[: limit - 3] + "..." if len(text) > limit else text
+
+
+def summarize(answer: Answer, annotations: dict[int, str], statuses: dict[int, str]) -> list[str]:
+    """The answer in sentences, built only from what the paths contain.
+
+    Grouped by the node reached rather than by path, because two paths ending at the same
+    artifact are one finding seen twice and reading them as two is how a trace overstates
+    what it found.
+    """
+    if not answer.found:
+        return []
+
+    lines: list[str] = []
+    seen: set[tuple[int, str]] = set()
+    for path in sorted(answer.paths, key=lambda p: (p.depth, p.target_id)):
+        target = path.target_id
+        step = path.steps[-1] if path.steps else None
+        if step is None:
+            continue
+        forward = step.to_node_id == target
+        key = (target, step.edge_type)
+        if key in seen:
+            continue
+        seen.add(key)
+
+        subject = inline(path, path.node_ids[0])
+        verb = phrase(step.edge_type, forward)
+        lines.append(f"{subject} {bold(verb)} {inline(path, target)}")
+
+        note = annotations.get(target)
+        status = statuses.get(target)
+        if status or note:
+            detail = ", ".join(x for x in (status, note) if x)
+            lines.append(dim(f"    that decision is {detail}"))
+    return lines
+
+
+def render(
+    answer: Answer,
+    *,
+    annotations: dict[int, str] | None = None,
+    statuses: dict[int, str] | None = None,
+    links: dict[str, str] | None = None,
+    verbose: bool = False,
+    out=None,
+) -> None:
+    out = out or sys.stdout
+    annotations = annotations or {}
+    statuses = statuses or {}
+    links = links or {}
+    p = lambda s="": print(s, file=out)  # noqa: E731
+
+    if not answer.found:
+        _render_refusal(answer, p)
+        return
+
+    if answer.used_inferred_fallback:
+        # Before the answer, not after it. A reader who stops at the first confident
+        # sentence must already have been told it is a guess.
+        p(_c("33", bold("  ! INFERRED — no explicit path existed; this is not a record")))
+
+    p(bold("  What the graph says"))
+    for line in summarize(answer, annotations, statuses):
+        p(f"    {line}")
+    p()
+
+    tiers = sorted({path.tier for path in answer.paths}, key=lambda t: len(t))
+    for tier in tiers:
+        p(f"  evidence: {_tier_colour(tier, bold(tier))} — {dim(trace.TIER_MEANING[tier])}")
+    p()
+
+    p(bold(f"  Evidence trail  ({plural(len(answer.paths), 'path')})"))
+    for i, path in enumerate(sorted(answer.paths, key=lambda x: (x.depth, x.target_id)), 1):
+        _render_path(path, i, annotations, statuses, verbose, p)
+
+    urls = _urls(answer)
+    # Artifacts the answer NAMES but no path passes through -- chiefly the credited
+    # implementer, which a Why-walk never reaches because it stops at the Decision. Named
+    # and unopenable is the worse half of the problem #19 was about.
+    already = dict(urls)
+    urls += [(text, url) for text, url in links.items() if text not in already]
+    if urls:
+        p(bold("  Check it on GitHub"))
+        for text, url in urls:
+            p(f"    {text:<24} {dim(url)}")
+        p()
+
+
+def _render_path(path, index, annotations, statuses, verbose, p) -> None:
+    mark = "" if _COLOR else trace.TIER_MARK.get(path.tier, "??") + " "
+    p(f"  [{index}] {mark}{_tier_colour(path.tier, path.tier)}  {plural(path.depth, 'hop')}")
+    p(f"      {label(path, path.node_ids[0], verbose=verbose)}")
+    # Including the start node. A query that matched a Decision directly begins there, and
+    # skipping it meant the one node whose label is deliberately uninformative -- see
+    # `trace.ref` -- was also the one node with nothing to explain it.
+    _annotate(path.node_ids[0], annotations, statuses, p)
+
+    for step, node_id in zip(path.steps, path.node_ids[1:]):
+        forward = step.to_node_id == node_id
+        detail = f"  {dim('via ' + step.extractor)}" if verbose else ""
+        p(f"       └─ {phrase(step.edge_type, forward)}  "
+          f"{_tier_colour(step.evidence_tier, '[' + step.evidence_tier + ']')}{detail}")
+        p(f"      {label(path, node_id, verbose=verbose)}")
+        _annotate(node_id, annotations, statuses, p)
+    p()
+
+
+def _annotate(node_id: int, annotations: dict, statuses: dict, p) -> None:
+    detail = ", ".join(x for x in (statuses.get(node_id), annotations.get(node_id)) if x)
+    if detail:
+        p(dim(f"          {detail}"))
+
+
+def _urls(answer: Answer) -> list[tuple[str, str]]:
+    """Every artifact in the answer that can be opened, deduplicated, in path order.
+
+    This is the whole §9 adjudication loop: read the claim, open the artifact, decide
+    whether the repository actually says that. It was previously a manual lookup of a
+    number the trace did not print.
+    """
+    seen: dict[str, str] = {}
+    for path in sorted(answer.paths, key=lambda p: (p.depth, p.target_id)):
+        for node_id in path.node_ids:
+            ref = path.ref(node_id)
+            if ref.url:
+                seen.setdefault(trace.ref(ref.node_type, ref.external_id), ref.url)
+    return list(seen.items())
+
+
+def _render_refusal(answer: Answer, p) -> None:
+    """Say what was looked for and what that means -- refusals are a primary output.
+
+    The distinction that matters is between "you asked the wrong question" and "the graph
+    genuinely holds no evidence", and only the second is a finding. Neither the engine's
+    one-line explanation nor a bare "no answer" separates them.
+    """
+    p(bold("  No answer — and that is a result, not a failure"))
+    p()
+    if answer.mode is Mode.WHY:
+        p("    Nothing in the ingested window records why this happened. The rubric needs")
+        p("    a motivating issue and merged work in the same conversation; a change made")
+        p("    without an issue leaves nothing to reconstruct a decision from.")
+    else:
+        p("    Nothing in the ingested window records what this affects. Impact is walked")
+        p("    forward over recorded links, so an artifact nothing references downstream")
+        p("    has no impact to report rather than an unknown one.")
+    p()
+    p(dim(f"    engine: {answer.explanation}"))
+    if answer.used_inferred_fallback:
+        p(dim("    the inferred fallback was tried and also found nothing"))
+    p()
+    p(bold("  What to try"))
+    p("    - widen the walk:      --depth 3")
+    p("    - check it was ingested: dg status")
+    p("    - the window is 12 months by default; older artifacts are deliberately absent")
+    p()

--- a/src/decision_graph/trace.py
+++ b/src/decision_graph/trace.py
@@ -1,0 +1,156 @@
+"""How a traversal is described, in the one place every reader shares (issue #69).
+
+Three things render an Engine 2 answer: `dg query`, the §9 evaluation report, and the
+prompt `dg ask` hands to a model. They must agree about what a node *is* and what a
+Decision is *credited to*, because a reader who checks one against another is doing the
+adjudication §9 depends on, and two implementations would drift exactly where that matters.
+That is the same argument `reasoning._walk` makes for having one traversal rather than two.
+
+The rule for everything here: **say what the graph holds, in the reader's vocabulary, and
+nothing else.** A label may translate `node:620` into `issue #5895` because the graph stores
+that number. It may not translate a `motivated_by` edge into "the maintainers wanted", which
+the graph does not hold and a reader could not check.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Node types whose external_id is a number a human uses. A commit's is a 40-character sha,
+# which is an identifier but not a readable one, so it is abbreviated the way git does.
+_NUMBERED = {"issue", "pull_request"}
+
+# What each tier means, in one sentence, for a reader who has not read §5.4. Printed once
+# per answer rather than per edge: the tier is the most important thing on the page and the
+# least self-explanatory, and a reader who does not know what "corroborated" is has no way
+# to weigh the answer they were given.
+TIER_MEANING = {
+    "explicit": "stated in the repository itself — a closing keyword, a review, a commit list",
+    "corroborated": "explicit, and the thread carries 3 of 4 independent kinds of signal",
+    "inferred": "the system's own guess; no explicit path existed, so this is not a record",
+}
+
+# Kept from the original renderer. Colour is not available when output is piped -- which is
+# every CI log and every `dg query > file` -- so the tier must survive in ASCII too.
+TIER_MARK = {"explicit": "==", "corroborated": "++", "inferred": "~~"}
+
+
+def ref(node_type: str | None, external_id: str | None) -> str:
+    """A node's identity as it exists outside this database.
+
+    `issue:620` is a primary key; the thing a reader can act on is `issue #5895`. Both the
+    number and the URL have been stored on every node since migration 0001 and neither was
+    ever printed.
+    """
+    if not external_id:
+        return node_type or "?"
+    if node_type in _NUMBERED:
+        return f"{node_type.replace('_', ' ')} #{external_id}"
+    if node_type == "commit":
+        return f"commit {external_id[:7]}"
+    if node_type == "decision":
+        # A Decision's external_id is its thread_key, which names the CLUSTER and, where a
+        # change took two attempts, names the abandoned pull request (issue #19). Printing
+        # it as though it identified the work is the misleading label that issue is about,
+        # so the cluster key is not the headline -- `decision_annotations` supplies what the
+        # Decision is actually credited to.
+        return "decision"
+    return f"{node_type} {external_id}"
+
+
+# ---------------------------------------------------------------------------
+# What a Decision is credited to (issue #19)
+# ---------------------------------------------------------------------------
+
+DECISION_FACTS_SQL = """
+SELECT d.node_id,
+       d.status::text AS status,
+       im.node_type   AS implementer_type,
+       im.external_id AS implementer_ref,
+       im.url         AS implementer_url,
+       pr.merged_at
+FROM decision d
+LEFT JOIN edge e  ON e.src_node_id = d.node_id
+                 AND e.edge_type   = 'implemented_by'
+                 AND e.valid_to IS NULL
+LEFT JOIN node im ON im.id = e.dst_node_id
+LEFT JOIN pull_request pr ON pr.node_id = im.id
+WHERE d.node_id = ANY(%s)
+ORDER BY d.node_id, im.external_id
+"""
+
+
+def format_implementer(row: dict[str, Any]) -> str:
+    kind = row["implementer_type"]
+    ref_ = row["implementer_ref"]
+    if kind == "commit":
+        return f"commit {ref_[:7]}"
+    if kind != "pull_request":
+        return f"{kind} {ref_}"
+    # Merge state is spelled out rather than implied. An unmerged implementer should not be
+    # able to sit quietly in a trace -- post-#17 it cannot exist, and this is how a
+    # regression would announce itself instead of reading as an ordinary path.
+    when = f"merged {row['merged_at']:%Y-%m-%d}" if row["merged_at"] else "NOT MERGED"
+    return f"PR #{ref_}, {when}"
+
+
+def decision_annotations(conn, node_ids: list[int]) -> dict[int, str]:
+    """Map Decision node ids to a short statement of what the graph credits them to.
+
+    A Why-walk reaching a Decision across `motivated_by` stops there and never traverses
+    `implemented_by`, so without this the only pull request number a reader sees is the one
+    inside the `thread_key` -- and that key names the cluster, not the work. 6 of 15
+    Decisions currently sit under a key naming a pull request that never merged.
+    """
+    if not node_ids:
+        return {}
+
+    grouped: dict[int, list[dict[str, Any]]] = {}
+    for row in conn.execute(DECISION_FACTS_SQL, (sorted(set(node_ids)),)).fetchall():
+        grouped.setdefault(row["node_id"], []).append(row)
+
+    notes: dict[int, str] = {}
+    for node_id, rows in grouped.items():
+        credited = [r for r in rows if r["implementer_ref"]]
+        if not credited:
+            # Unreachable while the rubric holds. Surfaced rather than skipped: a Decision
+            # asserting nothing is the single most important thing to show an adjudicator.
+            notes[node_id] = "no current implementer"
+            continue
+        # Every current implementer, not the first. A LIMIT 1 here would have concealed the
+        # double-implementer bug that the #17 fix introduced and then repaired.
+        notes[node_id] = "implemented by " + "; ".join(format_implementer(r) for r in credited)
+    return notes
+
+
+def decision_links(conn, node_ids: list[int]) -> dict[str, str]:
+    """`{"PR #5898": "https://github.com/..."}` for the artifacts credited with the work.
+
+    The implementer is named in the answer but is not on the path -- a Why-walk stops at
+    the Decision -- so without this it is the one artifact a reader is told about and
+    cannot open. It is also the artifact that did the thing, which makes it the one most
+    worth opening.
+    """
+    if not node_ids:
+        return {}
+    links: dict[str, str] = {}
+    for row in conn.execute(DECISION_FACTS_SQL, (sorted(set(node_ids)),)).fetchall():
+        if row["implementer_ref"] and row["implementer_url"]:
+            links[ref(row["implementer_type"], row["implementer_ref"])] = row["implementer_url"]
+    return links
+
+
+def decision_statuses(conn, node_ids: list[int]) -> dict[int, str]:
+    """Map Decision node ids to `explicit` or `reconstructed`.
+
+    Worth showing beside the annotation because they answer different questions. The status
+    says how the Decision came to exist -- itemised in a release note, or rebuilt from the
+    rubric -- and nothing else on screen distinguishes those two.
+    """
+    if not node_ids:
+        return {}
+    rows = conn.execute(
+        "SELECT node_id, status::text AS status FROM decision WHERE node_id = ANY(%s)",
+        (sorted(set(node_ids)),),
+    ).fetchall()
+    return {r["node_id"]: r["status"] for r in rows}

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 import unittest
 
 from decision_graph import explain
-from decision_graph.reasoning import Answer, Mode, Path, Step
+from decision_graph.reasoning import Answer, Mode, NodeRef, Path, Step
 
 
 class StubClient:
@@ -64,8 +64,11 @@ def _answer(*, found: bool, tier: str = "explicit", fallback: bool = False) -> A
     path = Path(
         node_ids=[1, 2],
         steps=[step],
-        titles={1: "decision", 2: "the motivating issue"},
-        types={1: "decision", 2: "issue"},
+        nodes={
+            1: NodeRef("decision", "decision", "thread:1:pr-5898"),
+            2: NodeRef("issue", "the motivating issue", "5895",
+                       "https://github.com/pallets/flask/issues/5895"),
+        },
     )
     return Answer(
         mode=Mode.WHY,
@@ -188,21 +191,36 @@ class AskPrintsItsEvidenceTest(unittest.TestCase):
 
     def test_the_trace_is_printed_with_the_prose(self) -> None:
         printed = self._run(_answer(found=True))
-        self.assertIn("motivated_by [explicit]", printed, "no trace was printed")
+        self.assertIn("Evidence trail", printed, "no trace was printed")
+        self.assertIn("[explicit]", printed, "the trace lost its evidence tier")
         self.assertIn("A plain-English summary.", printed)
+
+    def test_the_trace_names_artifacts_the_way_github_does(self) -> None:
+        # The point of #69: a reader checks the claim by opening the artifact, and a
+        # database primary key is not something they can open.
+        printed = self._run(_answer(found=True))
+        self.assertIn("issue #5895", printed)
+        self.assertIn("https://github.com/pallets/flask/issues/5895", printed)
+        self.assertNotIn("issue:2", printed, "a node id leaked into the default output")
 
     def test_an_inferred_answer_says_so_before_the_prose(self) -> None:
         printed = self._run(_answer(found=True, tier="inferred", fallback=True))
-        self.assertIn("INFERRED FALLBACK", printed)
+        self.assertIn("INFERRED", printed)
         self.assertLess(
-            printed.index("INFERRED FALLBACK"),
+            printed.index("INFERRED"),
             printed.index("A plain-English summary."),
             "the warning must reach the reader before the confident paragraph does",
         )
 
-    def test_a_refusal_prints_the_engines_words(self) -> None:
+    def test_a_refusal_says_what_it_means_and_what_to_try(self) -> None:
+        # A refusal is a primary output (8 of the 18 §9 outcomes). "no path found" alone
+        # cannot tell a reader whether they asked the wrong question or found a real gap.
         printed = self._run(_answer(found=False), summary=explain.NO_ANSWER)
-        self.assertIn("no answer", printed)
+        self.assertIn("No answer", printed)
+        self.assertIn("not a failure", printed)
+        self.assertIn("What to try", printed)
+        self.assertIn("engine: no path", printed,
+                      "the engine's own verdict must stay available, not be replaced")
 
 
 if __name__ == "__main__":

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -1,0 +1,189 @@
+"""What the reader is shown, and what must never disappear from it (issue #69).
+
+The renderer is presentation, so the risk is not that it computes something wrong — it is
+that it quietly stops showing something load-bearing. An answer whose evidence tier is
+missing, or whose inferred fallback is not flagged, reads exactly like a stronger answer;
+that is the failure mode §5.3 and §5.4 exist to prevent, arriving at the last possible
+moment. These tests pin the things that must survive every later edit to the layout.
+
+Standalone: `Answer` and `Path` are plain dataclasses, so none of this needs a database.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+
+from decision_graph import render, trace
+from decision_graph.reasoning import Answer, Mode, NodeRef, Path, Step
+
+
+def step(edge_type="motivated_by", tier="explicit", src=1, dst=2) -> Step:
+    return Step(
+        edge_id=1,
+        edge_type=edge_type,
+        tag="inferred" if tier == "inferred" else "explicit",
+        evidence_tier=tier,
+        from_node_id=src,
+        to_node_id=dst,
+        extractor="synthesis_closes_cluster",
+        source_ref=None,
+    )
+
+
+DECISION = NodeRef("decision", "change default redirect code to 303", "thread:1:pr-5898")
+ISSUE = NodeRef(
+    "issue",
+    "change default redirect code to 303",
+    "5895",
+    "https://github.com/pallets/flask/issues/5895",
+)
+
+
+def answer(*, found=True, tier="explicit", fallback=False, mode=Mode.WHY) -> Answer:
+    if not found:
+        return Answer(
+            mode=mode,
+            start_node_id=1,
+            paths=[],
+            used_inferred_fallback=fallback,
+            explanation="no path found, explicit or inferred",
+        )
+    path = Path(
+        node_ids=[1, 2],
+        steps=[step(tier=tier)],
+        nodes={1: DECISION, 2: ISSUE},
+    )
+    return Answer(
+        mode=mode,
+        start_node_id=1,
+        paths=[path],
+        used_inferred_fallback=fallback,
+        explanation="1 explicit path(s) found; inferred edges not consulted",
+    )
+
+
+def render_to_string(ans: Answer, **kwargs) -> str:
+    out = io.StringIO()
+    render.render(ans, out=out, **kwargs)
+    return out.getvalue()
+
+
+class IdentityTest(unittest.TestCase):
+    def test_artifacts_are_named_the_way_github_names_them(self) -> None:
+        printed = render_to_string(answer())
+        self.assertIn("issue #5895", printed)
+        self.assertNotIn("issue:2", printed, "a database primary key reached the reader")
+
+    def test_the_url_is_offered_so_the_claim_can_be_checked(self) -> None:
+        # §9's method is a human opening the artifact and comparing. The URL was stored on
+        # 988 of 1003 nodes and printed on none of them.
+        self.assertIn(
+            "https://github.com/pallets/flask/issues/5895", render_to_string(answer())
+        )
+
+    def test_a_decision_is_not_labelled_with_its_cluster_key(self) -> None:
+        # A Decision's external_id is its thread_key, which names the cluster and for 6 of
+        # 15 Decisions names a pull request that never merged (#19).
+        self.assertNotIn("thread:1:pr-5898", render_to_string(answer()))
+
+    def test_node_ids_are_still_available_under_verbose(self) -> None:
+        # Moved, not removed: they are what an adjudicator uses to query the graph directly.
+        printed = render_to_string(answer(), verbose=True)
+        self.assertIn("node:2", printed)
+
+
+class EvidenceTest(unittest.TestCase):
+    def test_the_tier_is_shown_and_explained(self) -> None:
+        printed = render_to_string(answer(tier="corroborated"))
+        self.assertIn("corroborated", printed)
+        self.assertIn(trace.TIER_MEANING["corroborated"], printed)
+
+    def test_an_inferred_fallback_is_flagged_before_the_answer(self) -> None:
+        printed = render_to_string(answer(tier="inferred", fallback=True))
+        self.assertIn("INFERRED", printed)
+        self.assertLess(
+            printed.index("INFERRED"),
+            printed.index("What the graph says"),
+            "a reader who stops at the first sentence must already know it is a guess",
+        )
+
+    def test_the_tier_survives_without_colour(self) -> None:
+        # Piped output has no colour, and CI logs and `dg query > file` are always piped.
+        # The ASCII mark is what carries the tier there.
+        printed = render_to_string(answer(tier="inferred", fallback=True))
+        self.assertIn(trace.TIER_MARK["inferred"], printed)
+
+    def test_the_extractor_is_available_under_verbose(self) -> None:
+        self.assertIn("synthesis_closes_cluster", render_to_string(answer(), verbose=True))
+
+
+class SentenceTest(unittest.TestCase):
+    def test_edge_direction_changes_the_verb(self) -> None:
+        # The same edge read the other way round is a different English claim, and getting
+        # this backwards would invert what the answer says while looking correct.
+        self.assertEqual(render.phrase("motivated_by", True), "was motivated by")
+        self.assertEqual(render.phrase("motivated_by", False), "motivated")
+
+    def test_an_unmapped_edge_type_falls_back_to_its_name(self) -> None:
+        # Better a bare edge type than a wrong verb; new edge types must not silently
+        # acquire prose that misstates them.
+        self.assertEqual(render.phrase("relates_to", True), "relates_to")
+
+    def test_the_summary_is_built_only_from_the_paths(self) -> None:
+        lines = render.summarize(answer(), {}, {})
+        self.assertEqual(len(lines), 1)
+        self.assertIn("issue #5895", lines[0])
+
+    def test_the_decision_annotation_reaches_the_reader(self) -> None:
+        printed = render_to_string(
+            answer(),
+            annotations={1: "implemented by PR #5898, merged 2026-01-25"},
+            statuses={1: "reconstructed"},
+        )
+        self.assertIn("PR #5898", printed)
+        self.assertIn("reconstructed", printed)
+
+    def test_an_artifact_named_but_not_walked_is_still_linkable(self) -> None:
+        # The credited implementer is named in the answer and is not on the path, so it is
+        # the one artifact a reader was told about and could not open.
+        printed = render_to_string(
+            answer(), links={"pull request #5898": "https://github.com/pallets/flask/pull/5898"}
+        )
+        self.assertIn("https://github.com/pallets/flask/pull/5898", printed)
+
+    def test_counts_are_not_written_as_path_s(self) -> None:
+        printed = render_to_string(answer())
+        self.assertIn("1 path", printed)
+        self.assertNotIn("path(s)", printed.split("engine:")[0])
+
+
+class RefusalTest(unittest.TestCase):
+    def test_a_refusal_says_it_is_a_result(self) -> None:
+        printed = render_to_string(answer(found=False))
+        self.assertIn("not a failure", printed)
+        self.assertIn("What to try", printed)
+
+    def test_a_refusal_keeps_the_engines_own_verdict(self) -> None:
+        # The prose explains; it does not replace. An adjudicator needs the engine's words.
+        self.assertIn(
+            "no path found, explicit or inferred", render_to_string(answer(found=False))
+        )
+
+    def test_impact_and_why_refusals_explain_different_things(self) -> None:
+        why = render_to_string(answer(found=False, mode=Mode.WHY))
+        impact = render_to_string(answer(found=False, mode=Mode.IMPACT))
+        self.assertIn("records why this happened", why)
+        self.assertIn("records what this affects", impact)
+
+    def test_a_tried_fallback_is_reported(self) -> None:
+        # "Nothing found" and "nothing found even after admitting guesses" are different
+        # statements about how hard the engine looked.
+        self.assertIn(
+            "inferred fallback was tried",
+            render_to_string(answer(found=False, fallback=True)),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_trace_annotation.py
+++ b/tests/test_trace_annotation.py
@@ -42,7 +42,7 @@ class FormatImplementerTest(unittest.TestCase):
                 "merged_at": datetime(2026, 1, 25, 3, 53, tzinfo=timezone.utc),
             }
         )
-        self.assertEqual(text, "PR 5899, merged 2026-01-25")
+        self.assertEqual(text, "PR #5899, merged 2026-01-25")
 
     def test_unmerged_pull_request_says_so_explicitly(self) -> None:
         # Post-#17 this cannot occur. It is spelled out rather than left blank so that a
@@ -75,16 +75,15 @@ class DescribeTest(unittest.TestCase):
         return reasoning.Path(
             node_ids=[928],
             steps=[],
-            titles={928: "deprecate `should_ignore_error`"},
-            types={928: "decision"},
+            nodes={928: reasoning.NodeRef("decision", "deprecate `should_ignore_error`")},
         )
 
     def test_annotation_is_appended_when_present(self) -> None:
         text = evaluation._describe(
-            self._path(), 928, {928: "implemented by PR 5899, merged 2026-01-25"}
+            self._path(), 928, {928: "implemented by PR #5899, merged 2026-01-25"}
         )
         self.assertIn("decision:928", text)
-        self.assertIn("PR 5899", text)
+        self.assertIn("PR #5899", text)
 
     def test_unannotated_node_is_unchanged(self) -> None:
         self.assertEqual(
@@ -209,7 +208,7 @@ class DecisionAnnotationsTest(unittest.TestCase):
         d = self._decision()
         self._implemented_by(d, self._pr(5899, self.MERGED))
         notes = evaluation.decision_annotations(self.conn, [d])
-        self.assertEqual(notes[d], "implemented by PR 5899, merged 2026-01-25")
+        self.assertEqual(notes[d], "implemented by PR #5899, merged 2026-01-25")
 
     def test_superseded_implementer_is_excluded(self) -> None:
         # This is the exact shape of decision 928: the abandoned attempt is still in the


### PR DESCRIPTION
Closes #69. First of three — Mermaid/DOT export and the HTML report follow.

## Before

```
WHY  start=node:620
-------------------
  [1] tier=explicit  depth=1
      issue:620 "change default redirect code to 303"
        ==<- motivated_by [explicit] (synthesis_closes_cluster)
      decision:1648 "change default redirect code to 303"
```

## After

```
Why did this happen?   'change default redirect code to 303'

  starting from  issue #5895  change default redirect code to 303
                 exact title match

  What the graph says
    issue #5895 "change default redirect code to 303" motivated the decision in this thread
        that decision is reconstructed, implemented by PR #5898, merged 2026-01-25

  evidence: explicit — stated in the repository itself, a closing keyword, a review, a commit list

  Evidence trail  (1 path)
  [1] == explicit  1 hop
      issue #5895 — change default redirect code to 303
       └─ motivated  [explicit]
      decision — change default redirect code to 303
          reconstructed, implemented by PR #5898, merged 2026-01-25

  Check it on GitHub
    issue #5895              https://github.com/pallets/flask/issues/5895
    pull request #5898       https://github.com/pallets/flask/pull/5898
```

## The rules this follows

**The summary is templated, never generated.** A Decision with a `motivated_by` and an
`implemented_by` edge determines that sentence completely. `_EDGE_PHRASE` maps an edge type
and direction to a verb and does nothing else — an unmapped edge type falls back to its own
name rather than acquiring prose that might misstate it, and there is a test for that. Same
rule `dg ask` follows for refusals (#65).

**Nothing was removed to make room.** Node ids and extractor names moved behind `-v`. The
ASCII tier marks (`==`, `++`, `~~`) stay, because colour is absent in every piped context and
the tier has to survive there.

**#19 finally reaches the command people run.** Showing a Decision's credited implementer
lived only in `evaluation.py`; `query.py` had no reference to `implemented_by`. A Why-walk
stops at the Decision, so the only PR a reader saw was the one in the `thread_key` — which
names the cluster and, for **6 of 15 Decisions**, names an abandoned one. It is now named,
dated, and linked; an artifact the answer names but no path walks through was the one thing a
reader was told about and could not open.

**A refusal is rendered as a result** — 8 of the 18 §9 outcomes are refusals:

```
  No answer — and that is a result, not a failure

    Nothing in the ingested window records why this happened. The rubric needs
    a motivating issue and merged work in the same conversation; ...

    engine: no path found, explicit or inferred
    the inferred fallback was tried and also found nothing

  What to try
    - widen the walk:      --depth 3
```

## Structure

`trace.py` is the shared vocabulary for the three things that render an answer — `dg query`,
the §9 worksheet, and the `dg ask` prompt. An adjudicator comparing one against another is
doing the job §9 exists for, and two implementations would drift exactly there.
`reasoning.Path` carries a `NodeRef` (type, title, external_id, url) instead of two parallel
dicts; `titles`/`types` remain as views since every caller reads them via `.get()`.

**One behaviour change:** three candidates no longer produce three separately-headed answers
to what is usually one finding seen from three nodes. The best match is answered, the others
are listed, `--all` restores the old behaviour.

## Verification

- **146 tests**, nothing skipped with `DATABASE_URL` set and Docker present; 19 are new and
  none needs a database.
- Checked by hand against the live graph in why mode, impact mode, and a refusal.
- The evaluation runner still runs. `eval/results.json` is deliberately **not** regenerated
  here: the corpus has grown since it was last taken and now answers one more query, and a
  new §9 record needs human adjudication rather than a drive-by commit inside a rendering PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CKgTDYCV3TwH1yzhxwscQ