### PR TITLE
Draw an answer: --format mermaid and --format dot (#71)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Every menu choice maps to one of these, so you can skip the menu once you know t
 | `dg status` | what is ingested: counts by type, per repo, cursor positions |
 | `dg query "..." --mode why` | ask why something happened, or what a change affects |
 | `dg ask "..."` | the same, asked in plain English — needs an Nvidia NIM key |
+| `dg query ... --format mermaid` | the same answer as a diagram (`dot` also available) |
 
 ```powershell
 .\dg.ps1 ingest --repo pallets/flask
@@ -133,8 +134,49 @@ A refusal is treated as a result, because it is one — 8 of the 18 §9 outcomes
     ...
 ```
 
+### Answers as diagrams
+
+`--format mermaid` (or `dot`) emits the traversal as a graph instead of prose. Raw, no code
+fence, so it pipes into a file:
+
+```powershell
+.\dg.ps1 query "#5898" --mode impact --format mermaid > answer.mmd
+```
+
+```
+graph LR
+  n656["pull request #5898<br/>redirect defaults to 303"]
+  n620(["issue #5895<br/>change default redirect code to 303"])
+  n658(("commit eca5fd1<br/>redirect defaults to 303"))
+  n1648{{"decision<br/>change default redirect code to 303"}}
+  n656 -->|"closes . explicit"| n620
+  n656 -->|"implements . explicit"| n658
+  n1648 -->|"was implemented by . explicit"| n656
+  classDef decision fill:#fde68a,stroke:#b45309,stroke-width:2px;
+  class n1648 decision;
+```
+
+Paste it into a ```` ```mermaid ```` block on GitHub and it renders there. `--format dot`
+gives Graphviz instead, with each node carrying its GitHub URL so a rendered SVG is
+clickable.
+
+Two constraints the diagram keeps, both about not claiming more than the walk did:
+
+- **Only edges the engine actually traversed are drawn.** The credited implementer is named
+  in the text output and is deliberately absent from the picture, because a Why-walk stops at
+  the Decision and never crosses `implemented_by`. A diagram is read as the whole story, so
+  it may contain nothing but the story.
+- **The tier survives the translation** — solid explicit, thick corroborated, dashed
+  inferred — *and* is written on every edge label. Line weight is a hint; the word is the
+  claim, and a picture that renders a guess and a record identically undoes the tiering at
+  the last step.
+
+Edges are drawn along the graph's own direction rather than the walker's, so a Why-walk that
+crosses `motivated_by` backwards still shows the arrow the edge actually has.
+
 `ingest` and `query` forward any flag they do not recognise to the underlying tools, so
-`--months`, `--resources`, `--max-pages`, `--as-of`, `--limit` and `--all` all still work.
+`--months`, `--resources`, `--max-pages`, `--as-of`, `--limit`, `--all` and `--format` all
+still work.
 
 ### What to expect
 
@@ -522,7 +564,7 @@ psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  9 checks
 psql "$DATABASE_URL" -f db/tests/0013_reference_retraction_checks.sql # 6 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 146 tests
+DATABASE_URL=... python -m unittest discover -s tests               # 161 tests
 ```
 
 `.github/workflows/ci.yml` runs all of it on every push and pull request, against Postgres
@@ -537,14 +579,14 @@ so four of the five suites printed `FAIL` inside a collapsed group and exited 0 
 then raises if anything failed, and `tests/test_sql_suites.py` asserts that every file in
 `db/tests/` does, so a suite added later cannot quietly arrive without it.
 
-All SQL suites run in a transaction and roll back. The Python suite runs 124 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 139 tests
 standalone. Setting `DATABASE_URL` adds 19 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 5 for the trace annotation, and 7 for reference retraction. Docker adds 3 more that compile the whole package on the
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
 
-A run without those is still reported as `OK`, with 22 of the 146 quietly skipped — so a
+A run without those is still reported as `OK`, with 22 of the 161 quietly skipped — so a
 local pass and a complete pass look alike. CI sets both, and nothing is skipped there.
 
 Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell

--- a/src/decision_graph/diagram.py
+++ b/src/decision_graph/diagram.py
@@ -1,0 +1,165 @@
+"""An answer as a picture: Mermaid and Graphviz DOT (issue #71).
+
+A traversal is a graph, and past a couple of hops an indented list is the wrong shape for
+one. An impact walk from `#5898` returns four paths that all leave the same node, and
+nothing in the text output shows that they fan out from one place.
+
+Two rules, and both are about not letting a picture claim more than the walk did:
+
+1. **Only edges the engine actually traversed are drawn.** The credited implementer is
+   named in the text output and is deliberately absent here, because a Why-walk stops at
+   the Decision and never crosses `implemented_by` — drawing it would put a hop in the
+   picture that the engine did not make. A diagram is read as the whole story, so it must
+   contain nothing but the story.
+2. **The evidence tier survives the translation.** Solid for explicit, thick for
+   corroborated, dashed for inferred, and the tier is written on the edge label as well as
+   drawn, because line weight is a hint and the word is the claim. A picture that renders a
+   guess and a record identically undoes §5.3 and §5.4 at the last step.
+
+Output is raw, with no code fence, so it pipes straight into a `.mmd` or `.dot` file.
+"""
+
+from __future__ import annotations
+
+from . import render, trace
+from .reasoning import Answer
+
+# Mermaid node shapes, chosen so the artifact kinds are distinguishable at a glance rather
+# than decoratively: a Decision is the thing this system asserts and gets the shape nothing
+# else uses.
+_MERMAID_SHAPE = {
+    "decision": ("{{", "}}"),  # hexagon
+    "issue": ("([", "])"),  # stadium
+    "pull_request": ("[", "]"),  # rectangle
+    "commit": ("((", "))"),  # circle
+    "release": ("[/", "/]"),  # parallelogram
+    "person": ("(", ")"),
+}
+
+_MERMAID_LINK = {
+    "explicit": "-->",
+    "corroborated": "==>",  # thick
+    "inferred": "-.->",  # dashed
+}
+
+_DOT_STYLE = {
+    "explicit": 'style=solid, penwidth=1.2',
+    "corroborated": 'style=solid, penwidth=2.6',
+    "inferred": 'style=dashed, penwidth=1.0',
+}
+
+
+def _escape_mermaid(text: str) -> str:
+    """Make a real GitHub title safe inside a Mermaid label.
+
+    Every label this module emits is quoted, and Mermaid's quoted form exists precisely so
+    that brackets, parentheses and `#` can appear literally -- escaping them anyway turns
+    `redirect defaults to 303 (#5898)` into a wall of `&#40;&#35;` that renders correctly
+    and reads terribly. The one character that cannot survive is the quote itself, which
+    ends the label early; Mermaid's own escape for it is `#quot;`.
+
+    A newline would end the statement, so it becomes a space. Mermaid signals a broken
+    label by rendering nothing rather than by reporting an error, which is why this is
+    conservative about the two characters that matter and relaxed about the rest.
+    """
+    return text.replace('"', "#quot;").replace("\n", " ").replace("\r", " ").strip()
+
+
+def _escape_dot(text: str) -> str:
+    return text.replace("\\", "\\\\").replace('"', '\\"').replace("\n", " ").strip()
+
+
+def _walked(answer: Answer):
+    """Every (src, dst, step) the engine traversed, deduplicated, in a stable order.
+
+    Paths overlap -- four impact paths from one node share that node and often a prefix --
+    so drawing per path would emit the same edge repeatedly and, in Mermaid, draw it
+    repeatedly too.
+    """
+    nodes: dict[int, tuple] = {}
+    edges: dict[int, tuple] = {}
+    for path in sorted(answer.paths, key=lambda p: (p.depth, p.target_id)):
+        for node_id in path.node_ids:
+            ref = path.ref(node_id)
+            nodes.setdefault(node_id, (ref.node_type, ref.title, ref.external_id, ref.url))
+        for step in path.steps:
+            edges.setdefault(step.edge_id, (step.from_node_id, step.to_node_id, step))
+    return nodes, edges
+
+
+def _title(node_type: str | None, external_id: str | None, title: str | None) -> tuple[str, str]:
+    head = trace.ref(node_type, external_id)
+    return head, render._clip(title, 48)
+
+
+def to_mermaid(answer: Answer) -> str:
+    nodes, edges = _walked(answer)
+    if not nodes:
+        return ""
+
+    lines = ["graph LR"]
+    for node_id, (node_type, title, external_id, _url) in nodes.items():
+        open_, close = _MERMAID_SHAPE.get(node_type or "", ("[", "]"))
+        head, short = _title(node_type, external_id, title)
+        # Escape the two halves separately, then join with the line break: `<br/>` is
+        # markup this module is adding, not content the repository wrote, so it must not
+        # pass through the escaper that would neutralise it.
+        text = _escape_mermaid(head)
+        if short:
+            text += "<br/>" + _escape_mermaid(short)
+        lines.append(f'  n{node_id}{open_}"{text}"{close}')
+
+    for _edge_id, (src, dst, step) in edges.items():
+        arrow = _MERMAID_LINK.get(step.evidence_tier, "-->")
+        # Always drawn along the graph's own direction, so the outward phrasing is always
+        # the right one -- a Why-walk crosses `motivated_by` backwards, but the edge still
+        # runs decision -> issue and the picture should say what the edge says, not what
+        # order the walker happened to visit it in.
+        verb = render.phrase(step.edge_type, True)
+        label = _escape_mermaid(f"{verb} · {step.evidence_tier}")
+        lines.append(f'  n{src} {arrow}|"{label}"| n{dst}')
+
+    # A Decision is the assertion this whole system exists to make, so it is the one node
+    # that is styled rather than left to the default.
+    decisions = [f"n{nid}" for nid, (t, _, _, _) in nodes.items() if t == "decision"]
+    if decisions:
+        lines.append("  classDef decision fill:#fde68a,stroke:#b45309,stroke-width:2px;")
+        lines.append(f"  class {','.join(decisions)} decision;")
+    return "\n".join(lines)
+
+
+def to_dot(answer: Answer) -> str:
+    nodes, edges = _walked(answer)
+    if not nodes:
+        return ""
+
+    lines = ["digraph answer {", "  rankdir=LR;", '  node [shape=box, fontname="Helvetica"];']
+    for node_id, (node_type, title, external_id, url) in nodes.items():
+        head, short = _title(node_type, external_id, title)
+        # `\\n` is DOT's line break inside a quoted label, and it is appended AFTER
+        # escaping: _escape_dot doubles backslashes, so building the label first would emit
+        # a literal backslash-n and print it as text.
+        label = _escape_dot(head)
+        if short:
+            label += "\\n" + _escape_dot(short)
+        shape = "hexagon" if node_type == "decision" else "box"
+        # DOT carries the URL as an attribute, so an SVG rendered from this is clickable --
+        # the same "check it on GitHub" affordance the text output has.
+        href = f', URL="{_escape_dot(url)}"' if url else ""
+        lines.append(f'  n{node_id} [label="{label}", shape={shape}{href}];')
+
+    for _edge_id, (src, dst, step) in edges.items():
+        verb = render.phrase(step.edge_type, True)  # graph direction; see to_mermaid
+        label = _escape_dot(f"{verb} ({step.evidence_tier})")
+        style = _DOT_STYLE.get(step.evidence_tier, "style=solid")
+        lines.append(f'  n{src} -> n{dst} [label="{label}", {style}];')
+
+    lines.append("}")
+    return "\n".join(lines)
+
+
+FORMATS = {"mermaid": to_mermaid, "dot": to_dot}
+
+
+def emit(answer: Answer, fmt: str) -> str:
+    return FORMATS[fmt](answer)

--- a/src/decision_graph/query.py
+++ b/src/decision_graph/query.py
@@ -19,7 +19,7 @@ import os
 import sys
 from datetime import datetime
 
-from . import db, reasoning, render, retrieval, trace
+from . import db, diagram, reasoning, render, retrieval, trace
 from .reasoning import Answer, Mode
 
 # Kept as a module attribute because it was one, and `from .query import TIER_MARK` is the
@@ -105,6 +105,12 @@ def main(argv: list[str] | None = None) -> int:
         "-v", "--verbose", action="store_true",
         help="show node ids and the extractor behind each edge",
     )
