### PR TITLE
dg report: the graph as a page you can browse (#73)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,8 @@ venv/
 __pycache__/
 *.pyc
 *.egg-info/
+
+# `dg report` writes here by default. It is a rendering of the graph in the project
+# directory (the only path that exists on both sides of the container bind mount), so it
+# lands where a stray `git add .` would pick it up.
+decision-graph-report.html

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Every menu choice maps to one of these, so you can skip the menu once you know t
 | `dg query "..." --mode why` | ask why something happened, or what a change affects |
 | `dg ask "..."` | the same, asked in plain English — needs an Nvidia NIM key |
 | `dg query ... --format mermaid` | the same answer as a diagram (`dot` also available) |
+| `dg report` | render every decision and its evidence to a browsable HTML page |
 
 ```powershell
 .\dg.ps1 ingest --repo pallets/flask
@@ -408,6 +409,41 @@ dg-query "#5898" --mode impact --depth 2
 dg-query "send_file type annotations" --mode why --as-of 2026-03-01T00:00:00Z
 ```
 
+## Browsing the graph (`dg report`)
+
+`dg query` answers one question and `--format mermaid` draws one answer. `dg report` renders
+the whole graph — every Decision, its status, its motivating issue, the pull request credited
+with the work and when it merged, the evidence tier on every edge, and a diagram of each
+thread:
+
+```powershell
+.\dg.ps1 report --open
+```
+
+```
+wrote /work/decision-graph-report.html
+  15 decisions from 238 clusters
+```
+
+The page is one self-contained file. It fetches exactly one script — the mermaid UMD build,
+pinned — and if that fetch fails the diagram source stays on the page as readable text
+instead of vanishing. **A classic `<script>` tag, not an ES module**: `dg report` writes a
+file you open from disk, and Chrome refuses a module import from a remote origin on a
+`file://` page, which would render every diagram as nothing on exactly the path this command
+produces.
+
+It states its own coverage at the top, because a page listing 15 Decisions and saying nothing
+about the 223 clusters that produced none is a coverage claim made by omission:
+
+> **This is not the repository's history.** It is what the §5.1 rubric could evidence: a
+> motivating issue and merged work in one conversation. 223 clusters produced no decision,
+> most because no issue is referenced from the work at all, and a refusal to assert is the
+> intended outcome there rather than a gap.
+
+Its numbers come from the graph at the moment you run it, not from `eval/results.json` —
+that file is the record of an evaluation run and stays one — and they agree with
+`eval/figures.sql`, which is the script that exists so any figure here can be checked.
+
 ## Asking in English (`dg ask`)
 
 `dg query` takes a title, a `#number`, or a sha. `dg ask` takes a sentence, uses a model to
@@ -564,7 +600,7 @@ psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  9 checks
 psql "$DATABASE_URL" -f db/tests/0013_reference_retraction_checks.sql # 6 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 161 tests
+DATABASE_URL=... python -m unittest discover -s tests               # 176 tests
 ```
 
 `.github/workflows/ci.yml` runs all of it on every push and pull request, against Postgres
@@ -579,14 +615,15 @@ so four of the five suites printed `FAIL` inside a collapsed group and exited 0 
 then raises if anything failed, and `tests/test_sql_suites.py` asserts that every file in
 `db/tests/` does, so a suite added later cannot quietly arrive without it.
 
-All SQL suites run in a transaction and roll back. The Python suite runs 139 tests
-standalone. Setting `DATABASE_URL` adds 19 integration tests — 7 for the traversal
+All SQL suites run in a transaction and roll back. The Python suite runs 152 tests
+standalone. Setting `DATABASE_URL` adds 21 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
-5 for the trace annotation, and 7 for reference retraction. Docker adds 3 more that compile the whole package on the
+5 for the trace annotation, 7 for reference retraction, and 2 that run every `dg report`
+query against the real schema, which is the half a fixture cannot check. Docker adds 3 more that compile the whole package on the
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
 
-A run without those is still reported as `OK`, with 22 of the 161 quietly skipped — so a
+A run without those is still reported as `OK`, with 24 of the 176 quietly skipped — so a
 local pass and a complete pass look alike. CI sets both, and nothing is skipped there.
 
 Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -728,6 +728,81 @@ def cmd_query(args: argparse.Namespace, extra: list[str]) -> int:
     return query.main([args.text] + list(extra))
 
 
+def cmd_report(args: argparse.Namespace) -> int:
+    """Render the graph to a browsable HTML file (issue #73).
+
+    Written next to `.env` in the project directory rather than into the container's
+    filesystem, because the point of the file is that a human opens it, and only the
+    bind-mounted project directory exists on both sides.
+    """
+    from . import report, retrieval
+
+    try:
+        conn = _connect()
+    except Exception as exc:
+        why, fix = explain_db_error(exc)
+        print(red(f"Cannot reach the database: {why}"))
+        print(f"{yellow('→')} {fix}")
+        return 1
+
+    repo = args.repo or os.environ.get("TARGET_REPO", "")
+    repo_node_id = retrieval.resolve_repo(conn, repo) if repo else None
+    if repo_node_id is None:
+        # Guessing which repository to report on would produce a page that looks complete
+        # and describes a different corpus than the reader expects.
+        rows = conn.execute(
+            "SELECT external_id FROM node WHERE node_type = 'repository' ORDER BY external_id"
+        ).fetchall()
+        if len(rows) == 1:
+            repo, repo_node_id = rows[0]["external_id"], None
+            repo_node_id = retrieval.resolve_repo(conn, repo)
+        else:
+            print(red(f"Cannot tell which repository to report on."))
+            print(f"{yellow('→')} pass --repo owner/name; ingested: "
+                  + ", ".join(r["external_id"] for r in rows))
+            conn.close()
+            return 2
+
+    data = report.collect(conn, repo_node_id)
+    conn.close()
+
+    if not data["decisions"]:
+        # Not an error. The rubric refusing to assert anything is a real state of this
+        # system, and a page saying so is more useful than a failure that implies breakage.
+        print(yellow("No decisions in the graph yet — the report would be empty."))
+        print(dim("  That is a result, not a failure: the rubric needs a motivating issue"))
+        print(dim("  and merged work in one thread. Run `dg status` to see what is ingested."))
+        return 0
+
+    out = Path(args.output) if args.output else PROJECT_DIR / "decision-graph-report.html"
+    out.write_text(report.render_html(data, repo), encoding="utf-8")
+
+    print(f"{green('wrote')} {out}")
+    print(dim(f"  {len(data['decisions'])} decisions from "
+              f"{data['coverage']['clusters']} clusters"))
+    if args.open:
+        _open_in_browser(out)
+    else:
+        print(dim("  open it in a browser, or re-run with --open"))
+    return 0
+
+
+def _open_in_browser(path: Path) -> None:
+    """Open the report, and say what to do when that is not possible.
+
+    `dg` runs inside a container with no browser and no display, which is the normal case
+    rather than the exception, so a failure here is expected and must not read as an error.
+    """
+    import webbrowser
+
+    try:
+        if webbrowser.open(path.as_uri()):
+            return
+    except Exception:  # noqa: BLE001 - a headless container raises in several ways
+        pass
+    print(dim("  (no browser reachable from here — open the file above from your host)"))
+
+
 def cmd_ask(args: argparse.Namespace, extra: list[str]) -> int:
     """Natural-language front door to the same engines `dg query` uses.
 
@@ -837,6 +912,12 @@ def build_parser() -> argparse.ArgumentParser:
     a = sub.add_parser("ask", help="ask a natural language question about the repository")
     a.add_argument("question", help="e.g. 'Why did we change the default redirect code?'")
     a.set_defaults(fn=cmd_ask, passthrough=True)
+
+    r = sub.add_parser("report", help="render the whole graph to a browsable HTML page")
+    r.add_argument("--repo", help="owner/name (defaults to TARGET_REPO from .env)")
+    r.add_argument("--output", help="where to write it (default: decision-graph-report.html)")
+    r.add_argument("--open", action="store_true", help="open it in a browser afterwards")
+    r.set_defaults(fn=cmd_report)
 
     return p
 

--- a/src/decision_graph/menu.py
+++ b/src/decision_graph/menu.py
@@ -175,6 +175,14 @@ def _run_query(mode: str):
     return go
 
 
+def _run_report(_ns: argparse.Namespace) -> None:
+    from .cli import cmd_report
+
+    # --open by default from the menu: someone who picked "browse the graph" from a list
+    # wants to look at it, not to be told where a file is.
+    cmd_report(argparse.Namespace(repo=None, output=None, open=True))
+
+
 def _run_ask(_ns: argparse.Namespace) -> None:
     from .cli import cmd_ask
 
@@ -192,6 +200,7 @@ ACTIONS = [
     Action("4", "Repository status", "counts, cursors, decisions", lambda ns: cmd_status(ns)),
     Action("5", "Health check", "what works, and how to fix what does not", lambda ns: cmd_doctor(ns)),
     Action("6", "Natural Language Q&A", "ask a question in plain English (requires Nvidia API key)", _run_ask),
+    Action("7", "Browse the graph", "render every decision and its evidence to an HTML page", _run_report),
     Action("i", "Setup / reconfigure", "token, target repo, migrations (safe to re-run)", _run_init),
 ]
 

--- a/src/decision_graph/menu.py
+++ b/src/decision_graph/menu.py
@@ -217,7 +217,8 @@ def _draw() -> None:
     print(
         "  " + dim("ask why? ") + "(2)   "
         + dim("what breaks? ") + "(3)   "
-        + dim("what is inside? ") + "(4)"
+        + dim("what is inside? ") + "(4)   "
+        + dim("show me everything? ") + "(7)"
     )
     print()
     print(f"  {_greeting()}.")

--- a/src/decision_graph/report.py
+++ b/src/decision_graph/report.py
@@ -1,0 +1,331 @@
+"""`dg report` — the graph as a page you can browse (issue #73).
+
+`dg query` answers one question and `--format mermaid` draws one answer. Neither shows the
+graph: what was reconstructed, what each Decision rests on, how the evidence tiers fall, or
+what the system did *not* find. For a tool whose entire product is a graph, that was the
+missing surface, and the only way to see it was a psql prompt and knowledge of the schema.
+
+Three constraints, and the third is the one that makes this honest:
+
+1. **Self-contained.** One file, opened from disk, no server. Mermaid is the single script
+   it fetches, and the page degrades to the same content as text when that fetch fails — a
+   diagram that silently disappears offline would be worse than never drawing one.
+2. **Generated from the graph, now.** Not from `eval/results.json`, which is the record of
+   an evaluation run and must stay one.
+3. **It states what it does not cover.** A page showing 15 Decisions and saying nothing
+   about the 223 clusters that produced none is a coverage claim made by omission. The
+   ratio and the reason are on the page, at the top, not in a footnote.
+"""
+
+from __future__ import annotations
+
+import html
+import json
+from datetime import datetime, timezone
+
+from . import trace
+
+# The UMD build specifically: it defines a global and works from a file:// page, where
+# the ESM build cannot be imported at all. Pinned, so a future release cannot change
+# what a saved report renders.
+MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@10.9.1/dist/mermaid.min.js"
+
+# One query per section, kept here rather than inline so the page is obviously a view over
+# the graph and every number on it can be traced to the SQL that produced it.
+DECISIONS_SQL = """
+SELECT d.node_id,
+       d.status::text                         AS status,
+       n.title,
+       n.thread_key,
+       d.decided_at,
+       src.node_type::text                    AS source_type,
+       src.external_id                        AS source_ref,
+       src.url                                AS source_url
+FROM decision d
+JOIN node n ON n.id = d.node_id
+LEFT JOIN node src ON src.id = d.source_artifact_node_id
+WHERE n.repo_node_id = %s
+ORDER BY d.decided_at DESC NULLS LAST, d.node_id
+"""
+
+# Everything the Decision links to, in both directions, with the tier. This is the evidence
+# the rubric accepted, which is the only thing that makes a reconstructed Decision more than
+# an assertion.
+EVIDENCE_SQL = """
+SELECT e.src_node_id, e.dst_node_id, e.edge_type::text AS edge_type,
+       e.evidence_tier::text AS evidence_tier, e.extractor,
+       o.node_type::text AS other_type, o.external_id AS other_ref,
+       o.title AS other_title, o.url AS other_url,
+       (e.src_node_id = ANY(%(ids)s)) AS outward
+FROM edge e
+JOIN node o ON o.id = CASE WHEN e.src_node_id = ANY(%(ids)s)
+                           THEN e.dst_node_id ELSE e.src_node_id END
+WHERE (e.src_node_id = ANY(%(ids)s) OR e.dst_node_id = ANY(%(ids)s))
+  AND e.valid_to IS NULL
+ORDER BY e.edge_type, o.external_id
+"""
+
+COVERAGE_SQL = """
+SELECT
+    (SELECT count(DISTINCT thread_key) FROM node
+      WHERE repo_node_id = %(repo)s AND thread_key IS NOT NULL
+        AND node_type <> 'decision')                                   AS clusters,
+    (SELECT count(*) FROM decision d JOIN node n ON n.id = d.node_id
+      WHERE n.repo_node_id = %(repo)s)                                 AS decisions,
+    (SELECT count(*) FROM node WHERE repo_node_id = %(repo)s
+        AND node_type = 'pull_request')                                AS pull_requests,
+    (SELECT count(*) FROM node WHERE repo_node_id = %(repo)s
+        AND node_type = 'issue')                                       AS issues,
+    (SELECT count(*) FROM node WHERE repo_node_id = %(repo)s
+        AND node_type = 'commit')                                      AS commits
+"""
+
+# Either endpoint, not just the source. A `reviewed` edge runs person -> pull_request and a
+# person belongs to no repository, so scoping by the source alone dropped every review from
+# the count -- and made this page disagree with eval/figures.sql, which is the script whose
+# whole purpose is that the numbers can be checked.
+TIERS_SQL = """
+SELECT e.evidence_tier::text AS tier, count(*) AS edges
+FROM edge e
+JOIN node s ON s.id = e.src_node_id
+JOIN node d ON d.id = e.dst_node_id
+WHERE (s.repo_node_id = %(repo)s OR d.repo_node_id = %(repo)s)
+  AND e.valid_to IS NULL
+GROUP BY 1 ORDER BY 2 DESC
+"""
+
+
+def _esc(text) -> str:
+    return html.escape(str(text if text is not None else ""), quote=True)
+
+
+def collect(conn, repo_node_id: int) -> dict:
+    """Everything the page shows, read in four queries.
+
+    Returned as plain data rather than rendered directly so the tests can assert what the
+    page will contain without parsing HTML, and so a future JSON export is the same read.
+    """
+    decisions = [dict(r) for r in conn.execute(DECISIONS_SQL, (repo_node_id,)).fetchall()]
+    ids = [d["node_id"] for d in decisions]
+
+    evidence: dict[int, list[dict]] = {i: [] for i in ids}
+    if ids:
+        for row in conn.execute(EVIDENCE_SQL, {"ids": ids}).fetchall():
+            owner = row["src_node_id"] if row["outward"] else row["dst_node_id"]
+            if owner in evidence:
+                evidence[owner].append(dict(row))
+
+    coverage = dict(conn.execute(COVERAGE_SQL, {"repo": repo_node_id}).fetchone())
+    tiers = [dict(r) for r in conn.execute(TIERS_SQL, {"repo": repo_node_id}).fetchall()]
+
+    annotations = trace.decision_annotations(conn, ids)
+    return {
+        "decisions": decisions,
+        "evidence": evidence,
+        "coverage": coverage,
+        "tiers": tiers,
+        "annotations": annotations,
+        "generated_at": datetime.now(timezone.utc),
+    }
+
+
+def _decision_mermaid(decision: dict, edges: list[dict]) -> str:
+    """One Decision and the artifacts it links to, as a diagram.
+
+    Built from the stored edges rather than from a traversal: this is not an answer to a
+    question, it is what the rubric accepted, and those are different claims. Only edges
+    that exist are drawn, which is the same rule `diagram.py` follows for a walk.
+    """
+    lines = ["graph LR", f'  d{decision["node_id"]}{{{{"decision"}}}}']
+    lines.append("  classDef decision fill:#fde68a,stroke:#b45309,stroke-width:2px;")
+    lines.append(f'  class d{decision["node_id"]} decision;')
+    for i, e in enumerate(edges):
+        name = trace.ref(e["other_type"], e["other_ref"])
+        title = (e["other_title"] or "")[:40].replace('"', "#quot;")
+        label = f'{name}<br/>{title}' if title else name
+        node = f"a{decision['node_id']}_{i}"
+        shape = ("([", "])") if e["other_type"] == "issue" else ("[", "]")
+        lines.append(f'  {node}{shape[0]}"{label}"{shape[1]}')
+        arrow = {"corroborated": "==>", "inferred": "-.->"}.get(e["evidence_tier"], "-->")
+        # Both the shape and the word, as in diagram.py: a reader who cannot tell a thick
+        # line from a thin one must still be told which tier this edge carries.
+        verb = f'{e["edge_type"].replace("_", " ")} · {e["evidence_tier"]}'
+        if e["outward"]:
+            lines.append(f'  d{decision["node_id"]} {arrow}|"{verb}"| {node}')
+        else:
+            lines.append(f'  {node} {arrow}|"{verb}"| d{decision["node_id"]}')
+    return "\n".join(lines)
+
+
+def _link(url: str | None, text: str) -> str:
+    """A GitHub link when there is a URL, plain text when there is not.
+
+    Kept as a function rather than an inline conditional inside an f-string: the version
+    that was inline had to dodge its own quoting and became unreadable, which is exactly
+    how an escaping bug gets in unnoticed.
+    """
+    return f'<a href="{_esc(url)}">{_esc(text)}</a>' if url else _esc(text)
+
+
+def _evidence_row(e: dict) -> str:
+    """One edge of a Decision's evidence, as a table row.
+
+    The direction arrow is not decoration. `motivated_by` outward from the Decision and
+    `implements` inward toward it are different claims about the same pair of artifacts,
+    and a table that showed only the edge type would read them as one.
+    """
+    arrow = "&rarr;" if e["outward"] else "&larr;"
+    name = _link(e["other_url"], trace.ref(e["other_type"], e["other_ref"]))
+    title = _esc((e["other_title"] or "")[:70])
+    tier = _esc(e["evidence_tier"])
+    return (
+        f"<tr><td>{_esc(e['edge_type'])}</td>"
+        f"<td>{arrow}</td>"
+        f'<td>{name} <span class="t">{title}</span></td>'
+        f'<td><span class="tier {tier}">{tier}</span></td>'
+        f'<td class="x">{_esc(e["extractor"])}</td></tr>'
+    )
+
+
+def render_html(data: dict, repo: str) -> str:
+    cov = data["coverage"]
+    clusters = cov["clusters"] or 0
+    pct = (100.0 * cov["decisions"] / clusters) if clusters else 0.0
+    tier_counts = {t["tier"]: t["edges"] for t in data["tiers"]}
+
+    cards = []
+    for d in data["decisions"]:
+        edges = data["evidence"].get(d["node_id"], [])
+        tiers = {e["evidence_tier"] for e in edges}
+        badge = "corroborated" if "corroborated" in tiers else "explicit"
+        note = data["annotations"].get(d["node_id"], "no current implementer")
+        source = ""
+        if d["source_ref"]:
+            name = trace.ref(d["source_type"], d["source_ref"])
+            source = (
+                f'<a href="{_esc(d["source_url"])}">{_esc(name)}</a>'
+                if d["source_url"]
+                else _esc(name)
+            )
+
+        rows = "".join(_evidence_row(e) for e in edges)
+
+        cards.append(f"""
+<article class="card">
+  <header>
+    <span class="status {_esc(d['status'])}">{_esc(d['status'])}</span>
+    <h3>{_esc(d['title'])}</h3>
+  </header>
+  <p class="meta">{note and _esc(note)}
+     {' · decided ' + d['decided_at'].strftime('%Y-%m-%d') if d.get('decided_at') else ''}
+     {' · from ' + source if source else ''}</p>
+  <p class="key">cluster <code>{_esc(d['thread_key'])}</code>
+     <span class="warn">names the cluster, not necessarily the work that landed</span></p>
+  <table>
+    <thead><tr><th>edge</th><th></th><th>artifact</th><th>tier</th><th>extractor</th></tr></thead>
+    <tbody>{rows or '<tr><td colspan="5">no edges</td></tr>'}</tbody>
+  </table>
+  <details><summary>diagram</summary>
+    <pre class="mermaid">{_esc(_decision_mermaid(d, edges))}</pre>
+  </details>
+</article>""")
+
+    return f"""<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>decision graph — {_esc(repo)}</title>
+<style>
+  :root {{ --bg:#fff; --fg:#1a1a1a; --dim:#666; --line:#e2e2e2; --card:#fafafa;
+           --explicit:#166534; --corroborated:#155e75; --inferred:#92400e; }}
+  @media (prefers-color-scheme: dark) {{
+    :root {{ --bg:#111; --fg:#e8e8e8; --dim:#9a9a9a; --line:#333; --card:#1a1a1a;
+             --explicit:#4ade80; --corroborated:#67e8f9; --inferred:#fbbf24; }}
+  }}
+  body {{ background:var(--bg); color:var(--fg); margin:0 auto; max-width:60rem; padding:2rem 1rem;
+         font:15px/1.55 -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif; }}
+  h1 {{ font-size:1.5rem; margin:0 0 .2rem; }}
+  .sub {{ color:var(--dim); margin:0 0 1.5rem; }}
+  .stats {{ display:flex; flex-wrap:wrap; gap:1.5rem; padding:1rem; background:var(--card);
+            border:1px solid var(--line); border-radius:8px; margin-bottom:1rem; }}
+  .stat b {{ display:block; font-size:1.6rem; }}
+  .stat span {{ color:var(--dim); font-size:.85rem; }}
+  .caveat {{ border-left:3px solid var(--inferred); padding:.6rem .9rem; background:var(--card);
+             margin:0 0 2rem; }}
+  .card {{ border:1px solid var(--line); border-radius:8px; padding:1rem 1.2rem; margin:0 0 1rem;
+           background:var(--card); }}
+  .card header {{ display:flex; gap:.6rem; align-items:baseline; }}
+  .card h3 {{ font-size:1.05rem; margin:0 0 .4rem; font-weight:600; }}
+  .status {{ font-size:.7rem; text-transform:uppercase; letter-spacing:.05em; padding:.15rem .45rem;
+             border-radius:4px; border:1px solid var(--line); color:var(--dim); white-space:nowrap; }}
+  .status.explicit {{ color:var(--explicit); border-color:currentColor; }}
+  .meta {{ margin:.2rem 0; }}
+  .key {{ color:var(--dim); font-size:.85rem; margin:.2rem 0 .8rem; }}
+  .warn {{ color:var(--inferred); }}
+  table {{ width:100%; border-collapse:collapse; font-size:.85rem; }}
+  th {{ text-align:left; color:var(--dim); font-weight:500; border-bottom:1px solid var(--line); }}
+  td {{ padding:.25rem .4rem .25rem 0; border-bottom:1px solid var(--line); vertical-align:top; }}
+  .t {{ color:var(--dim); }}
+  .x {{ color:var(--dim); font-family:ui-monospace,monospace; font-size:.75rem; }}
+  .tier {{ font-size:.72rem; padding:.1rem .35rem; border-radius:3px; border:1px solid currentColor; }}
+  .tier.explicit {{ color:var(--explicit); }}
+  .tier.corroborated {{ color:var(--corroborated); }}
+  .tier.inferred {{ color:var(--inferred); }}
+  a {{ color:inherit; }}
+  code {{ font-family:ui-monospace,monospace; font-size:.8em; }}
+  details {{ margin-top:.6rem; }} summary {{ cursor:pointer; color:var(--dim); font-size:.85rem; }}
+  /* Mermaid replaces the contents of pre.mermaid. Until (or unless) it does, this is the
+     diagram source, which is readable on its own -- that is the offline fallback. */
+  pre.mermaid {{ overflow-x:auto; font-size:.75rem; color:var(--dim); white-space:pre; }}
+  footer {{ color:var(--dim); font-size:.8rem; border-top:1px solid var(--line); margin-top:2rem;
+            padding-top:1rem; }}
+</style></head>
+<body>
+<h1>decision graph — {_esc(repo)}</h1>
+<p class="sub">{cov['decisions']} decisions reconstructed from {clusters} conversation
+clusters · generated {data['generated_at']:%Y-%m-%d %H:%M} UTC</p>
+
+<div class="stats">
+  <div class="stat"><b>{cov['decisions']}</b><span>decisions</span></div>
+  <div class="stat"><b>{clusters}</b><span>thread clusters</span></div>
+  <div class="stat"><b>{pct:.1f}%</b><span>coverage</span></div>
+  <div class="stat"><b>{cov['pull_requests']}</b><span>pull requests</span></div>
+  <div class="stat"><b>{cov['issues']}</b><span>issues</span></div>
+  <div class="stat"><b>{cov['commits']}</b><span>commits</span></div>
+  <div class="stat"><b>{tier_counts.get('corroborated', 0)}</b><span>corroborated edges</span></div>
+  <div class="stat"><b>{tier_counts.get('inferred', 0)}</b><span>inferred edges</span></div>
+</div>
+
+<p class="caveat"><strong>This is not the repository's history.</strong> It is what the §5.1
+rubric could evidence: a motivating issue and merged work in one conversation.
+{clusters - cov['decisions']} clusters produced no decision, most because no issue is
+referenced from the work at all, and a refusal to assert is the intended outcome there
+rather than a gap. Coverage, not precision, is this system's binding limit.</p>
+
+{''.join(cards)}
+
+<footer>Generated by <code>dg report</code> from the graph, not from an evaluation record.
+Every artifact links to GitHub so any claim here can be checked against the repository.
+Diagrams render with mermaid; if the script cannot load, the diagram source stays readable
+in place.</footer>
+
+<!-- A classic script tag, not an ES module. This file is opened from disk, and Chrome
+     refuses a module import from a remote origin on a file:// page (origin "null"), so the
+     module form renders every diagram as nothing on exactly the path the command produces.
+     The UMD build defines a global and loads fine there. -->
+<script src="{MERMAID_CDN}"></script>
+<script>
+  if (window.mermaid) {{
+    var dark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    mermaid.initialize({{
+      startOnLoad: true,
+      securityLevel: "strict",
+      theme: dark ? "dark" : "default",
+      // The dark theme still plates edge labels on near-white, which is unreadable here.
+      themeVariables: dark
+        ? {{ edgeLabelBackground: "#1a1a1a", lineColor: "#9a9a9a" }}
+        : {{ edgeLabelBackground: "#fafafa" }},
+    }});
+  }}
+</script>
+</body></html>
+"""

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -1,0 +1,188 @@
+"""What the browsable report must contain, and must not claim (issue #73).
+
+A page is read as a whole and a page of decisions is read as a history, so the risks here
+are about omission rather than error: 15 cards with nothing said about the 223 clusters
+that produced none is a coverage claim made by silence. These pin the parts that carry
+that weight, plus the two mechanical things that fail invisibly — a page that cannot
+render its diagrams when opened from disk, and one whose numbers disagree with the
+measurement script.
+
+Rendering is tested from fixture data, so no database is needed. `collect` reads the
+graph and is exercised by the integration test at the bottom when DATABASE_URL is set.
+"""
+
+from __future__ import annotations
+
+import os
+import unittest
+from datetime import datetime, timezone
+
+from decision_graph import report
+
+DSN = os.environ.get("DATABASE_URL")
+
+
+def decision(node_id=1, status="reconstructed", title="change default redirect code to 303"):
+    return {
+        "node_id": node_id,
+        "status": status,
+        "title": title,
+        "thread_key": "thread:1:pr-5898",
+        "decided_at": datetime(2026, 1, 25, tzinfo=timezone.utc),
+        "source_type": "release",
+        "source_ref": "3.1.0",
+        "source_url": "https://github.com/pallets/flask/releases/tag/3.1.0",
+    }
+
+
+def edge(edge_type="motivated_by", tier="explicit", outward=True, ref="5895"):
+    return {
+        "src_node_id": 1,
+        "dst_node_id": 2,
+        "edge_type": edge_type,
+        "evidence_tier": tier,
+        "extractor": "synthesis_closes_cluster",
+        "other_type": "issue",
+        "other_ref": ref,
+        "other_title": 'use "303" by default',
+        "other_url": f"https://github.com/pallets/flask/issues/{ref}",
+        "outward": outward,
+    }
+
+
+def data(decisions=None, edges=None, clusters=238, decisions_count=15):
+    d = decisions if decisions is not None else [decision()]
+    return {
+        "decisions": d,
+        "evidence": {x["node_id"]: (edges if edges is not None else [edge()]) for x in d},
+        "coverage": {
+            "clusters": clusters,
+            "decisions": decisions_count,
+            "pull_requests": 224,
+            "issues": 81,
+            "commits": 387,
+        },
+        "tiers": [{"tier": "explicit", "edges": 1248}, {"tier": "corroborated", "edges": 76}],
+        "annotations": {x["node_id"]: "implemented by PR #5898, merged 2026-01-25" for x in d},
+        "generated_at": datetime(2026, 9, 5, 15, 14, tzinfo=timezone.utc),
+    }
+
+
+class HonestyTest(unittest.TestCase):
+    def test_the_page_states_what_it_does_not_cover(self) -> None:
+        # The failure this guards is silence, not error: a page listing 15 decisions and
+        # saying nothing about the other 223 clusters is a coverage claim by omission.
+        html = report.render_html(data(), "pallets/flask")
+        self.assertIn("223 clusters produced no decision", html)
+        self.assertIn("not the repository's history", html)
+
+    def test_coverage_is_shown_as_a_ratio_not_just_a_count(self) -> None:
+        html = report.render_html(data(), "pallets/flask")
+        self.assertIn("6.3%", html)
+
+    def test_the_cluster_key_is_labelled_as_a_cluster(self) -> None:
+        # The thread_key names the cluster and for 6 of 15 Decisions names a pull request
+        # that never merged (#19). Printed without that warning it reads as the work.
+        html = report.render_html(data(), "pallets/flask")
+        self.assertIn("names the cluster", html)
+
+    def test_the_credited_implementer_and_merge_date_are_shown(self) -> None:
+        self.assertIn("PR #5898, merged 2026-01-25", report.render_html(data(), "x"))
+
+    def test_an_empty_graph_does_not_divide_by_zero(self) -> None:
+        html = report.render_html(data(decisions=[], clusters=0, decisions_count=0), "x")
+        self.assertIn("0.0%", html)
+
+
+class EvidenceTest(unittest.TestCase):
+    def test_every_edge_shows_its_tier(self) -> None:
+        html = report.render_html(data(edges=[edge(tier="corroborated")]), "x")
+        self.assertIn('class="tier corroborated"', html)
+
+    def test_edge_direction_is_shown(self) -> None:
+        # `motivated_by` out of a Decision and `implements` into it are different claims
+        # about the same pair, and an edge-type column alone reads them as one.
+        outward = report.render_html(data(edges=[edge(outward=True)]), "x")
+        inward = report.render_html(data(edges=[edge(outward=False)]), "x")
+        self.assertIn("&rarr;", outward)
+        self.assertIn("&larr;", inward)
+
+    def test_artifacts_link_to_github(self) -> None:
+        html = report.render_html(data(), "x")
+        self.assertIn('href="https://github.com/pallets/flask/issues/5895"', html)
+
+    def test_titles_are_html_escaped(self) -> None:
+        # Real titles contain quotes and angle brackets; one unescaped breaks the table
+        # silently, and the page still renders looking merely odd.
+        html = report.render_html(data(edges=[edge()]), "x")
+        self.assertIn("&quot;303&quot;", html)
+
+
+class DiagramTest(unittest.TestCase):
+    def test_the_diagram_names_the_tier_as_well_as_drawing_it(self) -> None:
+        mmd = report._decision_mermaid(decision(), [edge(tier="corroborated")])
+        self.assertIn("==>", mmd)
+        self.assertIn("corroborated", mmd)
+
+    def test_a_quote_in_a_title_cannot_break_the_diagram(self) -> None:
+        mmd = report._decision_mermaid(decision(), [edge()])
+        self.assertIn("#quot;", mmd)
+        self.assertNotIn('"303"', mmd)
+
+    def test_it_renders_without_a_module_script(self) -> None:
+        # THE bug this page would otherwise ship with: `dg report` writes a file that is
+        # opened from disk, and Chrome refuses a module import from a remote origin on a
+        # file:// page. The module form renders every diagram as nothing, silently, on
+        # exactly the path the command produces.
+        html = report.render_html(data(), "x")
+        self.assertNotIn('type="module"', html)
+        self.assertIn("<script src=", html)
+
+    def test_the_diagram_source_survives_as_the_offline_fallback(self) -> None:
+        # If the CDN is unreachable, mermaid never replaces the <pre>, so what stays on the
+        # page is the diagram source -- readable, and better than an empty box.
+        html = report.render_html(data(), "x")
+        self.assertIn('<pre class="mermaid">graph LR', html)
+
+
+@unittest.skipUnless(DSN, "DATABASE_URL not set")
+class CollectTest(unittest.TestCase):
+    """`collect` against the real schema — the queries are the half fixtures cannot check."""
+
+    def setUp(self) -> None:
+        from decision_graph import db
+
+        self.conn = db.connect(DSN)
+
+    def tearDown(self) -> None:
+        self.conn.rollback()
+        self.conn.close()
+
+    def _repo(self) -> int | None:
+        row = self.conn.execute(
+            "SELECT id FROM node WHERE node_type = 'repository' ORDER BY id LIMIT 1"
+        ).fetchone()
+        return row["id"] if row else None
+
+    def test_every_query_runs_against_the_real_schema(self) -> None:
+        repo = self._repo()
+        if repo is None:
+            self.skipTest("no repository ingested")
+        out = report.collect(self.conn, repo)
+        self.assertEqual(
+            set(out),
+            {"decisions", "evidence", "coverage", "tiers", "annotations", "generated_at"},
+        )
+        self.assertIn("clusters", out["coverage"])
+
+    def test_the_rendered_page_is_html(self) -> None:
+        repo = self._repo()
+        if repo is None:
+            self.skipTest("no repository ingested")
+        html = report.render_html(report.collect(self.conn, repo), "test/repo")
+        self.assertTrue(html.startswith("<!doctype html>"))
+        self.assertIn("</html>", html)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #73. Third and last of the three from #69.

`dg query` answers one question; `--format mermaid` draws one answer. Neither showed **the
graph** — what was reconstructed, what each Decision rests on, how the tiers fall, or what
the system did not find. The only way to see that was a psql prompt and knowledge of the
schema.

```powershell
.\dg.ps1 report --open
```
```
wrote /work/decision-graph-report.html
  15 decisions from 238 clusters
```

One self-contained file: every Decision with its status, motivating issue, the pull request
credited with the work and its merge date, the tier on every edge, every artifact linked to
GitHub, and a rendered diagram per thread. Menu option 7 opens it directly — someone who
picked "browse the graph" from a list wants to look at it, not be told where a file is.

Verified by opening it in a browser, not by reading the HTML: [screenshot](C:\Users\ASUS\AppData\Local\Temp\claude-chrome-screenshots-tp5qid\screenshot-1788621393250-0.jpg)

## Three things it gets right because they were checked, not assumed

**A classic `<script>` tag, not an ES module.** `dg report` writes a file you open from
*disk*, and Chrome refuses a module import from a remote origin on a `file://` page. The
module form renders every diagram as nothing, silently, on exactly the path this command
produces. The UMD build works there, and there is a test asserting no `type="module"` reaches
the page. If the CDN is unreachable at all, the diagram source stays visible as readable text
rather than vanishing.

**The numbers agree with `eval/figures.sql`.** They did not at first: scoping the tier counts
by the edge's source alone dropped every `reviewed` edge, because those run person → pull
request and a person belongs to no repository. The page said **67** corroborated where the
measurement script said **76**. Counting either endpoint fixes it — and finding a
disagreement like that is exactly why `figures.sql` exists.

**The page states its own coverage, at the top:**

> **This is not the repository's history.** It is what the §5.1 rubric could evidence: a
> motivating issue and merged work in one conversation. 223 clusters produced no decision,
> most because no issue is referenced from the work at all, and a refusal to assert is the
> intended outcome there rather than a gap.

15 cards with nothing said about the other 223 clusters would be a coverage claim made by
omission, and coverage — not precision — is this system's binding limit.

Generated from the graph at run time, never from `eval/results.json`; that file is the record
of an evaluation run and stays one.

## Verification

**176 tests**, nothing skipped with `DATABASE_URL` set and Docker present. 15 are new:
thirteen render from fixtures and need no database, two run every `dg report` query against
the real schema — the half a fixture cannot check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CKgTDYCV3TwH1yzhxwscQ