### PR TITLE
Make the menu the whole tool, not a launcher for three commands (#78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,18 +41,64 @@ token or repo.
 
 ### Just run it
 
-Run `dg` with no command and it opens an interactive menu — a banner, a live status line
-(is the database up? is the graph empty?), and a numbered list you pick from. Nothing to
-memorise; it asks for what a command would need. On a pipe or in a script it prints help
-instead, so it never blocks waiting for input.
-
 ```powershell
 .\dg.ps1
 ```
 
+No command, and **nothing to memorise** — a banner, a live status line (is the database up?
+is the graph empty?), and a numbered list:
+
+```
+  1  Browse decisions      see what was found, then drill into one
+  2  Ask why               why did a change happen?
+  3  Trace impact          what does a change affect, downstream?
+  4  Natural Language Q&A  ask in plain English (requires an Nvidia API key)
+  5  Report to HTML        every decision and its evidence, as a page
+  6  Repository status     counts, cursors, decisions
+  7  Health check          what works, and how to fix what does not
+  8  Ingest a repository   pull the last 12 months into the graph
+  i  Setup / reconfigure   token, target repo, migrations (safe to re-run)
+```
+
+**Browsing comes first because it is the only entry that asks nothing of you.** Every other
+question starts by wanting the name of something — `what changed?` — which is precisely what
+a newcomer does not have. Option 1 lists what was actually found and you pick a number:
+
+```
+  15 decisions, newest first:
+
+   1  2026-08-11  #6093   reconstructed  IPv6 addresses parsed incorrectly because of
+   ...
+   8  2026-01-25  #5895   reconstructed  change default redirect code to 303
+  12  2025-08-19  #5774   explicit       `stream_with_context` does not work with async
+
+  pick a number (or Enter to go back): 8
+```
+
+Pressing Enter at any `what changed?` prompt drops you into that same list rather than
+giving up.
+
+**Every answer then offers what used to be a flag**, in context, one keystroke each — and
+they are toggles, so the bar shows what is currently on:
+
+```
+  ------------------------------------------------------------------
+  d  diagram       [on]          as a mermaid graph you can paste into GitHub
+  v  details                     node ids and the extractor behind every edge
+  a  all matches                 answer from every candidate, not just the best
+  t  as of a date  [2025-06-01]  what the graph knew at a point in time
+  s  switch mode   [why]         ask the other question about the same thing
+  Enter  back
+```
+
+Each one re-runs the same `dg query` the flags would have run, so the menu cannot drift from
+what the command prints — it *is* what the command prints. On a pipe or in a script `dg`
+prints help instead, so it never blocks waiting for input that will not come.
+
 ### The commands
 
-Every menu choice maps to one of these, so you can skip the menu once you know them.
+Every menu choice maps to one of these. The flags are the scripting interface; you never
+need to type one to use the tool.
 
 | command | what it does |
 |---|---|
@@ -600,7 +646,7 @@ psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  9 checks
 psql "$DATABASE_URL" -f db/tests/0013_reference_retraction_checks.sql # 6 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 178 tests
+DATABASE_URL=... python -m unittest discover -s tests               # 189 tests
 ```
 
 `.github/workflows/ci.yml` runs all of it on every push and pull request, against Postgres
@@ -615,7 +661,7 @@ so four of the five suites printed `FAIL` inside a collapsed group and exited 0 
 then raises if anything failed, and `tests/test_sql_suites.py` asserts that every file in
 `db/tests/` does, so a suite added later cannot quietly arrive without it.
 
-All SQL suites run in a transaction and roll back. The Python suite runs 154 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 165 tests
 standalone. Setting `DATABASE_URL` adds 21 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 5 for the trace annotation, 7 for reference retraction, and 2 that run every `dg report`
@@ -623,7 +669,7 @@ query against the real schema, which is the half a fixture cannot check. Docker 
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
 
-A run without those is still reported as `OK`, with 24 of the 178 quietly skipped — so a
+A run without those is still reported as `OK`, with 24 of the 189 quietly skipped — so a
 local pass and a complete pass look alike. CI sets both, and nothing is skipped there.
 
 Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell

--- a/src/decision_graph/menu.py
+++ b/src/decision_graph/menu.py
@@ -142,6 +142,197 @@ def _ask(prompt: str, default: str = "") -> str:
     return raw or default
 
 
+# --- following up on an answer --------------------------------------------------------
+#
+# Everything here was previously a flag you had to know existed before you ran anything
+# (issue #78). Offered after an answer instead, where each one means something concrete
+# about the answer in front of you, and reachable by one keystroke.
+#
+# They are TOGGLES over a small state, not an accumulating list of flags. The first version
+# appended, which meant picking "diagram" and then "as of a date" left you in diagram mode
+# with no way back to prose except leaving the answer entirely -- the state was real but
+# invisible, and the only way to discover it was to be surprised by it. Here the state is
+# rebuilt into flags on every pass and printed in the bar, so what is on is on the screen.
+
+
+class View:
+    """What the reader currently wants to see of one answer.
+
+    Rendered by re-running `dg query` with the flags this produces, rather than by holding
+    an Answer and re-rendering it here. Re-running costs a second traversal -- milliseconds
+    -- and buys the thing this codebase keeps choosing: one implementation. A menu that
+    rendered answers its own way would be a second renderer to keep in step with the first.
+    """
+
+    def __init__(self, mode: str) -> None:
+        self.mode = mode
+        self.diagram = False
+        self.details = False
+        self.all_matches = False
+        self.as_of: str | None = None
+
+    def flags(self) -> list[str]:
+        argv = ["--mode", self.mode]
+        if self.diagram:
+            argv += ["--format", "mermaid"]
+        if self.details:
+            argv += ["-v"]
+        if self.all_matches:
+            argv += ["--all"]
+        if self.as_of:
+            argv += ["--as-of", f"{self.as_of}T00:00:00Z"]
+        return argv
+
+    def label(self, key: str) -> str:
+        """`on` when a toggle is active, so the bar states what is already applied."""
+        return {
+            "d": "on" if self.diagram else "",
+            "v": "on" if self.details else "",
+            "a": "on" if self.all_matches else "",
+            "t": self.as_of or "",
+            "s": self.mode,
+        }.get(key, "")
+
+    def toggle(self, key: str, ask=None) -> bool:
+        """Apply one keystroke. Returns False if the key means nothing here.
+
+        `ask` is injected so the date prompt can be driven by a test without a terminal.
+        """
+        if key == "d":
+            self.diagram = not self.diagram
+        elif key == "v":
+            self.details = not self.details
+        elif key == "a":
+            self.all_matches = not self.all_matches
+        elif key == "s":
+            self.mode = "impact" if self.mode == "why" else "why"
+        elif key == "t":
+            if self.as_of:
+                # A second press clears it. Time travel you cannot leave is a trap, and it
+                # is the toggle where being stuck is least obvious -- every later answer
+                # would be about a past that the reader has stopped thinking about.
+                self.as_of = None
+            else:
+                when = (ask or _ask)("as of when? (YYYY-MM-DD, or Enter to cancel)")
+                if when:
+                    self.as_of = when
+        else:
+            return False
+        return True
+
+
+FOLLOW_UPS = [
+    ("d", "diagram", "as a mermaid graph you can paste into GitHub"),
+    ("v", "details", "node ids and the extractor behind every edge"),
+    ("a", "all matches", "answer from every candidate, not just the best"),
+    ("t", "as of a date", "what the graph knew at a point in time"),
+    ("s", "switch mode", "ask the other question about the same thing"),
+]
+
+
+DECISIONS_SQL = """
+SELECT d.node_id,
+       d.status::text  AS status,
+       n.title,
+       iss.external_id AS issue_ref,
+       d.decided_at
+FROM decision d
+JOIN node n ON n.id = d.node_id
+LEFT JOIN edge e ON e.src_node_id = d.node_id
+                AND e.edge_type = 'motivated_by'
+                AND e.valid_to IS NULL
+LEFT JOIN node iss ON iss.id = e.dst_node_id AND iss.node_type = 'issue'
+ORDER BY d.decided_at DESC NULLS LAST, d.node_id
+"""
+
+
+def decision_rows(conn) -> list[dict]:
+    """Every reconstructed decision, newest first, with the issue that motivated it.
+
+    The issue number is what the browse list hands to `dg query`, because a Decision's own
+    external_id is its thread_key -- which names the cluster and, for 6 of 15 of them, names
+    a pull request that was abandoned (issue #19). Starting a walk from the motivating issue
+    starts it from an artifact that is what it says it is.
+    """
+    return [dict(r) for r in conn.execute(DECISIONS_SQL).fetchall()]
+
+
+def _pick_decision() -> str | None:
+    """Show the decisions and return the query string for the one chosen.
+
+    This exists because the menu used to open with "what changed?" -- a question the person
+    it was written for cannot answer. The graph holds 15 decisions and there was no way to
+    see what they were from inside the tool.
+    """
+    try:
+        conn = _connect()
+    except Exception as exc:
+        why, fix = explain_db_error(exc)
+        print(f"  {red('x')} {why}")
+        print(f"    {yellow('->')} {fix}")
+        return None
+
+    try:
+        rows = decision_rows(conn)
+    finally:
+        conn.close()
+
+    if not rows:
+        print(yellow("  No decisions in the graph yet."))
+        print(dim("  That is a result, not a failure: the rubric needs a motivating issue"))
+        print(dim("  and merged work in one thread. Try an ingest (menu 8) first."))
+        return None
+
+    print(f"  {bold(str(len(rows)))} decisions, newest first:")
+    print()
+    for i, r in enumerate(rows, 1):
+        when = f"{r['decided_at']:%Y-%m-%d}" if r["decided_at"] else " " * 10
+        ref = f"#{r['issue_ref']}" if r["issue_ref"] else "-"
+        # Both statuses are spelled out. Marking only the explicit ones would be shorter and
+        # would read as though the rest had no status at all, which is the kind of omission
+        # this codebase keeps deciding not to make.
+        status = "explicit" if r["status"] == "explicit" else "reconstructed"
+        painted = green(status) if r["status"] == "explicit" else dim(status)
+        pad = " " * (13 - len(status))
+        title = (r["title"] or "")[:44]
+        print(f"  {bold(f'{i:>2}')}  {dim(when)}  {ref:<7} {painted}{pad}  {title}")
+    print()
+
+    choice = _ask("pick a number (or Enter to go back)")
+    if not choice:
+        return None
+    try:
+        index = int(choice)
+        if index < 1:
+            raise IndexError(index)
+        row = rows[index - 1]
+    except (ValueError, IndexError):
+        print(yellow(f"  no decision numbered {choice!r}"))
+        return None
+    # Prefer the issue number: exact, unambiguous, and an artifact a reader can open.
+    return f"#{row['issue_ref']}" if row["issue_ref"] else (row["title"] or "")
+
+
+def _answer_and_follow_up(text: str, mode: str) -> None:
+    view = View(mode)
+    while True:
+        cmd_query(argparse.Namespace(text=text), view.flags())
+
+        print()
+        print(dim("  " + "-" * 66))
+        for key, label, hint in FOLLOW_UPS:
+            state = view.label(key)
+            marker = green(f"[{state}]") if state else "     "
+            print(f"  {bold(key)}  {label:<14}{marker:<14}{dim(hint)}")
+        print(f"  {bold('Enter')}  {'back':<11}")
+
+        choice = _ask("").lower()
+        if not choice:
+            return
+        if not view.toggle(choice):
+            print(yellow(f"  not an option: {choice!r}"))
+
+
 # --- the actions, each a thin gatherer in front of a real cmd_* -------------------------
 
 
@@ -163,16 +354,23 @@ def _run_ingest(_ns: argparse.Namespace) -> None:
 def _run_query(mode: str):
     def go(_ns: argparse.Namespace) -> None:
         subject = "changed" if mode == "why" else "you want to trace"
-        text = _ask(f"what {subject}? (a title, #number, or commit sha)")
+        text = _ask(f"what {subject}? (a title, #number, sha -- or Enter to browse)")
         if not text:
-            print(yellow("  nothing to look up"))
-            return
-        extra = ["--mode", mode]
-        if mode == "impact":
-            extra += ["--depth", _ask("depth", "2")]
-        cmd_query(argparse.Namespace(text=text), extra)
+            # An empty answer used to end the action. It is the commonest answer there is:
+            # the question asks you to name something before anything has been shown to
+            # you, so not knowing is the default state, not a mistake (issue #78).
+            text = _pick_decision()
+            if not text:
+                return
+        _answer_and_follow_up(text, mode)
 
     return go
+
+
+def _run_browse(_ns: argparse.Namespace) -> None:
+    text = _pick_decision()
+    if text:
+        _answer_and_follow_up(text, "why")
 
 
 def _run_report(_ns: argparse.Namespace) -> None:
@@ -194,13 +392,16 @@ def _run_ask(_ns: argparse.Namespace) -> None:
 
 
 ACTIONS = [
-    Action("1", "Ingest a repository", "pull the last 12 months into the graph", _run_ingest),
+    # Browsing comes first because it is the only entry that asks nothing of you. Every
+    # other query action begins by wanting a name you may not have.
+    Action("1", "Browse decisions", "see what was found, then drill into one", _run_browse),
     Action("2", "Ask why", "why did a change happen?", _run_query("why")),
     Action("3", "Trace impact", "what does a change affect, downstream?", _run_query("impact")),
-    Action("4", "Repository status", "counts, cursors, decisions", lambda ns: cmd_status(ns)),
-    Action("5", "Health check", "what works, and how to fix what does not", lambda ns: cmd_doctor(ns)),
-    Action("6", "Natural Language Q&A", "ask a question in plain English (requires Nvidia API key)", _run_ask),
-    Action("7", "Browse the graph", "render every decision and its evidence to an HTML page", _run_report),
+    Action("4", "Natural Language Q&A", "ask in plain English (requires an Nvidia API key)", _run_ask),
+    Action("5", "Report to HTML", "every decision and its evidence, as a page", _run_report),
+    Action("6", "Repository status", "counts, cursors, decisions", lambda ns: cmd_status(ns)),
+    Action("7", "Health check", "what works, and how to fix what does not", lambda ns: cmd_doctor(ns)),
+    Action("8", "Ingest a repository", "pull the last 12 months into the graph", _run_ingest),
     Action("i", "Setup / reconfigure", "token, target repo, migrations (safe to re-run)", _run_init),
 ]
 
@@ -215,10 +416,9 @@ def _draw() -> None:
     print(f"  {dim('why did this change happen -- reconstructed from a repository history')}")
     print()
     print(
-        "  " + dim("ask why? ") + "(2)   "
-        + dim("what breaks? ") + "(3)   "
-        + dim("what is inside? ") + "(4)   "
-        + dim("show me everything? ") + "(7)"
+        "  " + dim("show me what you found? ") + "(1)   "
+        + dim("why did this happen? ") + "(2)   "
+        + dim("what breaks? ") + "(3)"
     )
     print()
     print(f"  {_greeting()}.")

--- a/tests/test_menu.py
+++ b/tests/test_menu.py
@@ -39,6 +39,92 @@ class ActionTableTest(unittest.TestCase):
         self.assertIn("Ask why", labels)
         self.assertIn("Trace impact", labels)
 
+    def test_browsing_needs_no_prior_knowledge_and_comes_first(self) -> None:
+        # Every other query action opens by asking you to name something. Browsing is the
+        # only entry that asks nothing, so it is the one a first-time reader must land on
+        # (issue #78).
+        self.assertEqual(menu.ACTIONS[0].label, "Browse decisions")
+
+    def test_no_capability_is_reachable_only_by_a_flag(self) -> None:
+        # The point of #78: diagram, details, all-matches, point-in-time and mode-switching
+        # were reachable only by knowing a flag existed before you ran anything.
+        offered = {label for _key, label, _hint in menu.FOLLOW_UPS}
+        self.assertEqual(
+            offered,
+            {"diagram", "details", "all matches", "as of a date", "switch mode"},
+        )
+
+
+class ViewTest(unittest.TestCase):
+    """The follow-up toggles (issue #78).
+
+    These map keystrokes to `dg query` flags, and a key that quietly set the wrong flag
+    would answer a different question than the one on screen while looking entirely
+    plausible doing it. The first implementation accumulated flags instead of toggling,
+    which left "diagram" stuck on with no way back except leaving the answer.
+    """
+
+    def test_the_default_view_is_a_plain_why_answer(self) -> None:
+        self.assertEqual(menu.View("why").flags(), ["--mode", "why"])
+
+    def test_each_toggle_adds_its_flag(self) -> None:
+        for key, expected in [
+            ("d", ["--format", "mermaid"]),
+            ("v", ["-v"]),
+            ("a", ["--all"]),
+        ]:
+            with self.subTest(key=key):
+                view = menu.View("why")
+                self.assertTrue(view.toggle(key))
+                self.assertEqual(view.flags(), ["--mode", "why"] + expected)
+
+    def test_a_toggle_turns_back_off(self) -> None:
+        view = menu.View("why")
+        view.toggle("d")
+        view.toggle("d")
+        self.assertEqual(view.flags(), ["--mode", "why"])
+
+    def test_switch_mode_flips_and_flips_back(self) -> None:
+        view = menu.View("why")
+        view.toggle("s")
+        self.assertIn("impact", view.flags())
+        view.toggle("s")
+        self.assertIn("why", view.flags())
+
+    def test_as_of_prompts_and_can_be_cleared(self) -> None:
+        # Time travel you cannot leave is the toggle where being stuck is least obvious:
+        # every later answer would be about a past the reader has stopped thinking about.
+        view = menu.View("why")
+        view.toggle("t", ask=lambda _prompt: "2025-06-01")
+        self.assertIn("--as-of", view.flags())
+        self.assertIn("2025-06-01T00:00:00Z", view.flags())
+        view.toggle("t")
+        self.assertNotIn("--as-of", view.flags())
+
+    def test_cancelling_the_date_prompt_changes_nothing(self) -> None:
+        view = menu.View("why")
+        view.toggle("t", ask=lambda _prompt: "")
+        self.assertEqual(view.flags(), ["--mode", "why"])
+
+    def test_an_unknown_key_is_refused_rather_than_ignored(self) -> None:
+        # The loop prints "not an option" on False; silently swallowing it would look like
+        # the tool had done something.
+        self.assertFalse(menu.View("why").toggle("z"))
+
+    def test_the_bar_reports_what_is_already_on(self) -> None:
+        view = menu.View("why")
+        self.assertEqual(view.label("d"), "")
+        view.toggle("d")
+        self.assertEqual(view.label("d"), "on")
+        self.assertEqual(view.label("s"), "why")
+
+    def test_every_advertised_follow_up_is_a_real_toggle(self) -> None:
+        # The bar and the handler are two lists that must not drift: a row advertised with
+        # no handler behind it reads as a broken key.
+        for key, _label, _hint in menu.FOLLOW_UPS:
+            with self.subTest(key=key):
+                self.assertTrue(menu.View("why").toggle(key, ask=lambda _p: ""))
+
 
 class LoopTest(unittest.TestCase):
     def _run_with_input(self, lines: list[str]) -> int:


### PR DESCRIPTION
Closes #78.

The menu's own docstring says it exists so a newcomer does not have to know what to type. It
opened by asking:

```
  what changed? (a title, #number, or commit sha):
```

which is unanswerable by exactly that person. 15 decisions sat in the graph with **no way to
see what they were from inside the tool** — you had to render a report, or already know that
`#5898` was interesting. And five capabilities were reachable only by knowing a flag existed
before you ran anything: `--as-of`, `--format`, `-v`, `--all`, and the other mode.

## Browse first

```
  1  Browse decisions      see what was found, then drill into one
  2  Ask why               why did a change happen?
  3  Trace impact          what does a change affect, downstream?
  4  Natural Language Q&A  ask in plain English (requires an Nvidia API key)
  5  Report to HTML        every decision and its evidence, as a page
  6  Repository status     counts, cursors, decisions
  7  Health check          what works, and how to fix what does not
  8  Ingest a repository   pull the last 12 months into the graph
```

Option 1 is the only entry that asks nothing of you, so it is the one a first-time reader
lands on:

```
  15 decisions, newest first:

   1  2026-08-11  #6093   reconstructed  IPv6 addresses parsed incorrectly because of
   8  2026-01-25  #5895   reconstructed  change default redirect code to 303
  12  2025-08-19  #5774   explicit       `stream_with_context` does not work with async

  pick a number (or Enter to go back):
```

Enter at any `what changed?` prompt drops into that list rather than giving up — not knowing
is the default state, not a mistake.

The list hands `dg query` the **motivating issue's** number rather than the decision's own
id, because a Decision's `external_id` is its `thread_key`, which names the cluster and for
6 of 15 names a pull request that was abandoned (#19).

## Follow-ups are toggles, and the bar says what is on

```
  d  diagram       [on]          as a mermaid graph you can paste into GitHub
  v  details                     node ids and the extractor behind every edge
  a  all matches                 answer from every candidate, not just the best
  t  as of a date  [2025-06-01]  what the graph knew at a point in time
  s  switch mode   [why]         ask the other question about the same thing
  Enter  back
```

My first implementation accumulated flags instead of toggling, so picking "diagram" and then
"as of a date" left you stuck in diagram mode with no way back to prose except abandoning the
answer — state that was real, invisible, and discoverable only by being surprised by it. It's
now explicit state, rebuilt into flags on every pass and printed in the bar. A second press
of `t` clears the date, because time travel you cannot leave is the toggle where being stuck
is least obvious: every later answer would silently be about a past you had stopped thinking
about.

Each follow-up **re-runs the same `dg query` the flag would have run**. That costs a second
traversal — milliseconds — and buys one implementation. A menu that rendered answers its own
way would be a second renderer to keep in step with the first.

Flags are unchanged and remain the scripting interface.

## Verification

189 tests, nothing skipped. 11 are new and cover `View`: every advertised row has a handler
behind it, toggles turn off as well as on, cancelling the date prompt changes nothing, and an
unknown key is refused rather than silently swallowed. The browse-and-drill flow was driven
end to end with scripted keystrokes against the real code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CKgTDYCV3TwH1yzhxwscQ