+    parser.add_argument(
+        "--format",
+        choices=["text", *sorted(diagram.FORMATS)],
+        default="text",
+        help="text (default), or a diagram of the walk: mermaid, dot",
+    )
     args = parser.parse_args(argv)
 
     logging.basicConfig(
@@ -138,23 +144,40 @@ def main(argv: list[str] | None = None) -> int:
         print("  Try `#5898` or a commit sha, or check `dg status` for what is ingested.", file=sys.stderr)
         return 1
 
+    graphical = args.format != "text"
     question = "Why did this happen?" if args.mode == Mode.WHY.value else "What does this affect?"
-    print(render.bold(f"{question}   {render.dim(repr(args.query))}"))
-    print()
+    if not graphical:
+        print(render.bold(f"{question}   {render.dim(repr(args.query))}"))
+        print()
 
     chosen = candidates if args.all else candidates[:1]
     for c in chosen:
-        how = _MATCH_MEANING.get(c.match, c.match)
-        print(
-            f"  starting from  {render.bold(trace.ref(c.node_type, c.external_id))}"
-            f"  {(c.title or '')[:56]}"
-        )
-        print(render.dim(f"                 {how}"))
-        print()
+        if not graphical:
+            how = _MATCH_MEANING.get(c.match, c.match)
+            print(
+                f"  starting from  {render.bold(trace.ref(c.node_type, c.external_id))}"
+                f"  {(c.title or '')[:56]}"
+            )
+            print(render.dim(f"                 {how}"))
+            print()
 
         answer = reasoning.reason(
             conn, c.node_id, Mode(args.mode), max_depth=args.depth, as_of=as_of
         )
+        if graphical:
+            # Raw, so it pipes into a .mmd or .dot file. A refusal produces nothing at all
+            # rather than an empty diagram: an empty `graph LR` renders as a blank box,
+            # which reads as a drawing failure and not as "the graph holds no answer".
+            drawn = diagram.emit(answer, args.format)
+            if drawn:
+                print(drawn)
+            else:
+                print(
+                    f"# no answer to draw: {answer.explanation}",
+                    file=sys.stderr,
+                )
+            continue
+
         annotations, statuses, links = _decision_facts(conn, answer)
         render_answer(
             answer, annotations=annotations, statuses=statuses, links=links,
@@ -162,7 +185,7 @@ def main(argv: list[str] | None = None) -> int:
         )
 
     skipped = len(candidates) - len(chosen)
-    if skipped:
+    if skipped and not graphical:
         print(render.dim(
             f"  {render.plural(skipped, 'other candidate')} matched this query — "
             "`--all` answers from each of them."

--- a/tests/test_diagram.py
+++ b/tests/test_diagram.py
@@ -1,0 +1,161 @@
+"""What a picture of an answer may and may not say (issue #71).
+
+A diagram is read as the whole story, which makes two failures worse here than in the text
+output: drawing an edge the engine did not walk, and rendering a guess and a record
+identically. Both are silent — a Mermaid label that breaks renders as nothing at all rather
+than as an error, and a dashed line that becomes solid looks entirely fine.
+
+Standalone: builds `Answer` fixtures directly, no database.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from decision_graph import diagram
+from decision_graph.reasoning import Answer, Mode, NodeRef, Path, Step
+
+
+def step(edge_id=1, edge_type="motivated_by", tier="explicit", src=1, dst=2) -> Step:
+    return Step(
+        edge_id=edge_id,
+        edge_type=edge_type,
+        tag="inferred" if tier == "inferred" else "explicit",
+        evidence_tier=tier,
+        from_node_id=src,
+        to_node_id=dst,
+        extractor="synthesis_closes_cluster",
+        source_ref=None,
+    )
+
+
+def answer(paths, mode=Mode.WHY) -> Answer:
+    return Answer(
+        mode=mode,
+        start_node_id=1,
+        paths=paths,
+        used_inferred_fallback=any(
+            s.evidence_tier == "inferred" for p in paths for s in p.steps
+        ),
+        explanation="fixture",
+    )
+
+
+def one_hop(tier="explicit", title="change default redirect code to 303") -> Answer:
+    return answer([
+        Path(
+            node_ids=[1, 2],
+            steps=[step(tier=tier)],
+            nodes={
+                1: NodeRef("decision", title, "thread:1:pr-5898"),
+                2: NodeRef("issue", title, "5895",
+                           "https://github.com/pallets/flask/issues/5895"),
+            },
+        )
+    ])
+
+
+class MermaidTest(unittest.TestCase):
+    def test_nodes_and_edges_are_emitted(self) -> None:
+        out = diagram.to_mermaid(one_hop())
+        self.assertTrue(out.startswith("graph LR"))
+        self.assertIn("issue #5895", out)
+        self.assertIn("n1 -->", out)
+
+    def test_the_tier_is_drawn_and_written(self) -> None:
+        # Line weight is a hint; the word is the claim. A reader who cannot see the
+        # difference between a dashed and a solid line must still be told.
+        inferred = diagram.to_mermaid(one_hop(tier="inferred"))
+        self.assertIn("-.->", inferred)
+        self.assertIn("inferred", inferred)
+
+        corroborated = diagram.to_mermaid(one_hop(tier="corroborated"))
+        self.assertIn("==>", corroborated)
+
+        explicit = diagram.to_mermaid(one_hop())
+        self.assertIn("-->", explicit)
+        self.assertNotIn("-.->", explicit)
+
+    def test_a_quote_in_a_title_cannot_break_the_label(self) -> None:
+        # Mermaid signals a broken label by rendering nothing, so this fails silently and
+        # in the worst possible way: an empty picture that looks like an empty answer.
+        out = diagram.to_mermaid(one_hop(title='use "303" by default'))
+        self.assertIn("#quot;303#quot;", out)
+        self.assertNotIn('"303"', out)
+
+    def test_brackets_and_hashes_are_left_alone_inside_quotes(self) -> None:
+        # Mermaid's quoted form exists so these can appear literally. Escaping them anyway
+        # renders correctly and reads like machine output.
+        out = diagram.to_mermaid(one_hop(title="redirect defaults to 303 (#5898)"))
+        self.assertIn("(#5898)", out)
+        self.assertNotIn("&#35;", out)
+
+    def test_the_line_break_markup_survives_escaping(self) -> None:
+        self.assertIn("<br/>", diagram.to_mermaid(one_hop()))
+
+    def test_a_repeated_edge_is_drawn_once(self) -> None:
+        # Impact walks overlap heavily: four paths from one node share their prefix, and
+        # per-path emission would draw the same arrow four times.
+        shared = step(edge_id=7)
+        paths = [
+            Path(node_ids=[1, 2], steps=[shared],
+                 nodes={1: NodeRef("decision", "d"), 2: NodeRef("issue", "i", "5895")}),
+            Path(node_ids=[1, 2], steps=[shared],
+                 nodes={1: NodeRef("decision", "d"), 2: NodeRef("issue", "i", "5895")}),
+        ]
+        self.assertEqual(diagram.to_mermaid(answer(paths)).count("n1 -->"), 1)
+
+    def test_a_decision_is_styled_as_the_assertion_it_is(self) -> None:
+        out = diagram.to_mermaid(one_hop())
+        self.assertIn("classDef decision", out)
+        self.assertIn("{{", out, "the decision should have the shape nothing else uses")
+
+    def test_no_answer_draws_nothing_rather_than_an_empty_box(self) -> None:
+        # `graph LR` with no nodes renders as a blank frame, which reads as a broken
+        # diagram rather than as "the graph holds no answer".
+        self.assertEqual(diagram.to_mermaid(answer([])), "")
+
+
+class DotTest(unittest.TestCase):
+    def test_it_is_a_digraph_with_labelled_edges(self) -> None:
+        out = diagram.to_dot(one_hop())
+        self.assertTrue(out.startswith("digraph answer {"))
+        self.assertTrue(out.rstrip().endswith("}"))
+        self.assertIn("was motivated by (explicit)", out)
+
+    def test_the_line_break_is_dots_own_and_not_a_literal_backslash_n(self) -> None:
+        # _escape_dot doubles backslashes, so building the label before escaping emitted a
+        # literal `\\n` and printed it inside the box.
+        out = diagram.to_dot(one_hop())
+        self.assertIn("\\n", out)
+        self.assertNotIn("\\\\n", out)
+
+    def test_a_quote_in_a_title_is_escaped(self) -> None:
+        out = diagram.to_dot(one_hop(title='use "303" by default'))
+        self.assertIn('\\"303\\"', out)
+
+    def test_tiers_are_visually_distinct(self) -> None:
+        self.assertIn("style=dashed", diagram.to_dot(one_hop(tier="inferred")))
+        self.assertIn("penwidth=2.6", diagram.to_dot(one_hop(tier="corroborated")))
+
+    def test_nodes_carry_their_url_so_an_svg_is_clickable(self) -> None:
+        self.assertIn(
+            'URL="https://github.com/pallets/flask/issues/5895"', diagram.to_dot(one_hop())
+        )
+
+    def test_no_answer_draws_nothing(self) -> None:
+        self.assertEqual(diagram.to_dot(answer([])), "")
+
+
+class OnlyWhatWasWalkedTest(unittest.TestCase):
+    def test_the_diagram_contains_exactly_the_traversed_edges(self) -> None:
+        # The rule the module exists to keep. The credited implementer is named in the text
+        # output and is not on the path; drawing it would put a hop in the picture that the
+        # engine never made, and a picture is read as the whole story.
+        out = diagram.to_mermaid(one_hop())
+        self.assertEqual(out.count("-->"), 1)
+        self.assertEqual(len([ln for ln in out.splitlines() if ln.strip().startswith("n")]), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #71. Second of three.

```powershell
.\dg.ps1 query "#5898" --mode impact --format mermaid > answer.mmd
```

```
graph LR
  n656["pull request #5898<br/>redirect defaults to 303"]
  n620(["issue #5895<br/>change default redirect code to 303"])
  n658(("commit eca5fd1<br/>redirect defaults to 303"))
  n1648{{"decision<br/>change default redirect code to 303"}}
  n1562(("commit 809d5a8<br/>redirect defaults to 303 (#5898)"))
  n656 -->|"closes · explicit"| n620
  n656 -->|"implements · explicit"| n658
  n1648 -->|"was implemented by · explicit"| n656
  n1562 -->|"depends on · explicit"| n658
  classDef decision fill:#fde68a,stroke:#b45309,stroke-width:2px;
  class n1648 decision;
```

Raw, no code fence, so it pipes into a `.mmd` file; paste it in a ```` ```mermaid ```` block
and GitHub renders it. `--format dot` gives Graphviz, with each node carrying its GitHub URL
so a rendered SVG is clickable.

## Two rules the picture keeps

**Only walked edges are drawn.** The credited implementer is named in the text output and is
deliberately absent here — a Why-walk stops at the Decision and never crosses
`implemented_by`, so drawing it would put a hop in the picture the engine never made. A
diagram is read as the whole story, so it may contain nothing but the story.

**The tier survives the translation** — solid explicit, thick corroborated, dashed inferred —
*and* is written on every edge label. Line weight is a hint; the word is the claim. A picture
that renders a guess and a record identically undoes §5.3 and §5.4 at the last possible step.

Edges are drawn along the graph's own direction rather than the walker's: a Why-walk crosses
`motivated_by` backwards, but the edge still runs decision → issue.

## Two escaping bugs, found by writing the tests rather than by reading the output

- **Mermaid signals a broken label by rendering nothing**, so an unescaped quote produces an
  empty picture that reads as an empty answer. Only the quote is escaped (as `#quot;`),
  because every label here is quoted and Mermaid's quoted form exists precisely so brackets,
  parens and `#` can appear literally — escaping those anyway turned
  `redirect defaults to 303 (#5898)` into a wall of `&#40;&#35;` that rendered correctly and
  read like machine output.
- **DOT's line break is `\n` inside a quoted label**, and `_escape_dot` doubles backslashes,
  so building the label before escaping emitted a literal backslash-n and printed it in the
  box.

A refusal produces no diagram at all rather than an empty one (a note on stderr), because
`graph LR` with no nodes renders as a blank frame — which reads as a broken diagram, not as
"the graph holds no answer".

## Verification

161 tests, nothing skipped; 15 are new and none needs a database. Both formats checked by
hand against the live graph in why and impact modes. The Mermaid is rendered end-to-end in
the next PR, which embeds it in the HTML report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CKgTDYCV3TwH1yzhxwscQ