### PR TITLE
Stop rebuilding the image on every command (#75)

### DIFF
--- a/dg
+++ b/dg
@@ -33,7 +33,17 @@ docker compose version >/dev/null 2>&1 || fail \
 
 # Build once. Docker caches layers, so rebuilding after a Dockerfile change is quick, but
 # doing it on every command would add seconds to every query.
-if [ -z "$(docker compose images -q app 2>/dev/null)" ] || [ "${1:-}" = "rebuild" ]; then
+#
+# Ask about the IMAGE, not about a container. `docker compose images -q app` lists images
+# for a service's containers, and `app` only ever runs under `compose run --rm`, so it has
+# no container and that check was empty every time -- meaning the guard never fired and
+# every single command rebuilt and announced itself as the first run (issue #75).
+#
+# The name is the compose project name plus the service. If someone overrides the project
+# name the inspect misses and it rebuilds, which is exactly what happens today, so the
+# failure direction is unchanged.
+if ! docker image inspect decision-graph-app:latest >/dev/null 2>&1 \
+   || [ "${1:-}" = "rebuild" ]; then
     printf '\033[36mBuilding the decision-graph image (first run only)...\033[0m\n'
     docker compose build app || fail "Image build failed." "Scroll up for the build error."
     if [ "${1:-}" = "rebuild" ]; then printf '\033[32mRebuilt.\033[0m\n'; exit 0; fi

--- a/dg.ps1
+++ b/dg.ps1
@@ -34,8 +34,18 @@ if ($LASTEXITCODE -ne 0) {
 
 # Build once. Docker caches layers, so a rebuild after a Dockerfile change is quick, but
 # doing it on every command would add seconds to every query.
-$image = docker compose images -q app 2>$null
-if ([string]::IsNullOrWhiteSpace($image) -or $args[0] -eq 'rebuild') {
+#
+# Ask about the IMAGE, not about a container. `docker compose images -q app` lists images
+# for a service's containers, and `app` only ever runs under `compose run --rm`, so it has
+# no container and that check was empty every time -- meaning the guard never fired and
+# every single command rebuilt and announced itself as the first run (issue #75).
+#
+# The name is the compose project name plus the service. If someone overrides the project
+# name the inspect misses and it rebuilds, which is exactly what happens today, so the
+# failure direction is unchanged.
+docker image inspect decision-graph-app:latest 2>&1 | Out-Null
+$imageMissing = ($LASTEXITCODE -ne 0)
+if ($imageMissing -or $args[0] -eq 'rebuild') {
     Write-Host "Building the decision-graph image (first run only)..." -ForegroundColor Cyan
     docker compose build app
     if ($LASTEXITCODE -ne 0) { Fail "Image build failed." "Scroll up for the build error." }

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -777,7 +777,15 @@ def cmd_report(args: argparse.Namespace) -> int:
     out = Path(args.output) if args.output else PROJECT_DIR / "decision-graph-report.html"
     out.write_text(report.render_html(data, repo), encoding="utf-8")
 
-    print(f"{green('wrote')} {out}")
+    # `/work/decision-graph-report.html` is the path inside the container and means nothing
+    # on the host, where the reader is. The bind mount makes it the project directory, so
+    # say that instead of leaking a path they cannot open (issue #75).
+    try:
+        shown = out.relative_to(PROJECT_DIR)
+        where = f"{shown}  {dim('(in your project folder, next to .env)')}"
+    except ValueError:
+        where = str(out)
+    print(f"{green('wrote')} {where}")
     print(dim(f"  {len(data['decisions'])} decisions from "
               f"{data['coverage']['clusters']} clusters"))
     if args.open:


### PR DESCRIPTION
Closes #75. Found while testing the wrapper path end-to-end rather than running the Python
directly, which is how it had gone unnoticed.

## The bug

```sh
if [ -z "$(docker compose images -q app 2>/dev/null)" ]; then   # always empty
```

`docker compose images` lists images for a **service's containers**. `app` only ever runs
under `compose run --rm`, so it has no container:

```
$ docker compose images -q app
                              <- empty
$ docker images -q decision-graph-app
2313eb9d0cd5                  <- it is right there
```

So the guard never fired. Every `dg status`, every `dg query`, every `dg report` ran
`docker compose build app` first and printed `Building the decision-graph image (first run
only)...` — false every time after the first, on every command. The layer cache made it read
as sluggishness rather than as a bug.

## After

```
$ Measure-Command { .\dg.ps1 status }
elapsed: 2.4s        # no build line at all
```

`docker image inspect decision-graph-app:latest` asks about the image instead. If the compose
project name is overridden the inspect misses and it rebuilds — the current behaviour, so the
failure direction is unchanged. `dg.bat` delegates to `dg.ps1` and inherits the fix; both
wrappers stay pure ASCII, and `test_wrapper_encoding.py` still passes.

## Also in here

`dg report` printed `/work/decision-graph-report.html` — the path **inside the container** —
to a reader who is on the host and cannot open it. The bind mount makes `/work` the project
directory, so it now says:

```
wrote decision-graph-report.html  (in your project folder, next to .env)
```

## Verification

Exercised through the real wrappers, not through Python: `dg status`, `dg query`, `dg report`
and `dg doctor` all run clean, the Unicode output renders correctly in a Windows terminal, and
the report file lands on the host. 176 tests still pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CKgTDYCV3TwH1yzhxwscQ