### PR TITLE
dg ask was dead: the model retired, and every failure was a traceback (#80)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,3 +25,10 @@ BACKFILL_MONTHS=12
 # Leave it blank and everything except `dg ask` works. `dg doctor` warns if it is missing
 # rather than letting you find out after typing a question.
 NVIDIA_API_KEY=
+
+# Optional. Which model `dg ask` calls. A hosted model id is not a constant -- it has an
+# end-of-life date the code cannot see -- and the previous default was retired on
+# 2026-08-26, which broke `dg ask` with a 410. Set this to any id from
+# https://build.nvidia.com to move off a retired model without editing code or rebuilding.
+# Default: nvidia/nemotron-3-super-120b-a12b
+DG_NLP_MODEL=

--- a/README.md
+++ b/README.md
@@ -501,7 +501,10 @@ prose:
 ```
 
 It needs `NVIDIA_API_KEY` in `.env` (get one at <https://build.nvidia.com>) and calls
-`meta/llama-3.1-70b-instruct` through Nvidia NIM. **The question and the traversal paths
+`nvidia/nemotron-3-super-120b-a12b` through Nvidia NIM. **Set `DG_NLP_MODEL` in `.env` to
+use a different one** — a hosted model id has an end-of-life date the code cannot see, and
+the previous default was retired mid-project, so moving off a dead model must not require
+editing Python and rebuilding an image. **The question and the traversal paths
 leave your machine**; nothing else does, and no other command in this repository calls any
 service but GitHub. `dg doctor` reports whether the key and the package are present, so you
 find out before typing a question rather than after. Everything else works without it.
@@ -646,7 +649,7 @@ psql "$DATABASE_URL" -f db/tests/0006_corroboration_checks.sql      #  7 checks
 psql "$DATABASE_URL" -f db/tests/0008_landing_checks.sql            #  6 checks
 psql "$DATABASE_URL" -f db/tests/0009_decision_identity_checks.sql  #  9 checks
 psql "$DATABASE_URL" -f db/tests/0013_reference_retraction_checks.sql # 6 checks
-DATABASE_URL=... python -m unittest discover -s tests               # 189 tests
+DATABASE_URL=... python -m unittest discover -s tests               # 199 tests
 ```
 
 `.github/workflows/ci.yml` runs all of it on every push and pull request, against Postgres
@@ -661,7 +664,7 @@ so four of the five suites printed `FAIL` inside a collapsed group and exited 0 
 then raises if anything failed, and `tests/test_sql_suites.py` asserts that every file in
 `db/tests/` does, so a suite added later cannot quietly arrive without it.
 
-All SQL suites run in a transaction and roll back. The Python suite runs 165 tests
+All SQL suites run in a transaction and roll back. The Python suite runs 175 tests
 standalone. Setting `DATABASE_URL` adds 21 integration tests — 7 for the traversal
 fallback, which seed their own fixture because the real graph holds no inferred edges,
 5 for the trace annotation, 7 for reference retraction, and 2 that run every `dg report`
@@ -669,7 +672,7 @@ query against the real schema, which is the half a fixture cannot check. Docker 
 oldest Python `pyproject.toml` claims to support, because the Dockerfile pins a much newer
 one and otherwise nothing ever exercises the declared floor.
 
-A run without those is still reported as `OK`, with 24 of the 189 quietly skipped — so a
+A run without those is still reported as `OK`, with 24 of the 199 quietly skipped — so a
 local pass and a complete pass look alike. CI sets both, and nothing is skipped there.
 
 Three of the standalone tests assert the shell wrappers are pure ASCII. Windows PowerShell

--- a/src/decision_graph/cli.py
+++ b/src/decision_graph/cli.py
@@ -870,7 +870,7 @@ def cmd_ask(args: argparse.Namespace, extra: list[str]) -> int:
     heading("In plain English")
     print(explanation)
     print()
-    print(dim("Written by " + explain.MODEL + " from the trace above, which is the"))
+    print(dim("Written by " + explain.model() + " from the trace above, which is the"))
     print(dim("evidence. Where the two disagree, the trace is what the graph holds."))
     return 0
 

--- a/src/decision_graph/explain.py
+++ b/src/decision_graph/explain.py
@@ -29,12 +29,30 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 
 from . import trace
 from .reasoning import Answer, Mode
 
-MODEL = "meta/llama-3.1-70b-instruct"
+# The default model, overridable with DG_NLP_MODEL in .env.
+#
+# It is configurable because the previous value stopped existing: NIM retired
+# meta/llama-3.1-70b-instruct on 2026-08-26 and every `dg ask` began failing with a 410
+# and a traceback. A hosted model id is not a constant -- it has an end-of-life date the
+# code cannot see -- so pinning one in source guarantees the same failure again, and the
+# fix should not require editing Python and rebuilding an image.
+DEFAULT_MODEL = "nvidia/nemotron-3-super-120b-a12b"
+
+
+def model() -> str:
+    return os.environ.get("DG_NLP_MODEL") or DEFAULT_MODEL
+
+
+# Kept as a module attribute because the CLI prints it as the byline on a generated
+# paragraph, and a reader deciding how much to trust that paragraph should be told which
+# model wrote it -- especially now that it can be changed without touching the code.
+MODEL = model()
 
 # Returned verbatim when the graph found nothing. Deliberately a constant: see rule 1.
 NO_ANSWER = (
@@ -78,6 +96,59 @@ def get_client():
     return OpenAI(base_url="https://integrate.api.nvidia.com/v1", api_key=api_key)
 
 
+def _diagnose(exc: Exception) -> str:
+    """Turn a provider error into something the reader can act on.
+
+    Every one of these was previously a 40-line traceback out of the CLI. The status codes
+    are read by attribute rather than by catching openai's exception classes, because
+    `openai` is an optional extra here and this module must import without it.
+    """
+    status = getattr(exc, "status_code", None) or getattr(
+        getattr(exc, "response", None), "status_code", None
+    )
+    current = model()
+    if status == 410:
+        return (
+            f"Nvidia has retired the model '{current}'. Pick a current one from "
+            "https://build.nvidia.com and set DG_NLP_MODEL=<id> in .env -- no rebuild "
+            "needed. Every other command works without this."
+        )
+    if status in (401, 403):
+        return (
+            "Nvidia rejected the API key. Check NVIDIA_API_KEY in .env, or get a new one "
+            "at https://build.nvidia.com"
+        )
+    if status == 404:
+        return (
+            f"Nvidia has no model '{current}' available to this key. Set DG_NLP_MODEL in "
+            ".env to one listed at https://build.nvidia.com"
+        )
+    if status == 429:
+        return "Nvidia rate-limited this key. Wait a moment and try again."
+    first_line = str(exc).strip().splitlines()[0] if str(exc).strip() else exc.__class__.__name__
+    return f"the request to Nvidia failed: {first_line}"
+
+
+def _complete(client, **kwargs):
+    """One chat completion, with provider failures reported rather than raised raw."""
+    try:
+        return client.chat.completions.create(**kwargs)
+    except ExplainError:
+        raise
+    except Exception as exc:  # noqa: BLE001 - deliberately broad; see _diagnose
+        raise ExplainError(_diagnose(exc)) from exc
+
+
+# A model asked for "JSON only" routinely returns JSON with prose around it -- the model
+# this now defaults to answers `We need to output JSON only: {"query": ...}` even with
+# response_format set, and a reasoning model puts a whole plan first. Requiring the entire
+# reply to parse made the feature depend on a courtesy no provider actually guarantees.
+#
+# Greedy from the first brace to the last: the schema here is flat and single-object, so
+# the widest span is the object. A reply with no braces at all is still an error, loudly.
+_JSON_OBJECT_RE = re.compile(r"\{.*\}", re.DOTALL)
+
+
 def parse_intent(question: str, client=None) -> tuple[str, str]:
     """Turn a question into (search term, mode).
 
@@ -103,16 +174,22 @@ Output valid JSON ONLY in this format:
 
 User question: {question}
 """
-    response = client.chat.completions.create(
-        model=MODEL,
+    response = _complete(
+        client,
+        model=model(),
         messages=[{"role": "user", "content": prompt}],
         temperature=0.0,
         response_format={"type": "json_object"},
     )
     content = response.choices[0].message.content or ""
 
+    match = _JSON_OBJECT_RE.search(content)
+    if not match:
+        raise ExplainError(
+            f"the model did not return JSON: {content.strip()[:120]!r}"
+        )
     try:
-        result = json.loads(content)
+        result = json.loads(match.group(0))
     except json.JSONDecodeError as exc:
         raise ExplainError(
             f"the model did not return JSON: {content.strip()[:120]!r}"
@@ -202,8 +279,9 @@ Explain the result of this query clearly and concisely in plain English.
 - Name the evidence tier of what you assert. "explicit" and "corroborated" are recorded
   facts; "inferred" is the system's own guess and must be labelled as one.
 """
-    response = client.chat.completions.create(
-        model=MODEL,
+    response = _complete(
+        client,
+        model=model(),
         messages=[{"role": "user", "content": prompt}],
         temperature=0.2,
     )

--- a/tests/test_explain.py
+++ b/tests/test_explain.py
@@ -112,6 +112,91 @@ class ParseIntentTest(unittest.TestCase):
             explain.parse_intent("why?", client)
 
 
+class ProviderFailureTest(unittest.TestCase):
+    """A hosted model is not a constant, and every way it can fail was a traceback.
+
+    NIM retired `meta/llama-3.1-70b-instruct` on 2026-08-26 and `dg ask` began printing a
+    40-line stack trace ending in `openai.APIStatusError: Error code: 410`. The code was
+    right and the reporting was not: the reader needed one sentence naming the fix.
+    """
+
+    class _Boom(Exception):
+        def __init__(self, code=None):
+            self.status_code = code
+            super().__init__(f"Error code: {code}")
+
+    def test_a_retired_model_says_how_to_change_it(self) -> None:
+        text = explain._diagnose(self._Boom(410))
+        self.assertIn("retired", text)
+        self.assertIn("DG_NLP_MODEL", text)
+
+    def test_a_rejected_key_is_not_reported_as_a_missing_model(self) -> None:
+        # The two are one character apart in the status code and completely different jobs
+        # for the reader: replace a key, or pick a model.
+        text = explain._diagnose(self._Boom(401))
+        self.assertIn("key", text)
+        self.assertNotIn("DG_NLP_MODEL", text)
+
+    def test_an_unavailable_model_points_at_the_catalogue(self) -> None:
+        self.assertIn("DG_NLP_MODEL", explain._diagnose(self._Boom(404)))
+
+    def test_rate_limiting_says_to_wait(self) -> None:
+        self.assertIn("Wait", explain._diagnose(self._Boom(429)))
+
+    def test_an_unknown_failure_keeps_its_first_line(self) -> None:
+        text = explain._diagnose(ConnectionError("Connection refused\nsecond line"))
+        self.assertIn("Connection refused", text)
+        self.assertNotIn("second line", text)
+
+    def test_the_call_wrapper_raises_explain_error_not_the_provider_error(self) -> None:
+        class Exploding:
+            def __init__(self) -> None:
+                self.chat = self
+                self.completions = self
+
+            def create(self, **_kwargs):
+                raise ProviderFailureTest._Boom(410)
+
+        with self.assertRaises(explain.ExplainError):
+            explain.parse_intent("why?", Exploding())
+
+
+class ModelSelectionTest(unittest.TestCase):
+    def test_the_default_is_used_when_nothing_is_set(self) -> None:
+        import os
+        from unittest import mock
+
+        with mock.patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("DG_NLP_MODEL", None)
+            self.assertEqual(explain.model(), explain.DEFAULT_MODEL)
+
+    def test_the_environment_overrides_the_default(self) -> None:
+        # The point of making it configurable: a model retiring must not require editing
+        # Python and rebuilding an image.
+        import os
+        from unittest import mock
+
+        with mock.patch.dict(os.environ, {"DG_NLP_MODEL": "vendor/some-model"}):
+            self.assertEqual(explain.model(), "vendor/some-model")
+
+
+class JsonExtractionTest(unittest.TestCase):
+    """Models wrap JSON in prose even when asked not to, and even in JSON mode.
+
+    The model this defaults to answers `We need to output JSON only: {...}`, and a
+    reasoning model writes a plan first. Requiring the whole reply to parse made the
+    feature depend on a courtesy no provider actually guarantees.
+    """
+
+    def test_json_is_found_inside_surrounding_prose(self) -> None:
+        client = StubClient('We need to output JSON only: {"query": "#5898", "mode": "impact"} Done.')
+        self.assertEqual(explain.parse_intent("what breaks?", client), ("#5898", "impact"))
+
+    def test_a_reply_with_no_object_at_all_is_still_an_error(self) -> None:
+        with self.assertRaises(explain.ExplainError):
+            explain.parse_intent("why?", StubClient("I could not determine that."))
+
+
 class SummarizeTest(unittest.TestCase):
     def test_a_refusal_is_stated_by_the_code_and_never_generated(self) -> None:
         # The rule the module exists to enforce. 8 of the 18 §9 outcomes are refusals, and


### PR DESCRIPTION
Closes #80. Found by running it with a real key for the first time — none of this was
reachable from the tests, which stub the client and so prove the parsing and nothing about
the provider.

## What happened

```
openai.APIStatusError: Error code: 410 - {'detail': "The model
'meta/llama-3.1-70b-instruct' has reached its end of life on 2026-08-26T09:00:00Z
and is no longer available."}
```

preceded by 40 lines of stack.

## 1. The model is configurable now

A hosted model id is not a constant — it has an end-of-life date the code cannot see — so
pinning one in source guarantees a repeat, and the fix should not be "edit Python, rebuild
the image". `DG_NLP_MODEL` in `.env` overrides the default.

The new default, `nvidia/nemotron-3-super-120b-a12b`, was chosen by **listing what this key
can actually reach and probing the candidates**, not by guessing at a plausible id.

## 2. Provider failures are sentences

| status | what the reader is told |
|---|---|
| 410 | the model retired; set `DG_NLP_MODEL`, no rebuild needed |
| 401 / 403 | Nvidia rejected the key; check `NVIDIA_API_KEY` |
| 404 | no such model for this key; pick one from the catalogue |
| 429 | rate-limited, wait |
| anything else | the first line, not the stack |

410 and 401 are one character apart in the output and completely different jobs for the
reader. Status is read by attribute rather than by catching `openai`'s exception classes,
because `openai` is an optional extra and this module has to import without it.

## 3. JSON mode is not honoured

Probed **with `response_format={"type": "json_object"}` set**:

| model | reply |
|---|---|
| `nvidia/nemotron-3-super-120b-a12b` | `We need to output JSON only: {"query": ...}` |
| `nvidia/nemotron-3.5-lightning-30b-a3b` | `Here's a thinking process: 1. **Analyze...` |
| `openai/gpt-oss-20b` | empty `content` |

So `json.loads(whole_reply)` was a bet on a courtesy no provider guarantees. The object is
extracted from the reply now; a reply with no object at all is still an error, loudly.

## Verified end to end, through the wrapper, against the real API

```
In plain English
────────────────
The decision to change Flask's default redirect code to 303 was explicitly motivated by
issue #5895, which requested that change. This motivation is recorded as an **explicit**
evidence tier.

Written by nvidia/nemotron-3-super-120b-a12b from the trace above, which is the
evidence. Where the two disagree, the trace is what the graph holds.
```

and the old failure, reproduced deliberately with `DG_NLP_MODEL=meta/llama-3.1-70b-instruct`:

```
error: Nvidia has retired the model 'meta/llama-3.1-70b-instruct'. Pick a current one
from https://build.nvidia.com and set DG_NLP_MODEL=<id> in .env -- no rebuild needed.
Every other command works without this.
```

one sentence, exit 2. `dg doctor` now reports **All checks passed**.

199 tests, nothing skipped; 10 are new. The byline reads `model()` rather than the
import-time constant, so it names the model that actually wrote the paragraph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CKgTDYCV3TwH1yzhxwscQ