### PR TITLE
A point-in-time refusal must name the moment it was asked about

### DIFF
--- a/README.md
+++ b/README.md
@@ -600,7 +600,7 @@ psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  9 checks
 psql "$DATABASE_URL" -f db/tests/0013_reference_retraction_checks.sql # 6 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 176 tests
+DATABASE_URL=... python -m unittest discover -s tests               # 178 tests
 ```
 
 `.github/workflows/ci.yml` runs all of it on every push and pull request, against Postgres
@@ -615,7 +615,7 @@ so four of the five suites printed `FAIL` inside a collapsed group and exited 0 
 then raises if anything failed, and `tests/test_sql_suites.py` asserts that every file in
 `db/tests/` does, so a suite added later cannot quietly arrive without it.
 
-All SQL suites run in a transaction and roll back. The Python suite runs 152 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 154 tests
 standalone. Setting `DATABASE_URL` adds 21 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 5 for the trace annotation, 7 for reference retraction, and 2 that run every `dg report`
@@ -623,7 +623,7 @@ query against the real schema, which is the half a fixture cannot check. Docker 
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
 
-A run without those is still reported as `OK`, with 24 of the 176 quietly skipped — so a
+A run without those is still reported as `OK`, with 24 of the 178 quietly skipped — so a
 local pass and a complete pass look alike. CI sets both, and nothing is skipped there.
 
 Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell

--- a/src/decision_graph/query.py
+++ b/src/decision_graph/query.py
@@ -43,12 +43,13 @@ def render_answer(
     annotations: dict[int, str] | None = None,
     statuses: dict[int, str] | None = None,
     links: dict[str, str] | None = None,
+    as_of=None,
     verbose: bool = False,
     out=None,
 ) -> None:
     render.render(
         answer, annotations=annotations, statuses=statuses, links=links,
-        verbose=verbose, out=out,
+        as_of=as_of, verbose=verbose, out=out,
     )
 
 
@@ -181,7 +182,7 @@ def main(argv: list[str] | None = None) -> int:
         annotations, statuses, links = _decision_facts(conn, answer)
         render_answer(
             answer, annotations=annotations, statuses=statuses, links=links,
-            verbose=args.verbose,
+            as_of=as_of, verbose=args.verbose,
         )
 
     skipped = len(candidates) - len(chosen)

--- a/src/decision_graph/render.py
+++ b/src/decision_graph/render.py
@@ -165,6 +165,7 @@ def render(
     annotations: dict[int, str] | None = None,
     statuses: dict[int, str] | None = None,
     links: dict[str, str] | None = None,
+    as_of=None,
     verbose: bool = False,
     out=None,
 ) -> None:
@@ -175,7 +176,7 @@ def render(
     p = lambda s="": print(s, file=out)  # noqa: E731
 
     if not answer.found:
-        _render_refusal(answer, p)
+        _render_refusal(answer, p, as_of)
         return
 
     if answer.used_inferred_fallback:
@@ -251,15 +252,28 @@ def _urls(answer: Answer) -> list[tuple[str, str]]:
     return list(seen.items())
 
 
-def _render_refusal(answer: Answer, p) -> None:
+def _render_refusal(answer: Answer, p, as_of=None) -> None:
     """Say what was looked for and what that means -- refusals are a primary output.
 
     The distinction that matters is between "you asked the wrong question" and "the graph
     genuinely holds no evidence", and only the second is a finding. Neither the engine's
     one-line explanation nor a bare "no answer" separates them.
+
+    A point-in-time query adds a third case, and it is the one most easily misread: the
+    evidence exists but did not exist YET. Saying "nothing records why this happened" to
+    someone who asked as of last June states something false about the graph, so the
+    timestamp is named before anything else.
     """
     p(bold("  No answer — and that is a result, not a failure"))
     p()
+    if as_of is not None:
+        p(f"    Asked as of {as_of:%Y-%m-%d}. Nothing that answers this existed in the")
+        p("    graph at that moment — edges are time-versioned, so this says when the")
+        p("    evidence appeared, not that it is absent now. Drop --as-of to ask about today.")
+        p()
+        p(dim(f"    engine: {answer.explanation}"))
+        p()
+        return
     if answer.mode is Mode.WHY:
         p("    Nothing in the ingested window records why this happened. The rubric needs")
         p("    a motivating issue and merged work in the same conversation; a change made")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -176,6 +176,19 @@ class RefusalTest(unittest.TestCase):
         self.assertIn("records why this happened", why)
         self.assertIn("records what this affects", impact)
 
+    def test_a_point_in_time_refusal_names_the_moment(self) -> None:
+        # The most easily misread refusal: the evidence exists but did not exist YET.
+        # "Nothing records why this happened" is false when the caller asked about a date
+        # before the work landed, and it is the answer a temporal control depends on.
+        from datetime import datetime
+
+        printed = render_to_string(answer(found=False), as_of=datetime(2025, 6, 1))
+        self.assertIn("as of 2025-06-01", printed)
+        self.assertIn("not that it is absent now", printed)
+
+    def test_an_ordinary_refusal_does_not_mention_time(self) -> None:
+        self.assertNotIn("as of", render_to_string(answer(found=False)))
+
     def test_a_tried_fallback_is_reported(self) -> None:
         # "Nothing found" and "nothing found even after admitting guesses" are different
         # statements about how hard the engine looked.


### PR DESCRIPTION
Found while writing a walkthrough for someone else to run — the kind of thing you only see
when you read your own output as a stranger would.

`--as-of 2025-06-01` on a change made in 2026 answered:

```
  No answer — and that is a result, not a failure

    Nothing in the ingested window records why this happened. The rubric needs
    a motivating issue and merged work in the same conversation; a change made
    without an issue leaves nothing to reconstruct a decision from.
```

Every word of that is false about this graph. The evidence exists — it did not exist *yet*.

This matters more than an ordinary wording slip because the point-in-time query is the one
mechanical check §9 calls load-bearing: F1 returns 1 path now and 0 as of 2025-06, which is
what shows the time filter restricts rather than being silently ignored. A control whose
negative result reads as "there is no evidence here" is not much of a control.

## After

```
  No answer — and that is a result, not a failure

    Asked as of 2025-06-01. Nothing that answers this existed in the
    graph at that moment — edges are time-versioned, so this says when the
    evidence appeared, not that it is absent now. Drop --as-of to ask about today.

    engine: no path found, explicit or inferred
```

Two tests: the timestamped refusal says so, and an ordinary refusal still does not mention
time. 178 tests, nothing skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CKgTDYCV3TwH1yzhxwscQ